### PR TITLE
fix take_ownership bug

### DIFF
--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -221,6 +221,9 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
             -- Setting generate_ui to this sentinel value
             -- makes vanilla localization code run instead of SMODS's code
             orig_o.generate_ui = 0
+		else
+			 -- reset the value if otherwise, in case when the object was taken over before and this value was already set
+			orig_o.generate_ui = nil
         end
         -- TODO
         -- it's unclear how much we should modify `obj` on a failed take_ownership call.

--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -222,8 +222,10 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
             -- makes vanilla localization code run instead of SMODS's code
             orig_o.generate_ui = 0
 		else
-			 -- reset the value if otherwise, in case when the object was taken over before and this value was already set
-			orig_o.generate_ui = nil
+			-- reset the value if otherwise, in case when the object was taken over before and this value was already set to 0
+			if orig_o.generate_ui == 0 then
+				orig_o.generate_ui = nil
+			end
         end
         -- TODO
         -- it's unclear how much we should modify `obj` on a failed take_ownership call.


### PR DESCRIPTION
There is a bug where `take_ownership` does not reset the `orig_o.generate_ui` value when the object ownership was taken the second time, so it keeps calling the vanilla localization function despite SMODS side having one.