### PR TITLE
change debug port to one with fewer collisions

### DIFF
--- a/src/logging.lua
+++ b/src/logging.lua
@@ -3,7 +3,7 @@
 
 function initializeSocketConnection()
     local socket = require("socket")
-    client = socket.connect("localhost", 12345)
+    client = socket.connect("localhost", 53153)
     if not client then
         print("Failed to connect to the debug server")
     end

--- a/tk_debug_window.py
+++ b/tk_debug_window.py
@@ -636,7 +636,7 @@ def client_handler(client_socket, console: Console):
 
 def listen_for_clients(console: Console):
     server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    server_socket.bind(('localhost', 12345))
+    server_socket.bind(('localhost', 53153))
     server_socket.listen()
     while True:
         client, addr = server_socket.accept()


### PR DESCRIPTION
Port 12345 is used by a lot of different random things, so the risk of port collisions causing the debug console to conflict with some other software is relatively high. Changing it to another port that's not so commonly used should make that a lot less likely