### PR TITLE
Change straight algorithm

### DIFF
--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -1781,6 +1781,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
             ignore = false
         },
         next = {},
+        prev = {},
         straight_edge = false,
         -- TODO we need a better system for what this is doing.
         -- We should allow setting a playing card's atlas and position to any values,
@@ -1825,6 +1826,12 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
                     table.insert(self.obj_buffer, j, self.key)
                 else
                     table.insert(self.obj_buffer, self.key)
+                end
+                for _,v in ipairs(self.next) do
+                    local other = self.obj_table[v]
+                    if other then
+                        table.insert(other.prev, self.key)
+                    end
                 end
             end
         end,
@@ -2344,7 +2351,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
     }
     SMODS.PokerHandPart {
         key = '_straight',
-        func = function(hand) return get_straight(hand) end
+        func = function(hand) return get_straight(hand, next(SMODS.find_card('j_four_fingers')) and 4 or 5, next(SMODS.find_card('j_shortcut'))) end
     }
     SMODS.PokerHandPart {
         key = '_flush',


### PR DESCRIPTION
The current algorithm for straights is pretty bad with custom ranks that have split paths. This proposes a new one that works correctly in cases where the previous one failed.
Example: Given ranks 10->11->12->13 with `SMODS.Ranks['10'].next = {'Jack', '11'}`.
- 9,10,J,Q is a valid 4-finger straight
- 9,10,J,11,12 should also be a valid 4-finger straight but isn't because the current algorithm gets trapped in the first path

Originally tried to base an implementation of quantum ranks on this but realized this would be inefficient as candidate straights can be invalidated at each step and checking a given hand with quantum ranks for containing a straight is exponential in the length of the straight.

Also builds prev tables in ranks when injected. Not used here but figured it might be useful to have