### PR TITLE
More deck contexts, SMODS.Back.calculate

### DIFF
--- a/lovely/back.toml
+++ b/lovely/back.toml
@@ -46,7 +46,7 @@ match_indent = true
 payload = '''
 	local obj = self.effect.center
 	if obj.apply and type(obj.apply) == 'function' then
-		obj:apply()
+		obj:apply(self)
 	end'''
 
 # Back:trigger_effect(args)
@@ -58,9 +58,14 @@ position = 'after'
 match_indent = true
 payload = '''
 	local obj = self.effect.center
-	if obj.trigger_effect and type(obj.trigger_effect) == 'function' then
+	if type(obj.calculate) == 'function' then
+		local o = {obj:calculate(self, args)}
+		if next(o) ~= nil then return unpack(o) end
+	elseif type(obj.trigger_effect) == 'function' then
+		-- kept for compatibility
+		sendWarnMessage(('Found `trigger_effect` function on SMODS.Back object "%s". This field is deprecated; please use `calculate` instead.'):format(obj.key), 'Back')
 		local o = {obj:trigger_effect(args)}
-		if o then return unpack(o) end
+		if next(o) ~= nil then return unpack(o) end
 	end'''
 
 ## Back:generate_UI

--- a/lovely/better_calc.toml
+++ b/lovely/better_calc.toml
@@ -89,6 +89,7 @@ for k=1, #G.jokers.cards do
     if eval then 
         table.insert(effects, eval)
     end
+end
 '''
 position = 'at'
 match_indent = true
@@ -113,6 +114,7 @@ for k=1, #G.jokers.cards + #G.consumeables.cards do
             end
         end
     end
+end
 '''
 [[patches]]
 [patches.pattern]
@@ -455,6 +457,8 @@ payload = ''
 [patches.pattern]
 target = "functions/state_events.lua"
 pattern = '''
+    scoring_hand[i].lucky_trigger = nil
+
         for ii = 1, #effects do
         --If chips added, do chip add event and add the chips to the total
         if effects[ii].chips then 
@@ -521,6 +525,9 @@ position = "at"
 payload = '''
         -- Base game calculation removed
         SMODS.trigger_effects(effects, scoring_hand[i])
+        local deck_effect = G.GAME.selected_back:trigger_effect({cardarea = G.play, full_hand = G.play.cards, scoring_hand = scoring_hand, scoring_name = text, poker_hands = poker_hands, other_card = scoring_hand[i], individual = true})
+        if deck_effect then SMODS.calculate_effect(deck_effect, G.deck.cards[1]) end
+        scoring_hand[i].lucky_trigger = nil
     end
     scoring_hand[i].extra_enhancements = nil
 end
@@ -574,6 +581,8 @@ position = "at"
 payload = '''
 -- Base game calculation removed 2
 SMODS.trigger_effects(effects, G.hand.cards[i])
+local deck_effect = G.GAME.selected_back:trigger_effect({cardarea = G.hand, full_hand = G.play.cards, scoring_hand = scoring_hand, scoring_name = text, poker_hands = poker_hands, other_card = G.hand.cards[i], individual = true})
+if deck_effect then SMODS.calculate_effect(deck_effect, G.deck.cards[1]) end
 
 if reps[j] == 1 and effects.calculated then
     SMODS.calculate_repetitions(G.hand.cards[i], {cardarea = G.hand, full_hand = G.play.cards, scoring_hand = scoring_hand, scoring_name = text, poker_hands = poker_hands, other_card = G.hand.cards[i], repetition = true, card_effects = effects}, reps)
@@ -642,7 +651,10 @@ payload = '''
 local eval = eval_card(_card, {cardarea = G.jokers, full_hand = G.play.cards, scoring_hand = scoring_hand, scoring_name = text, poker_hands = poker_hands, edition = true, post_joker = true})
 if eval.edition then effects[#effects+1] = eval end
 
-SMODS.trigger_effects(effects, _card)'''
+SMODS.trigger_effects(effects, _card)
+local deck_effect = G.GAME.selected_back:trigger_effect({full_hand = G.play.cards, scoring_hand = scoring_hand, scoring_name = text, poker_hands = poker_hands, other_joker = _card.ability.set == 'Joker' and _card or false, other_consumeable = _card.ability.set ~= 'Joker' and _card or false})
+if deck_effect then SMODS.calculate_effect(deck_effect, G.deck.cards[1]) end
+'''
 # Joker effects
 ## I am NOT converting this to regex (yet)
 [[patches]]
@@ -1083,6 +1095,7 @@ if reps[j] == 1 then
 end
 
 SMODS.trigger_effects(effects, G.hand.cards[i])
+G.GAME.selected_back:trigger_effect({cardarea = G.hand, other_card = G.hand.cards[i], individual = true, end_of_round = true})
 j = j + (effects.calculated and 1 or #reps)
 
 -- TARGET: effects after hand evaluation

--- a/lovely/better_calc.toml
+++ b/lovely/better_calc.toml
@@ -271,8 +271,8 @@ pattern = "local effects = {eval_card(scoring_hand[i], {cardarea = G.play, full_
 match_indent = true
 position = "at"
 payload = '''
-local effects = {eval_card(scoring_hand[i], {main_scoring = true, cardarea = G.play, full_hand = G.play.cards, scoring_hand = scoring_hand, poker_hand = text})}
-SMODS.calculate_quantum_enhancements(scoring_hand[i], effects, {main_scoring = true, cardarea = G.play, full_hand = G.play.cards, scoring_hand = scoring_hand, poker_hand = text})
+local effects = {eval_card(scoring_hand[i], {main_scoring = true, cardarea = G.play, full_hand = G.play.cards, scoring_hand = scoring_hand, scoring_name = text, poker_hands = poker_hands})}
+SMODS.calculate_quantum_enhancements(scoring_hand[i], effects, {main_scoring = true, cardarea = G.play, full_hand = G.play.cards, scoring_hand = scoring_hand, scoring_name = text, poker_hands = poker_hands})
 '''
 [[patches]]
 [patches.pattern]


### PR DESCRIPTION
Adds context.individual and context.other_joker/other_consumeable as evaluated contexts for decks. Also introduces `SMODS.Back.calculate` and deprecates `SMODS.Back.trigger_effect` to indicate consistency with other calculate functions. This calculate function as well as `SMODS.Back.apply` get passed the `Back` they're called on, again for consistency