### PR TITLE
fix: main scoring on card still using get_edition

### DIFF
--- a/lovely/better_calc.toml
+++ b/lovely/better_calc.toml
@@ -202,6 +202,16 @@ if context.cardarea == G.play then
     if p_dollars > 0 then 
         ret.p_dollars = p_dollars
     end
+
+    local jokers = card:calculate_joker(context)
+    if jokers then 
+        ret.jokers = jokers
+    end
+
+    local edition = card:get_edition(context)
+    if edition then 
+        ret.edition = edition
+    end
 '''
 match_indent = true
 position = "at"
@@ -229,6 +239,16 @@ if context.cardarea == G.play and context.main_scoring then
     end
 
     -- TARGET: main scoring on played cards
+
+    local jokers = card:calculate_joker(context)
+    if jokers then 
+        ret.jokers = jokers
+    end
+
+    local edition = card:calculate_edition(context)
+    if edition then 
+        ret.edition = edition
+    end
 """
 [[patches]]
 [patches.pattern]


### PR DESCRIPTION
All other instances of get_edition have been replaced with calculate_edition, respecting Edition.take_ownership.calculate, this one is missing

On that note, since it seems to me that all other instances of get_edition() has been fully eliminated and replaced with calculate_edition, I'm not sure I understand why overrides.lua:1474 has been commented out.