### PR TITLE
Add Easy Joker Resizing

### DIFF
--- a/lovely/joker_size.toml
+++ b/lovely/joker_size.toml
@@ -59,10 +59,14 @@ self.VT.w = self.T.w
 '''
 position = "before"
 payload = '''
-if self.config.center.pixel_size and self.config.center.pixel_size.h then
+if self.config.center.display_size and self.config.center.display_size.h then
+    self.T.h = H*(self.config.center.display_size.h/95)
+elseif self.config.center.pixel_size and self.config.center.pixel_size.h then
     self.T.h = H*(self.config.center.pixel_size.h/95)
 end
-if self.config.center.pixel_size and self.config.center.pixel_size.w then
+if self.config.center.display_size and self.config.center.display_size.w then
+    self.T.w = W*(self.config.center.display_size.w/71)
+elseif self.config.center.pixel_size and self.config.center.pixel_size.w then
     self.T.w = W*(self.config.center.pixel_size.w/71)
 end
 '''

--- a/lovely/joker_size.toml
+++ b/lovely/joker_size.toml
@@ -1,0 +1,69 @@
+[manifest]
+version = "1.0.0"
+dump_lua = true
+priority = 0
+
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+if _center.name == 'Square Joker' and (_center.discovered or self.bypass_discovery_center) then 
+    self.children.center.scale.y = self.children.center.scale.x
+end
+'''
+position = "after"
+payload = '''
+if _center.pixel_size and _center.pixel_size.h and (_center.discovered or self.bypass_discovery_center) then
+    self.children.center.scale.y = self.children.center.scale.y*(_center.pixel_size.h/95)
+end
+if _center.pixel_size and _center.pixel_size.w and (_center.discovered or self.bypass_discovery_center) then
+    self.children.center.scale.x = self.children.center.scale.x*(_center.pixel_size.w/71)
+end
+'''
+match_indent = true
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+if center.name == "Wee Joker" and (center.discovered or self.bypass_discovery_center) then 
+    H = H*0.7
+    W = W*0.7
+    self.T.h = H
+    self.T.w = W
+end
+'''
+position = "after"
+payload = '''
+if center.display_size and center.display_size.h and (center.discovered or self.bypass_discovery_center) then
+    H = H*(center.display_size.h/95)
+    self.T.h = H
+elseif center.pixel_size and center.pixel_size.h and (center.discovered or self.bypass_discovery_center) then
+    H = H*(center.pixel_size.h/95)
+    self.T.h = H
+end
+if center.display_size and center.display_size.w and (center.discovered or self.bypass_discovery_center) then
+    W = W*(center.display_size.w/71)
+    self.T.w = W
+elseif center.pixel_size and center.pixel_size.w and (center.discovered or self.bypass_discovery_center) then
+    W = W*(center.pixel_size.w/71)
+    self.T.w = W
+end
+'''
+match_indent = true
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+self.VT.h = self.T.H
+self.VT.w = self.T.w
+'''
+position = "before"
+payload = '''
+if self.config.center.pixel_size and self.config.center.pixel_size.h then
+    self.T.h = H*(self.config.center.pixel_size.h/95)
+end
+if self.config.center.pixel_size and self.config.center.pixel_size.w then
+    self.T.w = W*(self.config.center.pixel_size.w/71)
+end
+'''
+match_indent = true


### PR DESCRIPTION
Adds the ability to set the size of jokers through parameters  
`pixel_size` controls how large the joker's sprite is considered. Ex: half joker would set `pixel_size.h` to indicate that it has a smaller sprite. defaults to `{ w = 71, h = 90 }`  
`display_size` controls how the joker's sprite is scaled. Ex: wee joker would set both `display_size.h` and `display_size.w` to indicate that it should be shrunk. defaults to `pixel_size`  
partial tables can also be used, with the default being used for missing values  
`pixel_size` and `display_size` can be combined and both work as normal  
in other words, `display_size` controls the bounding box of the joker, and `pixel_size` controls the portion of the sprite that it fit to the bounding box  
WARNING! stake stickers look broken on narrow & tall jokers. this is a result of how stickers are scaled and cannot reasonably be avoided
also works for consumables, vouchers, and booster packs!