### PR TITLE
feat(mod_config): Allow for nested config values for mods

### DIFF
--- a/src/ui.lua
+++ b/src/ui.lua
@@ -951,45 +951,23 @@ function SMODS.load_mod_config(mod)
     if not s2 or type(default_config) ~= 'table' then default_config = {} end
     mod.config = default_config
     
-    -- Hacky line to allow for recursive calling of the function while keeping it local scoped, open to better solutions lol
-    local insertSavedConfig = function(...) end 
-    insertSavedConfig = function(savedCfg, defaultCfg)
+    local function insert_saved_config(savedCfg, defaultCfg)
         for savedKey, savedVal in pairs(savedCfg) do
-            -- If the key doesn't exist in the default config, just set the whole thing regardless of value typing
-            if not defaultCfg[savedKey] then
-                defaultCfg[savedKey] = savedVal
-                goto continue
-            end
-
-            -- If the saved config value is a table and the default config value isn't a table, give priority to default
             local savedValType = type(savedVal)
             local defaultValType = type(defaultCfg[savedKey])
-            if savedValType == "table" and defaultValType ~= "table" then
-                goto continue
-            end
-
-            -- If the types of the saved config value and default config value are mismatched, give priority to the default
-            if savedValType ~= defaultValType then
-                goto continue
-            end
-
-            -- If the saved config value is a table and so is the default config value, call this function recursively
-            if savedValType == "table" and defaultValType == "table" then
-                insertSavedConfig(savedVal, defaultCfg[savedKey])
-                goto continue
-            end
-                
-            -- If the saved config value doesn't match the default config value, use the saved value
-            if savedVal ~= defaultCfg[savedKey] then
+            if not defaultCfg[savedKey] then
                 defaultCfg[savedKey] = savedVal
-                goto continue
+            elseif savedValType ~= defaultValType then
+            elseif savedValType == "table" and defaultValType == "table" then
+                insert_saved_config(savedVal, defaultCfg[savedKey])
+            elseif savedVal ~= defaultCfg[savedKey] then
+                defaultCfg[savedKey] = savedVal
             end
             
-            ::continue::
         end
     end
 
-    insertSavedConfig(config, mod.config)
+    insert_saved_config(config, mod.config)
 
     return mod.config
 end


### PR DESCRIPTION
## The Goal
The goal of this PR is to allow for mods `config.lua` file to make use of nested values.

## The Problem
Consider the following:
For sake of example, lets say I have the following as my `config.lua` file for my mod:
```lua
return {
    ["foo_group_1"] = {
        ["money"] = 10,
        ["enabled"] = true,
    },
    ["foo_group_2"] = {
        ["yellow"] = {
            ["label"] = "cat",
            ["enabled"] = false,
        },
    },
}
```

Lets say the player uses the mod config menu to edit the settings of the mod to make the following table be our current saved config for the mod:
```lua
{
    ["foo_group_1"] = {
        ["money"] = 23,
        ["enabled"] = true,
    },
    ["foo_group_2"] = {
        ["yellow"] = {
            ["label"] = "bear",
            ["enabled"] = false,
        },
    },
}
```

As of right now all is fine, however, lets say the mod developer wants to add a feature to their mod and needs to add a new item in `foo_group_2`, making the new `config.lua` file look like so:
```lua
return {
    ["foo_group_1"] = {
        ["money"] = 10,
        ["enabled"] = true,
    },
    ["foo_group_2"] = {
        ["yellow"] = {
            ["label"] = "cat",
            ["enabled"] = false,
        },
        ["green"] = {
            ["label"] = "dog",
            ["enabled"] = false,
        },
    },
}
```

The problem now happens if our player loads the new version of the mod with their old saved config on file, the `SMODS.load_mod_config` method will do a combination of the saved and default configs without taking into account any nesting, resulting in a loaded mod config of a table like this:
```lua
{
    ["foo_group_1"] = {
        ["money"] = 23,
        ["enabled"] = true,
    },
    ["foo_group_2"] = {
        ["yellow"] = {
            ["label"] = "bear",
            ["enabled"] = false,
        },
    },
}
```

This is now a problem because the player's game will crash when trying to access `config.foo_group_2.green`

## The Proposed Solution
With this PR, the final combined table will instead look like this:
```lua
{
    ["foo_group_1"] = {
        ["money"] = 23,
        ["enabled"] = true,
    },
    ["foo_group_2"] = {
        ["yellow"] = {
            ["label"] = "bear",
            ["enabled"] = false,
        },
        ["green"] = {
            ["label"] = "dog",
            ["enabled"] = false,
        },
    },
}
```