### PR TITLE
Fix: Gold cards are triggering twice

### DIFF
--- a/src/utils.lua
+++ b/src/utils.lua
@@ -851,7 +851,10 @@ function Card:calculate_enhancement(context)
 end
 
 function SMODS.get_enhancements(card, extra_only)
-    if not SMODS.optional_features.quantum_enhancements then return card.ability.set == 'Enhanced' and { [card.config.center.key] = true } or {} end
+    if not SMODS.optional_features.quantum_enhancements then
+	if extra_only then return {} end
+	return card.ability.set == 'Enhanced' and { [card.config.center.key] = true } or {} end
+    end
     if card.extra_enhancements and next(card.extra_enhancements) then
         if extra_only then
             local extras = copy_table(card.extra_enhancements)

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -853,7 +853,7 @@ end
 function SMODS.get_enhancements(card, extra_only)
     if not SMODS.optional_features.quantum_enhancements then
 	if extra_only then return {} end
-	return card.ability.set == 'Enhanced' and { [card.config.center.key] = true } or {} end
+	return card.ability.set == 'Enhanced' and { [card.config.center.key] = true } or {}
     end
     if card.extra_enhancements and next(card.extra_enhancements) then
         if extra_only then


### PR DESCRIPTION
version: **1.0.0~ALPHA-1318d-STEAMODDED**

Investigated this issue, I've managed to narrow it down to eval_card being called twice with identical contexts: `context.end_of_round = true, context.playing_card_end_of_round = true`

I think I have the root cause.

First evaluation (normal), will calculate card's "regular" enhancement: smods/utils.lua:1394

`local effects = {eval_card(card, context)}`

Second evaluation (extra), will calculate card's extra enhancement: smods/utils.lua:1403

`effects[#effects+1] = eval_card(card, context)`

This should not be called at all, the card is a regular gold card with the quantum enhancement feature on default setting (turned off). However, it is called, because smods/utils.lua:1395

`local extra_enhancements = SMODS.get_enhancements(card, true)`

Returns an enhancement (the card's base enhancement) despite being called with extra_only.

I'm not sure what the intention is here so I'm not confident the patch is correct in every case.