### PR TITLE
Fix: fix deck unlock stake

### DIFF
--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -1247,7 +1247,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
     local function stake_mod(stake)
         return {
             inject = function(self)
-                self.unlock_condition.stake = SMODS.Stakes[stake].stake_level
+                self.unlock_condition.stake = SMODS.Stakes[stake].order
                 SMODS.Back.inject(self)
             end
         }


### PR DESCRIPTION
When having a SMODS.Stake between the vanilla stakes, e.g.:
```lua
SMODS.Stake {
    key = 'silver',
    pos = {x = 0, y = 0},
    applied_stakes = {'red'},
    above_stake = 'red',
    colour = G.C.GOLD,
    loc_txt = {
        name = "Silver Stake",
        text = {}
    },
    prefix_config = {above_stake = {mod = false}, applied_stakes = {mod = false}},
}
```

Then the deck gets confused about its unlock stake (this is painted deck; it normally has the green stake as unlock):

![image](https://github.com/user-attachments/assets/92cbf8c1-f7d0-46b3-89ca-150ffd0882e2)
