### PR TITLE
Add shadow option to mod:description_loc_vars

### DIFF
--- a/src/ui.lua
+++ b/src/ui.lua
@@ -245,7 +245,7 @@ function buildModDescTab(mod)
             if (G.localization.descriptions.Mod or {})[mod.id] then
                 modNodes[#modNodes + 1] = {}
                 local loc_vars = mod.description_loc_vars and mod:description_loc_vars() or {}
-                localize { type = 'descriptions', key = loc_vars.key or mod.id, set = 'Mod', nodes = modNodes[#modNodes], vars = loc_vars.vars, scale = loc_vars.scale, text_colour = loc_vars.text_colour }
+                localize { type = 'descriptions', key = loc_vars.key or mod.id, set = 'Mod', nodes = modNodes[#modNodes], vars = loc_vars.vars, scale = loc_vars.scale, text_colour = loc_vars.text_colour, shadow = loc_vars.shadow }
                 modNodes[#modNodes] = desc_from_rows(modNodes[#modNodes])
                 modNodes[#modNodes].config.colour = loc_vars.background_colour or modNodes[#modNodes].config.colour
             else


### PR DESCRIPTION
Allows mod developers to use shadows in their mod description using `description_loc_vars`, if they want