### PR TITLE
Improve SMODS.deepfind

### DIFF
--- a/src/utils.lua
+++ b/src/utils.lua
@@ -1537,7 +1537,10 @@ local flat_copy_table = function(tbl)
 end
 
 ---Seatch for val anywhere deep in tbl. Return a table of finds, or the first found if immediate is provided.
-SMODS.deepfind = function(tbl, val, immediate)
+SMODS.deepfind = function(tbl, val, args)
+    args = args or {}
+    local immediate = args.immediate or false
+    local mode = ((args.mode == "index" and "i") or (args.mode == "value" and "v'))
     local seen = {[tbl] = true}
     local collector = {}
     local stack = { {tbl = tbl, path = {}, objpath = {}} }
@@ -1556,7 +1559,7 @@ SMODS.deepfind = function(tbl, val, immediate)
         --for every table that we have
         for i, v in pairs(currentTbl) do
             --if the value matches
-            if v == val then
+            if (mode == "v" and v == val) or (mode == "i") and i == val then
                 --copy our values and store it in the collector
                 local newPath = flat_copy_table(currentPath)
                 local newObjPath = flat_copy_table(currentObjPath)
@@ -1582,7 +1585,7 @@ SMODS.deepfind = function(tbl, val, immediate)
 
     return collector
 end
-
+--[[
 --Seatch for val as an index anywhere deep in tbl. Return a table of finds, or the first found if immediate is provided.
 SMODS.deepfindbyindex = function(tbl, val, immediate)
     local seen = {[tbl] = true}
@@ -1629,7 +1632,7 @@ SMODS.deepfindbyindex = function(tbl, val, immediate)
 
     return collector
 end
-
+]]
 -- this is for debugging
 SMODS.debug_calculation = function()
     G.contexts = {}

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -1537,15 +1537,19 @@ local flat_copy_table = function(tbl)
 end
 
 ---Seatch for val anywhere deep in tbl. Return a table of finds, or the first found if args.immediate is provided.
-SMODS.deepfind = function(tbl, val, args)
-    args = args or {}
+SMODS.deepfind = function(tbl, val, mode, immediate)
     --backwards compat (remove later probably)
-    if args == true then
-        args = {immediate = true}
+    if mode == true then
+        mode = "v"
+        immediate = true
     end
-    local immediate = args.immediate or false
-    local mode = (((args.mode == "index" or args.mode == "i") and "i") 
-    or ((args.mode == "value" or args.mode == "v") and "v")) or "v"
+    if mode == "index" then
+        mode = "i"
+    elseif mode == "value" then
+        mode = "v"
+    elseif mode ~= "v" and mode ~= "i" then
+        mode = "v"
+    end
     local seen = {[tbl] = true}
     local collector = {}
     local stack = { {tbl = tbl, path = {}, objpath = {}} }
@@ -1593,7 +1597,7 @@ end
 
 --backwards compat (remove later probably)
 SMODS.deepfindbyindex = function(tbl, val, immediate)
-    return SMODS.deepfind(tbl, val, {mode = "i", immediate=immediate})
+    return SMODS.deepfind(tbl, val, "i", immediate)
 end
 
 -- this is for debugging


### PR DESCRIPTION
This mainly just merges SMODS.deepfind and SMODS.deepfindbyindex into one singular function.
SMODS.deepfindbyindex still exists as a shorthand for backwards compatibility reasons.
The old syntax for calling SMODS.deepfind also still works, for the same backwards compatibility reason.