### PR TITLE
fix repetitions ignoring `remove_default_message`

### DIFF
--- a/src/utils.lua
+++ b/src/utils.lua
@@ -1216,7 +1216,7 @@ SMODS.calculate_repetitions = function(card, context, reps)
         if value.repetitions then
             for h=1, value.repetitions do
                 value.card = value.card or card
-                value.message = value.message or localize('k_again_ex')
+                value.message = value.message or (not value.remove_default_message and localize('k_again_ex'))
                 reps[#reps+1] = {key = value}
             end
         end
@@ -1234,7 +1234,7 @@ SMODS.calculate_repetitions = function(card, context, reps)
 
                     for h=1, value.repetitions do
                         value.card = value.card or _card
-                        value.message = value.message or localize('k_again_ex')
+                        value.message = value.message or (not value.remove_default_message and localize('k_again_ex'))
                         reps[#reps+1] = {key = value}
                         for i=1, rt do
                             local rt_eval, rt_post = eval_card(_card, context)
@@ -1268,7 +1268,7 @@ SMODS.calculate_retriggers = function(card, context, _ret)
                 if value.repetitions then
                     for h=1, value.repetitions do
                         value.retrigger_card = _card
-                        value.message = value.message or localize('k_again_ex')
+                        value.message = value.message or (not value.remove_default_message and localize('k_again_ex'))
                         retriggers[#retriggers + 1] = value
                     end
                 end


### PR DESCRIPTION
[1404e](https://github.com/Steamodded/smods/commit/1189481445a3ddef598c978d67df78d0ac8e4ed6) added a default message for repetetions and joker retriggers. unfortanately, this default message is always applied, even if `remove_default_message` is specified. this pull request fixes that bug.