### PR TITLE
Fix set_edition not properly resetting negative playing cards

### DIFF
--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -1303,6 +1303,9 @@ function Card:set_edition(edition, immediate, silent)
 		elseif self.ability.set == 'Joker' and self.area == G.jokers then
 			G.jokers.config.card_limit = G.jokers.config.card_limit - self.edition.card_limit
 		elseif self.area == G.hand then
+			if G.hand.config.real_card_limit then
+				G.hand.config.real_card_limit = G.hand.config.real_card_limit - self.edition.card_limit
+			end
 			G.hand.config.card_limit = G.hand.config.card_limit - self.edition.card_limit
 		end
 	end


### PR DESCRIPTION
This fixes hand size permanently increasing by 1 when using Death to turn a negative card non-negative.
(just a copy of the addition code later down in the function, but subtracting instead)