### PR TITLE
fix seed advancing on collection

### DIFF
--- a/lovely/fixes.toml
+++ b/lovely/fixes.toml
@@ -594,6 +594,19 @@ pattern = '''and \(G\.hand\.cards\[1\] or \(G\.hand\.config\.card_limit <= 0\)\)
 position = "at"
 payload = ''' '''
 
+# Fix prng calls on collection advancing seeds
+# Keep vanilla behaviour for to-do list
+[[patches]]
+[patches.pattern]
+target = "functions/misc_functions.lua"
+pattern = "if key == 'seed' then return math.random() end"
+position = "after"
+payload = """
+if G.SETTINGS.paused and key ~= 'to_do' then return math.random() end
+"""
+overwrite = true
+match_indent = true
+
 # Fixes Steam API not loading on unix
 [[patches]]
 [patches.pattern]


### PR DESCRIPTION
noticed a slight flaw where calling a pseudorandom in set_ability advances seeds while in the collection

kept this behaviour for to-do list, which, despite an attempted "fix" visible in card.lua, still has this issue in vanilla