### PR TITLE
Booster Packs now respect changes to number of choices

### DIFF
--- a/lovely/booster.toml
+++ b/lovely/booster.toml
@@ -36,7 +36,7 @@ if booster_obj and SMODS.Centers[booster_obj.key] then
     G.STATE = G.STATES.SMODS_BOOSTER_OPENED
     SMODS.OPENED_BOOSTER = self
 end
-G.GAME.pack_choices = self.ability.choose
+G.GAME.pack_choices = self.ability.choose or self.config.center.config.choose or 1
 """
 
 # Card:open

--- a/lovely/booster.toml
+++ b/lovely/booster.toml
@@ -25,7 +25,9 @@ if self.ability.name:find('Arcana') then
         elseif self.ability.name:find('Buffoon') then
             G.STATE = G.STATES.BUFFOON_PACK
             G.GAME.pack_size = self.ability.extra
-        end'''
+        end
+
+        G.GAME.pack_choices = self.config.center.config.choose or 1'''
 match_indent = true
 position = "at"
 payload = """
@@ -34,6 +36,7 @@ if booster_obj and SMODS.Centers[booster_obj.key] then
     G.STATE = G.STATES.SMODS_BOOSTER_OPENED
     SMODS.OPENED_BOOSTER = self
 end
+G.GAME.pack_choices = self.ability.choose
 """
 
 # Card:open

--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -1442,7 +1442,6 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
 
     SMODS.Booster:take_ownership_by_kind('Celestial', {
         group_key = "k_celestial_pack",
-        config = {extra = 10, choose = 1},
         update_pack = SMODS.Booster.update_pack,
         ease_background_colour = function(self) ease_background_colour_blind(G.STATES.PLANET_PACK) end,
         create_UIBox = SMODS.Booster.create_UIBox,


### PR DESCRIPTION
Fix a weird bug where modifying a Booster Pack's `ability.choose` value appears to work when viewing the pack's description but then doesn't actually work when opening the pack.