### PR TITLE
fix(create_card): Remove additional sound effect

### DIFF
--- a/src/utils.lua
+++ b/src/utils.lua
@@ -317,7 +317,7 @@ function SMODS.create_card(t)
     if not t.area and not t.key and t.set and SMODS.ConsumableTypes[t.set] then
         t.area = G.consumeables
     end
-    SMODS.bypass_create_card_edition = t.no_edition
+    SMODS.bypass_create_card_edition = t.no_edition or t.edition
     local _card = create_card(t.set, t.area, t.legendary, t.rarity, t.skip_materialize, t.soulable, t.key, t.key_append)
     SMODS.bypass_create_card_edition = nil
 


### PR DESCRIPTION
create_card polls for edition and applies it, if we're not disabling create_card edition poll behaviour when we're already going to force an edition, then a sound effect will potentially play due to two editions being applied