### PR TITLE
feat: Add permanent playing card bonuses

### DIFF
--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -62,7 +62,58 @@ return {
                     'This mod has been',
                     '{C:attention}disabled!{}'
                 }
-            }
+            },
+
+
+            -- card perma bonuses
+            card_extra_xchips = {
+                text = {
+                    "{C:chips}+{X:chips,C:white}X#1#{} extra chips"
+                }
+            },
+            card_extra_mult = {
+                text = {
+                    "{C:mult}+#1#{} extra Mult"
+                }
+            },
+            card_extra_xmult = {
+                text = {
+                    "{C:mult}+{X:mult,C:white}X#1#{} extra Mult"
+                }
+            },
+            card_extra_hchips = {
+                text = {
+                    "{C:chips}+#1#{} extra chips",
+                    "while this card",
+                    "stays in hand",
+                }
+            },
+            card_extra_hxchips = {
+                text = {
+                    "{C:chips}+{X:chips,C:white}X#1#{} extra chips",
+                    "while this card",
+                    "stays in hand",
+                }
+            },
+            card_extra_hmult = {
+                text = {
+                    "{C:mult}+#1#{} extra Mult",
+                    "while this card",
+                    "stays in hand",
+                }
+            },
+            card_extra_hxmult = {
+                text = {
+                    "{C:mult}+{X:mult,C:white}X#1#{} extra Mult",
+                    "while this card",
+                    "stays in hand",
+                }
+            },
+            card_extra_dollars = {
+                text = {
+                    "{C:money}+$#1#{} when scored",
+                }
+            },
         },
         Edition = {
             e_negative_playing_card = {

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -66,53 +66,55 @@ return {
 
 
             -- card perma bonuses
-            card_extra_xchips = {
+            card_extra_chips={
+                text={
+                    "{C:chips}#1#{} extra chips",
+                },
+            },
+            card_extra_x_chips = {
                 text = {
-                    "{C:chips}+{X:chips,C:white}X#1#{} extra chips"
+                    "{X:chips,C:white}X#1#{} extra chips"
                 }
             },
             card_extra_mult = {
                 text = {
-                    "{C:mult}+#1#{} extra Mult"
+                    "{C:mult}#1#{} extra Mult"
                 }
             },
-            card_extra_xmult = {
+            card_extra_x_mult = {
                 text = {
-                    "{C:mult}+{X:mult,C:white}X#1#{} extra Mult"
+                    "{X:mult,C:white}X#1#{} extra Mult"
                 }
             },
-            card_extra_hchips = {
+            card_extra_p_dollars = {
                 text = {
-                    "{C:chips}+#1#{} extra chips",
-                    "while this card",
-                    "stays in hand",
+                    "{C:money}#1#{} when scored",
                 }
             },
-            card_extra_hxchips = {
+            card_extra_h_chips = {
                 text = {
-                    "{C:chips}+{X:chips,C:white}X#1#{} extra chips",
-                    "while this card",
-                    "stays in hand",
+                    "{C:chips}#1#{} chips when held",
                 }
             },
-            card_extra_hmult = {
+            card_extra_h_x_chips = {
                 text = {
-                    "{C:mult}+#1#{} extra Mult",
-                    "while this card",
-                    "stays in hand",
+                    "{X:chips,C:white}X#1#{} extra chips when held",
                 }
             },
-            card_extra_hxmult = {
+            card_extra_h_mult = {
                 text = {
-                    "{C:mult}+{X:mult,C:white}X#1#{} extra Mult",
-                    "while this card",
-                    "stays in hand",
+                    "{C:mult}#1#{} extra Mult",
                 }
             },
-            card_extra_dollars = {
+            card_extra_h_x_mult = {
                 text = {
-                    "{C:money}+$#1#{} when scored",
+                    "{X:mult,C:white}X#1#{} extra Mult when held",
                 }
+            },
+            card_extra_h_dollars = {
+                text = {
+                    "{C:money}#1#{} if held at end of round",
+                },
             },
         },
         Edition = {

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -71,6 +71,11 @@ return {
                     "{C:chips}#1#{} extra chips",
                 },
             },
+            card_x_chips = {
+                text = {
+                    "{X:chips,C:white}X#1#{} chips"
+                }
+            },
             card_extra_x_chips = {
                 text = {
                     "{X:chips,C:white}X#1#{} extra chips"
@@ -79,6 +84,11 @@ return {
             card_extra_mult = {
                 text = {
                     "{C:mult}#1#{} extra Mult"
+                }
+            },
+            card_x_mult = {
+                text = {
+                    "{X:mult,C:white}X#1#{} Mult"
                 }
             },
             card_extra_x_mult = {
@@ -96,6 +106,11 @@ return {
                     "{C:chips}#1#{} chips when held",
                 }
             },
+            card_h_x_chips = {
+                text = {
+                    "{X:chips,C:white}X#1#{} chips when held",
+                }
+            },
             card_extra_h_x_chips = {
                 text = {
                     "{X:chips,C:white}X#1#{} extra chips when held",
@@ -103,7 +118,12 @@ return {
             },
             card_extra_h_mult = {
                 text = {
-                    "{C:mult}#1#{} extra Mult",
+                    "{C:mult}#1#{} extra Mult when held",
+                }
+            },
+            card_h_x_mult = {
+                text = {
+                    "{X:mult,C:white}X#1#{} Mult when held",
                 }
             },
             card_extra_h_x_mult = {
@@ -122,6 +142,15 @@ return {
                 name = "Negative",
                 text = {
                     "{C:dark_edition}+#1#{} hand size"
+                },
+            },
+        },
+        Enhanced = {
+            m_stone={
+                name="Stone Card",
+                text={
+                    "{C:chips}#1#{} chips",
+                    "no rank or suit",
                 },
             },
         }

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -149,7 +149,7 @@ return {
             m_gold={
                 name="Gold Card",
                 text={
-                    "{C:money}#1#{} if held",
+                    "{C:money}#1#{} if this",
                     "card is held in hand",
                     "at end of round",
                 },

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -146,11 +146,25 @@ return {
             },
         },
         Enhanced = {
+            m_gold={
+                name="Gold Card",
+                text={
+                    "{C:money}#1#{} if held",
+                    "card is held in hand",
+                    "at end of round",
+                },
+            },
             m_stone={
                 name="Stone Card",
                 text={
                     "{C:chips}#1#{} chips",
                     "no rank or suit",
+                },
+            },
+            m_mult={
+                name="Mult Card",
+                text={
+                    "{C:mult}#1#{} Mult",
                 },
             },
         }

--- a/lovely/playing_card.toml
+++ b/lovely/playing_card.toml
@@ -329,8 +329,8 @@ end
 if specific_vars and specific_vars.bonus_h_x_mult then
 	localize{type = 'other', key = 'card_extra_h_x_mult', nodes = desc_nodes, vars = {specific_vars.bonus_h_x_mult}}
 end
-if specific_vars and specific_vars.bonus_dollars then
-	localize{type = 'other', key = 'card_extra_p_dollars', nodes = desc_nodes, vars = {specific_vars.bonus_dollars}}
+if specific_vars and specific_vars.bonus_p_dollars then
+	localize{type = 'other', key = 'card_extra_p_dollars', nodes = desc_nodes, vars = {specific_vars.bonus_p_dollars}}
 end
 if specific_vars and specific_vars.bonus_h_dollars then
 	localize{type = 'other', key = 'card_extra_h_dollars', nodes = desc_nodes, vars = {specific_vars.bonus_h_dollars}}
@@ -366,8 +366,8 @@ end
 if specific_vars and specific_vars.bonus_h_x_mult then
 	localize{type = 'other', key = 'card_extra_h_x_mult', nodes = desc_nodes, vars = {specific_vars.bonus_h_x_mult}}
 end
-if specific_vars and specific_vars.bonus_dollars then
-	localize{type = 'other', key = 'card_extra_p_dollars', nodes = desc_nodes, vars = {specific_vars.bonus_dollars}}
+if specific_vars and specific_vars.bonus_p_dollars then
+	localize{type = 'other', key = 'card_extra_p_dollars', nodes = desc_nodes, vars = {specific_vars.bonus_p_dollars}}
 end
 if specific_vars and specific_vars.bonus_h_dollars then
 	localize{type = 'other', key = 'card_extra_h_dollars', nodes = desc_nodes, vars = {specific_vars.bonus_h_dollars}}
@@ -409,7 +409,7 @@ bonus_h_chips = self.ability.perma_h_chips and self.ability.perma_h_chips ~= 0 a
 bonus_h_x_chips = self.ability.perma_h_x_chips and self.ability.perma_h_x_chips ~= 0 and self.ability.perma_h_x_chips ~= 1 and (self.ability.perma_h_x_chips or 0) or nil,
 bonus_h_mult = self.ability.perma_h_mult and self.ability.perma_h_mult ~= 0 and (self.ability.perma_h_mult > 0 and '+'..self.ability.perma_h_mult or self.ability.perma_h_mult) or nil,
 bonus_h_x_mult = self.ability.perma_h_x_mult and self.ability.perma_h_x_mult ~= 0 and (self.ability.perma_h_x_mult or 0) or nil,
-bonus_dollars = self.ability.perma_p_dollars and self.ability.perma_p_dollars ~= 0 and (self.ability.perma_p_dollars > 0 and '$'.. self.ability.perma_p_dollars or '-$'..-self.ability.perma_p_dollars) or nil,
+bonus_p_dollars = self.ability.perma_p_dollars and self.ability.perma_p_dollars ~= 0 and (self.ability.perma_p_dollars > 0 and '$'.. self.ability.perma_p_dollars or '-$'..-self.ability.perma_p_dollars) or nil,
 bonus_h_dollars = self.ability.perma_h_dollars and self.ability.perma_h_dollars ~= 0 and (self.ability.perma_h_dollars > 0 and '$'.. self.ability.perma_h_dollars or '-$'..-self.ability.perma_h_dollars) or nil,'''
 match_indent = true
 overwrite = false

--- a/lovely/playing_card.toml
+++ b/lovely/playing_card.toml
@@ -301,6 +301,15 @@ end
 ### Permanent card values implementations
 ## Adapted from AMM (https://github.com/AutumnMood924/AutumnMoodMechanics)
 
+# generate_card_ui(): mult card special case
+[[patches]]
+[patches.pattern]
+target = "functions/common_events.lua"
+pattern = "if _c.effect == 'Mult Card' then loc_vars = {_c.config.mult}"
+position = "at"
+payload = "if _c.effect == 'Mult Card' then loc_vars = {SMODS.signed(_c.config.mult + (specific_vars and specific_vars.bonus_mult or 0))}"
+match_indent = true
+
 # generate_card_ui(): glass card special case
 [[patches]]
 [patches.pattern]
@@ -325,7 +334,7 @@ match_indent = true
 target = "functions/common_events.lua"
 pattern = "elseif _c.effect == 'Gold Card' then loc_vars = {_c.config.h_dollars}"
 position = "at"
-payload = "elseif _c.effect == 'Gold Card' then loc_vars = {specific_vars and specific_vars.total_h_dollars or _c.config.h_dollars}"
+payload = "elseif _c.effect == 'Gold Card' then loc_vars = {specific_vars and SMODS.signed_dollars(specific_vars.total_h_dollars) or _c.config.h_dollars and SMODS.signed_dollars(_c.config.h_dollars) or 0}"
 match_indent = true
 
 # generate_card_ui(): stone card special case
@@ -334,7 +343,7 @@ match_indent = true
 target = "functions/common_events.lua"
 pattern = "elseif _c.effect == 'Stone Card' then loc_vars = {((specific_vars and specific_vars.bonus_chips) or _c.config.bonus)}"
 position = "at"
-payload = "elseif _c.effect == 'Stone Card' then loc_vars = {((specific_vars and specific_vars.bonus_chips) or _c.config.bonus and (_c.config.bonus > 0 and '+'.._c.config.bonus or _c.config.bonus) or 0)}"
+payload = "elseif _c.effect == 'Stone Card' then loc_vars = {((specific_vars and SMODS.signed(specific_vars.bonus_chips)) or _c.config.bonus and SMODS.signed(_c.config.bonus) or 0)}"
 match_indent = true
 
 # generate_card_ui(): show permanent bonuses on default playing cards
@@ -345,31 +354,31 @@ pattern = "elseif _c.set == 'Enhanced' then"
 position = "before"
 payload = '''
 if specific_vars and specific_vars.total_x_chips then
-	localize{type = 'other', key = 'card_x_chips', nodes = desc_nodes, vars = {specific_vars.total_x_chips}}
+	localize{type = 'other', key = 'card_x_chips', nodes = desc_nodes, vars = {SMODS.signed(specific_vars.total_x_chips)}}
 end
 if specific_vars and specific_vars.bonus_mult then
-	localize{type = 'other', key = 'card_extra_mult', nodes = desc_nodes, vars = {specific_vars.bonus_mult}}
+	localize{type = 'other', key = 'card_extra_mult', nodes = desc_nodes, vars = {SMODS.signed(specific_vars.bonus_mult)}}
 end
 if specific_vars and specific_vars.total_x_mult then
 	localize{type = 'other', key = 'card_x_mult', nodes = desc_nodes, vars = {specific_vars.total_x_mult}}
 end
 if specific_vars and specific_vars.bonus_h_chips then
-	localize{type = 'other', key = 'card_extra_h_chips', nodes = desc_nodes, vars = {specific_vars.bonus_h_chips}}
+	localize{type = 'other', key = 'card_extra_h_chips', nodes = desc_nodes, vars = {SMODS.signed(specific_vars.bonus_h_chips)}}
 end
 if specific_vars and specific_vars.total_h_x_chips then
 	localize{type = 'other', key = 'card_h_x_chips', nodes = desc_nodes, vars = {specific_vars.total_h_x_chips}}
 end
 if specific_vars and specific_vars.bonus_h_mult then
-	localize{type = 'other', key = 'card_extra_h_mult', nodes = desc_nodes, vars = {specific_vars.bonus_h_mult}}
+	localize{type = 'other', key = 'card_extra_h_mult', nodes = desc_nodes, vars = {SMODS.signed(specific_vars.bonus_h_mult)}}
 end
 if specific_vars and specific_vars.total_h_x_mult then
 	localize{type = 'other', key = 'card_h_x_mult', nodes = desc_nodes, vars = {specific_vars.total_h_x_mult}}
 end
 if specific_vars and specific_vars.bonus_p_dollars then
-	localize{type = 'other', key = 'card_extra_p_dollars', nodes = desc_nodes, vars = {specific_vars.bonus_p_dollars}}
+	localize{type = 'other', key = 'card_extra_p_dollars', nodes = desc_nodes, vars = {SMODS.signed_dollars(specific_vars.bonus_p_dollars)}}
 end
 if specific_vars and specific_vars.bonus_h_dollars then
-	localize{type = 'other', key = 'card_extra_h_dollars', nodes = desc_nodes, vars = {specific_vars.bonus_h_dollars}}
+	localize{type = 'other', key = 'card_extra_h_dollars', nodes = desc_nodes, vars = {SMODS.signed_dollars(specific_vars.bonus_h_dollars)}}
 end'''
 match_indent = true
 overwrite = false
@@ -384,29 +393,29 @@ payload = '''
 if specific_vars and specific_vars.total_x_chips then
 	localize{type = 'other', key = 'card_x_chips', nodes = desc_nodes, vars = {specific_vars.total_x_chips}}
 end
-if specific_vars and specific_vars.bonus_mult then
-	localize{type = 'other', key = 'card_extra_mult', nodes = desc_nodes, vars = {specific_vars.bonus_mult}}
+if specific_vars and specific_vars.bonus_mult and _c.effect ~= 'Mult Card'  then
+	localize{type = 'other', key = 'card_extra_mult', nodes = desc_nodes, vars = {SMODS.signed(specific_vars.bonus_mult)}}
 end
 if specific_vars and specific_vars.total_x_mult and _c.effect ~= 'Glass Card' then
 	localize{type = 'other', key = 'card_x_mult', nodes = desc_nodes, vars = {specific_vars.total_x_mult}}
 end
 if specific_vars and specific_vars.bonus_h_chips then
-	localize{type = 'other', key = 'card_extra_h_chips', nodes = desc_nodes, vars = {specific_vars.bonus_h_chips}}
+	localize{type = 'other', key = 'card_extra_h_chips', nodes = desc_nodes, vars = {SMODS.signed(specific_vars.bonus_h_chips)}}
 end
 if specific_vars and specific_vars.total_h_x_chips then
 	localize{type = 'other', key = 'card_h_x_chips', nodes = desc_nodes, vars = {specific_vars.total_h_x_chips}}
 end
 if specific_vars and specific_vars.bonus_h_mult then
-	localize{type = 'other', key = 'card_extra_h_mult', nodes = desc_nodes, vars = {specific_vars.bonus_h_mult}}
+	localize{type = 'other', key = 'card_extra_h_mult', nodes = desc_nodes, vars = {SMODS.signed(specific_vars.bonus_h_mult)}}
 end
 if specific_vars and specific_vars.total_h_x_mult and _c.effect ~= 'Steel Card' then
 	localize{type = 'other', key = 'card_h_x_mult', nodes = desc_nodes, vars = {specific_vars.total_h_x_mult}}
 end
 if specific_vars and specific_vars.bonus_p_dollars then
-	localize{type = 'other', key = 'card_extra_p_dollars', nodes = desc_nodes, vars = {specific_vars.bonus_p_dollars}}
+	localize{type = 'other', key = 'card_extra_p_dollars', nodes = desc_nodes, vars = {SMODS.signed_dollars(specific_vars.bonus_p_dollars)}}
 end
 if specific_vars and specific_vars.bonus_h_dollars and _c.effect ~= 'Gold Card' then
-	localize{type = 'other', key = 'card_extra_h_dollars', nodes = desc_nodes, vars = {specific_vars.bonus_h_dollars}}
+	localize{type = 'other', key = 'card_extra_h_dollars', nodes = desc_nodes, vars = {SMODS.signed_dollars(specific_vars.bonus_h_dollars)}}
 end'''
 match_indent = true
 overwrite = false
@@ -433,21 +442,21 @@ target = "card.lua"
 pattern = "bonus_chips = (self.ability.bonus + (self.ability.perma_bonus or 0)) > 0 and (self.ability.bonus + (self.ability.perma_bonus or 0)) or nil,"
 position = "at"
 payload = '''
-bonus_x_chips = self.ability.perma_x_chips and self.ability.perma_x_chips ~=0 and (self.ability.perma_x_chips or 0) or nil,
+bonus_x_chips = self.ability.perma_x_chips ~= 0 and self.ability.perma_x_chips or nil,
 total_x_chips = total_x_chips ~= 0 and total_x_chips ~= 1 and total_x_chips or nil,
-bonus_mult = self.ability.perma_mult and self.ability.perma_mult ~= 0 and (self.ability.perma_mult > 0 and '+'..self.ability.perma_mult or self.ability.perma_mult) or nil,
-bonus_x_mult = self.ability.perma_x_mult and self.ability.perma_x_mult ~= 0 and (self.ability.perma_x_mult or 0) or nil,
+bonus_mult = self.ability.perma_mult ~= 0 and self.ability.perma_mult or nil,
+bonus_x_mult = self.ability.perma_x_mult ~= 0 and self.ability.perma_x_mult or nil,
 total_x_mult = total_x_mult ~= 0 and total_x_mult ~= 1 and total_x_mult or nil,
-bonus_h_chips = self.ability.perma_h_chips and self.ability.perma_h_chips ~= 0 and (self.ability.perma_h_chips > 0 and '+'..self.ability.perma_h_chips or self.ability.perma_h_chips) or nil,
-bonus_h_x_chips = self.ability.perma_h_x_chips and self.ability.perma_h_x_chips ~= 0 and self.ability.perma_h_x_chips ~= 1 and (self.ability.perma_h_x_chips or 0) or nil,
+bonus_h_chips = self.ability.perma_h_chips ~= 0 and self.ability.perma_h_chips or nil,
+bonus_h_x_chips = self.ability.perma_h_x_chips ~= 0 and self.ability.perma_h_x_chips ~= 1 and self.ability.perma_h_x_chips or nil,
 total_h_x_chips = total_h_x_chips ~= 0 and total_h_x_chips ~= 1 and total_h_x_chips or nil,
-bonus_h_mult = self.ability.perma_h_mult and self.ability.perma_h_mult ~= 0 and (self.ability.perma_h_mult > 0 and '+'..self.ability.perma_h_mult or self.ability.perma_h_mult) or nil,
-bonus_h_x_mult = self.ability.perma_h_x_mult and self.ability.perma_h_x_mult ~= 0 and (self.ability.perma_h_x_mult or 0) or nil,
+bonus_h_mult = self.ability.perma_h_mult ~= 0 and self.ability.perma_h_mult or nil,
+bonus_h_x_mult = self.ability.perma_h_x_mult ~= 0 and self.ability.perma_h_x_mult or nil,
 total_h_x_mult = total_h_x_mult ~= 0 and total_h_x_mult ~= 1 and total_h_x_mult or nil,
-bonus_p_dollars = self.ability.perma_p_dollars and self.ability.perma_p_dollars ~= 0 and (self.ability.perma_p_dollars > 0 and '$'.. self.ability.perma_p_dollars or '-$'..-self.ability.perma_p_dollars) or nil,
-bonus_h_dollars = self.ability.perma_h_dollars and self.ability.perma_h_dollars ~= 0 and (self.ability.perma_h_dollars > 0 and '$'.. self.ability.perma_h_dollars or '-$'..-self.ability.perma_h_dollars) or nil,
+bonus_p_dollars = self.ability.perma_p_dollars ~= 0 and self.ability.perma_p_dollars or nil,
+bonus_h_dollars = self.ability.perma_h_dollars ~= 0 and self.ability.perma_h_dollars or nil,
 total_h_dollars = total_h_dollars ~= 0 and total_h_dollars or nil,
-bonus_chips = bonus_chips and bonus_chips ~= 0 and (bonus_chips > 0 and '+'..bonus_chips or bonus_chips) or nil,'''
+bonus_chips = bonus_chips ~= 0 and bonus_chips or nil,'''
 match_indent = true
 overwrite = false
 

--- a/lovely/playing_card.toml
+++ b/lovely/playing_card.toml
@@ -308,29 +308,32 @@ target = "functions/common_events.lua"
 pattern = "elseif _c.set == 'Enhanced' then"
 position = "before"
 payload = '''
-if specific_vars and specific_vars.bonus_xchips then
-	localize{type = 'other', key = 'card_extra_xchips', nodes = desc_nodes, vars = {specific_vars.bonus_xchips}}
+if specific_vars and specific_vars.bonus_x_chips then
+	localize{type = 'other', key = 'card_extra_x_chips', nodes = desc_nodes, vars = {specific_vars.bonus_x_chips}}
 end
 if specific_vars and specific_vars.bonus_mult then
 	localize{type = 'other', key = 'card_extra_mult', nodes = desc_nodes, vars = {specific_vars.bonus_mult}}
 end
-if specific_vars and specific_vars.bonus_xmult then
-	localize{type = 'other', key = 'card_extra_xmult', nodes = desc_nodes, vars = {specific_vars.bonus_xmult}}
+if specific_vars and specific_vars.bonus_x_mult then
+	localize{type = 'other', key = 'card_extra_x_mult', nodes = desc_nodes, vars = {specific_vars.bonus_x_mult}}
 end
-if specific_vars and specific_vars.bonus_hchips then
-	localize{type = 'other', key = 'card_extra_hchips', nodes = desc_nodes, vars = {specific_vars.bonus_hchips}}
+if specific_vars and specific_vars.bonus_h_chips then
+	localize{type = 'other', key = 'card_extra_h_chips', nodes = desc_nodes, vars = {specific_vars.bonus_h_chips}}
 end
-if specific_vars and specific_vars.bonus_hxchips then
-	localize{type = 'other', key = 'card_extra_hxchips', nodes = desc_nodes, vars = {specific_vars.bonus_hxchips}}
+if specific_vars and specific_vars.bonus_h_x_chips then
+	localize{type = 'other', key = 'card_extra_h_x_chips', nodes = desc_nodes, vars = {specific_vars.bonus_h_x_chips}}
 end
-if specific_vars and specific_vars.bonus_hmult then
-	localize{type = 'other', key = 'card_extra_hmult', nodes = desc_nodes, vars = {specific_vars.bonus_hmult}}
+if specific_vars and specific_vars.bonus_h_mult then
+	localize{type = 'other', key = 'card_extra_h_mult', nodes = desc_nodes, vars = {specific_vars.bonus_h_mult}}
 end
-if specific_vars and specific_vars.bonus_hxmult then
-	localize{type = 'other', key = 'card_extra_hxmult', nodes = desc_nodes, vars = {specific_vars.bonus_hxmult}}
+if specific_vars and specific_vars.bonus_h_x_mult then
+	localize{type = 'other', key = 'card_extra_h_x_mult', nodes = desc_nodes, vars = {specific_vars.bonus_h_x_mult}}
 end
 if specific_vars and specific_vars.bonus_dollars then
-	localize{type = 'other', key = 'card_extra_dollars', nodes = desc_nodes, vars = {specific_vars.bonus_dollars}}
+	localize{type = 'other', key = 'card_extra_p_dollars', nodes = desc_nodes, vars = {specific_vars.bonus_dollars}}
+end
+if specific_vars and specific_vars.bonus_h_dollars then
+	localize{type = 'other', key = 'card_extra_h_dollars', nodes = desc_nodes, vars = {specific_vars.bonus_h_dollars}}
 end'''
 match_indent = true
 overwrite = false
@@ -342,30 +345,53 @@ target = "functions/common_events.lua"
 pattern = "elseif _c.set == 'Booster' then"
 position = "before"
 payload = '''
-if specific_vars and specific_vars.bonus_xchips then
-	localize{type = 'other', key = 'card_extra_xchips', nodes = desc_nodes, vars = {specific_vars.bonus_xchips}}
+if specific_vars and specific_vars.bonus_x_chips then
+	localize{type = 'other', key = 'card_extra_xchips', nodes = desc_nodes, vars = {specific_vars.bonus_x_chips}}
 end
 if specific_vars and specific_vars.bonus_mult then
 	localize{type = 'other', key = 'card_extra_mult', nodes = desc_nodes, vars = {specific_vars.bonus_mult}}
 end
-if specific_vars and specific_vars.bonus_xmult then
-	localize{type = 'other', key = 'card_extra_xmult', nodes = desc_nodes, vars = {specific_vars.bonus_xmult}}
+if specific_vars and specific_vars.bonus_x_mult then
+	localize{type = 'other', key = 'card_extra_x_mult', nodes = desc_nodes, vars = {specific_vars.bonus_x_mult}}
 end
-if specific_vars and specific_vars.bonus_hchips then
-	localize{type = 'other', key = 'card_extra_hchips', nodes = desc_nodes, vars = {specific_vars.bonus_hchips}}
+if specific_vars and specific_vars.bonus_h_chips then
+	localize{type = 'other', key = 'card_extra_h_chips', nodes = desc_nodes, vars = {specific_vars.bonus_h_chips}}
 end
-if specific_vars and specific_vars.bonus_hxchips then
-	localize{type = 'other', key = 'card_extra_hxchips', nodes = desc_nodes, vars = {specific_vars.bonus_hxchips}}
+if specific_vars and specific_vars.bonus_h_x_chips then
+	localize{type = 'other', key = 'card_extra_h_x_chips', nodes = desc_nodes, vars = {specific_vars.bonus_h_x_chips}}
 end
-if specific_vars and specific_vars.bonus_hmult then
-	localize{type = 'other', key = 'card_extra_hmult', nodes = desc_nodes, vars = {specific_vars.bonus_hmult}}
+if specific_vars and specific_vars.bonus_h_mult then
+	localize{type = 'other', key = 'card_extra_h_mult', nodes = desc_nodes, vars = {specific_vars.bonus_h_mult}}
 end
-if specific_vars and specific_vars.bonus_hxmult then
-	localize{type = 'other', key = 'card_extra_hxmult', nodes = desc_nodes, vars = {specific_vars.bonus_hxmult}}
+if specific_vars and specific_vars.bonus_h_x_mult then
+	localize{type = 'other', key = 'card_extra_h_x_mult', nodes = desc_nodes, vars = {specific_vars.bonus_h_x_mult}}
 end
 if specific_vars and specific_vars.bonus_dollars then
-	localize{type = 'other', key = 'card_extra_dollars', nodes = desc_nodes, vars = {specific_vars.bonus_dollars}}
+	localize{type = 'other', key = 'card_extra_p_dollars', nodes = desc_nodes, vars = {specific_vars.bonus_dollars}}
+end
+if specific_vars and specific_vars.bonus_h_dollars then
+	localize{type = 'other', key = 'card_extra_h_dollars', nodes = desc_nodes, vars = {specific_vars.bonus_h_dollars}}
 end'''
+match_indent = true
+overwrite = false
+
+# generate_UIBox_ability_table(): prime extra chips
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = "loc_vars = { playing_card = not not self.base.colour, value = self.base.value, suit = self.base.suit, colour = self.base.colour,"
+position = "before"
+payload = 'local bonus_chips = self.ability.bonus + (self.ability.perma_bonus or 0)'
+match_indent = true
+overwrite = false
+
+# generate_UIBox_ability_table(): represent extra chips
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = "bonus_chips = (self.ability.bonus + (self.ability.perma_bonus or 0)) > 0 and (self.ability.bonus + (self.ability.perma_bonus or 0)) or nil,"
+position = "at"
+payload = "bonus_chips = bonus_chips and bonus_chips ~= 0 and (bonus_chips > 0 and '+'..bonus_chips or bonus_chips) or nil"
 match_indent = true
 overwrite = false
 
@@ -376,14 +402,15 @@ target = "card.lua"
 pattern = "nominal_chips = self.base.nominal > 0 and self.base.nominal or nil,"
 position = "after"
 payload = '''
-bonus_xchips = (self.ability.perma_xbonus or 0) > 1 and (self.ability.perma_xbonus or 0) or nil,
-bonus_mult = (self.ability.perma_mult or 0) > 0 and (self.ability.perma_mult or 0) or nil,
-bonus_xmult = (self.ability.perma_xmult or 0) > 1 and (self.ability.perma_xmult or 0) or nil,
-bonus_hchips = (self.ability.perma_hbonus or 0) > 0 and (self.ability.perma_hbonus or 0) or nil,
-bonus_hxchips = (self.ability.perma_hxbonus or 0) > 1 and (self.ability.perma_hxbonus or 0) or nil,
-bonus_hmult = (self.ability.perma_hmult or 0) > 0 and (self.ability.perma_hmult or 0) or nil,
-bonus_hxmult = (self.ability.perma_hxmult or 0) > 1 and (self.ability.perma_hxmult or 0) or nil,
-bonus_dollars = (self.ability.perma_dollars or 0) > 0 and (self.ability.perma_dollars or 0) or nil,'''
+bonus_x_chips = self.ability.perma_x_chips and self.ability.perma_x_chips ~=0 and (self.ability.perma_x_chips or 0) or nil,
+bonus_mult = self.ability.perma_mult and self.ability.perma_mult ~= 0 and (self.ability.perma_mult > 0 and '+'..self.ability.perma_mult or self.ability.perma_mult) or nil,
+bonus_x_mult = self.ability.perma_x_mult and self.ability.perma_x_mult ~= 0 and (self.ability.perma_x_mult or 0) or nil,
+bonus_h_chips = self.ability.perma_h_chips and self.ability.perma_h_chips ~= 0 and (self.ability.perma_h_chips > 0 and '+'..self.ability.perma_h_chips or self.ability.perma_h_chips) or nil,
+bonus_h_x_chips = self.ability.perma_h_x_chips and self.ability.perma_h_x_chips ~= 0 and self.ability.perma_h_x_chips ~= 1 and (self.ability.perma_h_x_chips or 0) or nil,
+bonus_h_mult = self.ability.perma_h_mult and self.ability.perma_h_mult ~= 0 and (self.ability.perma_h_mult > 0 and '+'..self.ability.perma_h_mult or self.ability.perma_h_mult) or nil,
+bonus_h_x_mult = self.ability.perma_h_x_mult and self.ability.perma_h_x_mult ~= 0 and (self.ability.perma_h_x_mult or 0) or nil,
+bonus_dollars = self.ability.perma_p_dollars and self.ability.perma_p_dollars ~= 0 and (self.ability.perma_p_dollars > 0 and '$'.. self.ability.perma_p_dollars or '-$'..-self.ability.perma_p_dollars) or nil,
+bonus_h_dollars = self.ability.perma_h_dollars and self.ability.perma_h_dollars ~= 0 and (self.ability.perma_h_dollars > 0 and '$'.. self.ability.perma_h_dollars or '-$'..-self.ability.perma_h_dollars) or nil,'''
 match_indent = true
 overwrite = false
 
@@ -394,14 +421,15 @@ target = "card.lua"
 pattern = "perma_bonus = self.ability and self.ability.perma_bonus or 0,"
 position = "after"
 payload = '''
-perma_xbonus = self.ability and self.ability.perma_xbonus or 1,
+perma_x_chips = self.ability and self.ability.perma_x_chips or 0,
 perma_mult = self.ability and self.ability.perma_mult or 0,
-perma_xmult = self.ability and self.ability.perma_xmult or 1,
-perma_hbonus = self.ability and self.ability.perma_hbonus or 0,
-perma_hxbonus = self.ability and self.ability.perma_hxbonus or 1,
-perma_hmult = self.ability and self.ability.perma_hmult or 0,
-perma_hxmult = self.ability and self.ability.perma_hxmult or 1,
-perma_dollars = self.ability and self.ability.perma_dollars or 0,
+perma_x_mult = self.ability and self.ability.perma_x_mult or 0,
+perma_h_chips = self.ability and self.ability.perma_h_chips or 0,
+perma_h_x_chips = self.ability and self.ability.perma_h_x_chips or 0,
+perma_h_mult = self.ability and self.ability.perma_hmult or 0,
+perma_h_x_mult = self.ability and self.ability.perma_h_x_mult or 0,
+perma_p_dollars = self.ability and self.ability.perma_p_dollars or 0,
+perma_h_dollars = self.ability and self.ability.perma_p_dollars or 0,
 '''
 match_indent = true
 overwrite = false
@@ -431,11 +459,31 @@ overwrite = false
 position = 'after'
 payload = '''
 local h_chips = card:get_chip_h_bonus()
-if h_chips > 0 then
-	ret.playing_card.chips = h_chips
+if h_chips ~= 0 then
+	ret.playing_card.h_chips = h_chips
 end
 local h_x_chips = card:get_chip_h_x_bonus()
 if h_x_chips > 0 then
 	ret.playing_card.x_chips = h_x_chips
 end
 '''
+
+# Card:get_end_of_round_effect
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+if self.ability.h_dollars > 0 then
+    ret.h_dollars = self.ability.h_dollars
+    ret.card = self
+end
+'''
+position = "before"
+match_indent = true
+payload = '''
+if (self.ability.h_dollars + self.ability.perma_h_dollars) ~= 0 then
+    ret.h_dollars = (ret.h_dollars or 0) + self.ability.h_dollars + self.ability.perma_h_dollars
+    ret.card = self
+end
+'''
+times = 1

--- a/lovely/playing_card.toml
+++ b/lovely/playing_card.toml
@@ -89,7 +89,7 @@ payload = '''
         G.ARGS.LOC_COLOURS[v:lower()] = G.C.RARITY[v]
     end
     for _, v in ipairs(SMODS.ConsumableType.ctype_buffer) do
-        G.ARGS.LOC_COLOURS[v:lower()] = G.C.SECONDARY_SET[v] 
+        G.ARGS.LOC_COLOURS[v:lower()] = G.C.SECONDARY_SET[v]
     end
     for _, v in ipairs(SMODS.Suit.obj_buffer) do
         G.ARGS.LOC_COLOURS[v:lower()] = G.C.SUITS[v]
@@ -146,7 +146,7 @@ function Card:get_nominal(mod)
     local mult = 1
     local rank_mult = 1
     if mod == 'suit' then mult = 10000 end
-    if self.ability.effect == 'Stone Card' or (self.config.center.no_suit and self.config.center.no_rank) then 
+    if self.ability.effect == 'Stone Card' or (self.config.center.no_suit and self.config.center.no_rank) then
         mult = -10000
     elseif self.config.center.no_suit then
         mult = 0
@@ -272,7 +272,7 @@ for j = 1, #suit_map do
     if SUITS[suit_map[j]][1] then num_suits = num_suits + 1 end
 end
 for j = 1, #suit_map do
-    $mid			
+    $mid
             (0.42 - (num_suits <= 4 and 0 or num_suits >= 8 and 0.28 or 0.07 * (num_suits - 4))) * G.CARD_H,'''
 
 [[patches]]
@@ -296,4 +296,146 @@ payload = '''if card_type == 'Default' or card_type == 'Enhanced' and not _c.rep
     end
 end
 
+'''
+
+### Permanent card values implementations
+## Adapted from AMM (https://github.com/AutumnMood924/AutumnMoodMechanics)
+
+# generate_card_ui(): show permanent bonuses on enhanced playing cards
+[[patches]]
+[patches.pattern]
+target = "functions/common_events.lua"
+pattern = "elseif _c.set == 'Enhanced' then"
+position = "before"
+payload = '''
+if specific_vars and specific_vars.bonus_xchips then
+	localize{type = 'other', key = 'card_extra_xchips', nodes = desc_nodes, vars = {specific_vars.bonus_xchips}}
+end
+if specific_vars and specific_vars.bonus_mult then
+	localize{type = 'other', key = 'card_extra_mult', nodes = desc_nodes, vars = {specific_vars.bonus_mult}}
+end
+if specific_vars and specific_vars.bonus_xmult then
+	localize{type = 'other', key = 'card_extra_xmult', nodes = desc_nodes, vars = {specific_vars.bonus_xmult}}
+end
+if specific_vars and specific_vars.bonus_hchips then
+	localize{type = 'other', key = 'card_extra_hchips', nodes = desc_nodes, vars = {specific_vars.bonus_hchips}}
+end
+if specific_vars and specific_vars.bonus_hxchips then
+	localize{type = 'other', key = 'card_extra_hxchips', nodes = desc_nodes, vars = {specific_vars.bonus_hxchips}}
+end
+if specific_vars and specific_vars.bonus_hmult then
+	localize{type = 'other', key = 'card_extra_hmult', nodes = desc_nodes, vars = {specific_vars.bonus_hmult}}
+end
+if specific_vars and specific_vars.bonus_hxmult then
+	localize{type = 'other', key = 'card_extra_hxmult', nodes = desc_nodes, vars = {specific_vars.bonus_hxmult}}
+end
+if specific_vars and specific_vars.bonus_dollars then
+	localize{type = 'other', key = 'card_extra_dollars', nodes = desc_nodes, vars = {specific_vars.bonus_dollars}}
+end'''
+match_indent = true
+overwrite = false
+
+# generate_card_ui(): show permanent bonuses on default playing cards
+[[patches]]
+[patches.pattern]
+target = "functions/common_events.lua"
+pattern = "elseif _c.set == 'Booster' then"
+position = "before"
+payload = '''
+if specific_vars and specific_vars.bonus_xchips then
+	localize{type = 'other', key = 'card_extra_xchips', nodes = desc_nodes, vars = {specific_vars.bonus_xchips}}
+end
+if specific_vars and specific_vars.bonus_mult then
+	localize{type = 'other', key = 'card_extra_mult', nodes = desc_nodes, vars = {specific_vars.bonus_mult}}
+end
+if specific_vars and specific_vars.bonus_xmult then
+	localize{type = 'other', key = 'card_extra_xmult', nodes = desc_nodes, vars = {specific_vars.bonus_xmult}}
+end
+if specific_vars and specific_vars.bonus_hchips then
+	localize{type = 'other', key = 'card_extra_hchips', nodes = desc_nodes, vars = {specific_vars.bonus_hchips}}
+end
+if specific_vars and specific_vars.bonus_hxchips then
+	localize{type = 'other', key = 'card_extra_hxchips', nodes = desc_nodes, vars = {specific_vars.bonus_hxchips}}
+end
+if specific_vars and specific_vars.bonus_hmult then
+	localize{type = 'other', key = 'card_extra_hmult', nodes = desc_nodes, vars = {specific_vars.bonus_hmult}}
+end
+if specific_vars and specific_vars.bonus_hxmult then
+	localize{type = 'other', key = 'card_extra_hxmult', nodes = desc_nodes, vars = {specific_vars.bonus_hxmult}}
+end
+if specific_vars and specific_vars.bonus_dollars then
+	localize{type = 'other', key = 'card_extra_dollars', nodes = desc_nodes, vars = {specific_vars.bonus_dollars}}
+end'''
+match_indent = true
+overwrite = false
+
+# generate_UIBox_ability_table(): prime specific_vars for playing cards
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = "nominal_chips = self.base.nominal > 0 and self.base.nominal or nil,"
+position = "after"
+payload = '''
+bonus_xchips = (self.ability.perma_xbonus or 0) > 1 and (self.ability.perma_xbonus or 0) or nil,
+bonus_mult = (self.ability.perma_mult or 0) > 0 and (self.ability.perma_mult or 0) or nil,
+bonus_xmult = (self.ability.perma_xmult or 0) > 1 and (self.ability.perma_xmult or 0) or nil,
+bonus_hchips = (self.ability.perma_hbonus or 0) > 0 and (self.ability.perma_hbonus or 0) or nil,
+bonus_hxchips = (self.ability.perma_hxbonus or 0) > 1 and (self.ability.perma_hxbonus or 0) or nil,
+bonus_hmult = (self.ability.perma_hmult or 0) > 0 and (self.ability.perma_hmult or 0) or nil,
+bonus_hxmult = (self.ability.perma_hxmult or 0) > 1 and (self.ability.perma_hxmult or 0) or nil,
+bonus_dollars = (self.ability.perma_dollars or 0) > 0 and (self.ability.perma_dollars or 0) or nil,'''
+match_indent = true
+overwrite = false
+
+# set_ability: set defaults for permanent bonuses
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = "perma_bonus = self.ability and self.ability.perma_bonus or 0,"
+position = "after"
+payload = '''
+perma_xbonus = self.ability and self.ability.perma_xbonus or 1,
+perma_mult = self.ability and self.ability.perma_mult or 0,
+perma_xmult = self.ability and self.ability.perma_xmult or 1,
+perma_hbonus = self.ability and self.ability.perma_hbonus or 0,
+perma_hxbonus = self.ability and self.ability.perma_hxbonus or 1,
+perma_hmult = self.ability and self.ability.perma_hmult or 0,
+perma_hxmult = self.ability and self.ability.perma_hxmult or 1,
+perma_dollars = self.ability and self.ability.perma_dollars or 0,
+'''
+match_indent = true
+overwrite = false
+
+# eval_card(): score xbonus on playing cards
+[[patches]]
+[patches.pattern]
+target = 'functions/common_events.lua'
+pattern = "-- TARGET: main scoring on played cards"
+match_indent = true
+overwrite = false
+position = 'after'
+payload = '''
+local x_chips = card:get_chip_x_bonus()
+if x_chips > 0 then
+	ret.playing_card.x_chips = x_chips
+end
+'''
+
+# eval_card(): score hbonus and hxbonus on held playing cards
+[[patches]]
+[patches.pattern]
+target = 'functions/common_events.lua'
+pattern = "-- TARGET: main scoring on held cards"
+match_indent = true
+overwrite = false
+position = 'after'
+payload = '''
+local h_chips = card:get_chip_h_bonus()
+if h_chips > 0 then
+	ret.playing_card.chips = h_chips
+end
+local h_x_chips = card:get_chip_h_x_bonus()
+if h_x_chips > 0 then
+	ret.playing_card.x_chips = h_x_chips
+end
 '''

--- a/lovely/playing_card.toml
+++ b/lovely/playing_card.toml
@@ -301,33 +301,69 @@ end
 ### Permanent card values implementations
 ## Adapted from AMM (https://github.com/AutumnMood924/AutumnMoodMechanics)
 
-# generate_card_ui(): show permanent bonuses on enhanced playing cards
+# generate_card_ui(): glass card special case
+[[patches]]
+[patches.pattern]
+target = "functions/common_events.lua"
+pattern = "elseif _c.effect == 'Glass Card' then loc_vars = {_c.config.Xmult, G.GAME.probabilities.normal, _c.config.extra}"
+position = "at"
+payload = "elseif _c.effect == 'Glass Card' then loc_vars = {specific_vars and specific_vars.total_x_mult or _c.config.Xmult, G.GAME.probabilities.normal, _c.config.extra}"
+match_indent = true
+
+# generate_card_ui(): steel card special case
+[[patches]]
+[patches.pattern]
+target = "functions/common_events.lua"
+pattern = "elseif _c.effect == 'Steel Card' then loc_vars = {_c.config.h_x_mult}"
+position = "at"
+payload = "elseif _c.effect == 'Steel Card' then loc_vars = {specific_vars and specific_vars.total_h_x_mult or _c.config.h_x_mult}"
+match_indent = true
+
+# generate_card_ui(): gold card special case
+[[patches]]
+[patches.pattern]
+target = "functions/common_events.lua"
+pattern = "elseif _c.effect == 'Gold Card' then loc_vars = {_c.config.h_dollars}"
+position = "at"
+payload = "elseif _c.effect == 'Gold Card' then loc_vars = {specific_vars and specific_vars.total_h_dollars or _c.config.h_dollars}"
+match_indent = true
+
+# generate_card_ui(): stone card special case
+[[patches]]
+[patches.pattern]
+target = "functions/common_events.lua"
+pattern = "elseif _c.effect == 'Stone Card' then loc_vars = {((specific_vars and specific_vars.bonus_chips) or _c.config.bonus)}"
+position = "at"
+payload = "elseif _c.effect == 'Stone Card' then loc_vars = {((specific_vars and specific_vars.bonus_chips) or _c.config.bonus and (_c.config.bonus > 0 and '+'.._c.config.bonus or _c.config.bonus) or 0)}"
+match_indent = true
+
+# generate_card_ui(): show permanent bonuses on default playing cards
 [[patches]]
 [patches.pattern]
 target = "functions/common_events.lua"
 pattern = "elseif _c.set == 'Enhanced' then"
 position = "before"
 payload = '''
-if specific_vars and specific_vars.bonus_x_chips then
-	localize{type = 'other', key = 'card_extra_x_chips', nodes = desc_nodes, vars = {specific_vars.bonus_x_chips}}
+if specific_vars and specific_vars.total_x_chips then
+	localize{type = 'other', key = 'card_x_chips', nodes = desc_nodes, vars = {specific_vars.total_x_chips}}
 end
 if specific_vars and specific_vars.bonus_mult then
 	localize{type = 'other', key = 'card_extra_mult', nodes = desc_nodes, vars = {specific_vars.bonus_mult}}
 end
-if specific_vars and specific_vars.bonus_x_mult then
-	localize{type = 'other', key = 'card_extra_x_mult', nodes = desc_nodes, vars = {specific_vars.bonus_x_mult}}
+if specific_vars and specific_vars.total_x_mult then
+	localize{type = 'other', key = 'card_x_mult', nodes = desc_nodes, vars = {specific_vars.total_x_mult}}
 end
 if specific_vars and specific_vars.bonus_h_chips then
 	localize{type = 'other', key = 'card_extra_h_chips', nodes = desc_nodes, vars = {specific_vars.bonus_h_chips}}
 end
-if specific_vars and specific_vars.bonus_h_x_chips then
-	localize{type = 'other', key = 'card_extra_h_x_chips', nodes = desc_nodes, vars = {specific_vars.bonus_h_x_chips}}
+if specific_vars and specific_vars.total_h_x_chips then
+	localize{type = 'other', key = 'card_h_x_chips', nodes = desc_nodes, vars = {specific_vars.total_h_x_chips}}
 end
 if specific_vars and specific_vars.bonus_h_mult then
 	localize{type = 'other', key = 'card_extra_h_mult', nodes = desc_nodes, vars = {specific_vars.bonus_h_mult}}
 end
-if specific_vars and specific_vars.bonus_h_x_mult then
-	localize{type = 'other', key = 'card_extra_h_x_mult', nodes = desc_nodes, vars = {specific_vars.bonus_h_x_mult}}
+if specific_vars and specific_vars.total_h_x_mult then
+	localize{type = 'other', key = 'card_h_x_mult', nodes = desc_nodes, vars = {specific_vars.total_h_x_mult}}
 end
 if specific_vars and specific_vars.bonus_p_dollars then
 	localize{type = 'other', key = 'card_extra_p_dollars', nodes = desc_nodes, vars = {specific_vars.bonus_p_dollars}}
@@ -338,60 +374,55 @@ end'''
 match_indent = true
 overwrite = false
 
-# generate_card_ui(): show permanent bonuses on default playing cards
+# generate_card_ui(): show permanent bonuses on enhanced playing cards
 [[patches]]
 [patches.pattern]
 target = "functions/common_events.lua"
 pattern = "elseif _c.set == 'Booster' then"
 position = "before"
 payload = '''
-if specific_vars and specific_vars.bonus_x_chips then
-	localize{type = 'other', key = 'card_extra_xchips', nodes = desc_nodes, vars = {specific_vars.bonus_x_chips}}
+if specific_vars and specific_vars.total_x_chips then
+	localize{type = 'other', key = 'card_x_chips', nodes = desc_nodes, vars = {specific_vars.total_x_chips}}
 end
 if specific_vars and specific_vars.bonus_mult then
 	localize{type = 'other', key = 'card_extra_mult', nodes = desc_nodes, vars = {specific_vars.bonus_mult}}
 end
-if specific_vars and specific_vars.bonus_x_mult then
-	localize{type = 'other', key = 'card_extra_x_mult', nodes = desc_nodes, vars = {specific_vars.bonus_x_mult}}
+if specific_vars and specific_vars.total_x_mult and _c.effect ~= 'Glass Card' then
+	localize{type = 'other', key = 'card_x_mult', nodes = desc_nodes, vars = {specific_vars.total_x_mult}}
 end
 if specific_vars and specific_vars.bonus_h_chips then
 	localize{type = 'other', key = 'card_extra_h_chips', nodes = desc_nodes, vars = {specific_vars.bonus_h_chips}}
 end
-if specific_vars and specific_vars.bonus_h_x_chips then
-	localize{type = 'other', key = 'card_extra_h_x_chips', nodes = desc_nodes, vars = {specific_vars.bonus_h_x_chips}}
+if specific_vars and specific_vars.total_h_x_chips then
+	localize{type = 'other', key = 'card_h_x_chips', nodes = desc_nodes, vars = {specific_vars.total_h_x_chips}}
 end
 if specific_vars and specific_vars.bonus_h_mult then
 	localize{type = 'other', key = 'card_extra_h_mult', nodes = desc_nodes, vars = {specific_vars.bonus_h_mult}}
 end
-if specific_vars and specific_vars.bonus_h_x_mult then
-	localize{type = 'other', key = 'card_extra_h_x_mult', nodes = desc_nodes, vars = {specific_vars.bonus_h_x_mult}}
+if specific_vars and specific_vars.total_h_x_mult and _c.effect ~= 'Steel Card' then
+	localize{type = 'other', key = 'card_h_x_mult', nodes = desc_nodes, vars = {specific_vars.total_h_x_mult}}
 end
 if specific_vars and specific_vars.bonus_p_dollars then
 	localize{type = 'other', key = 'card_extra_p_dollars', nodes = desc_nodes, vars = {specific_vars.bonus_p_dollars}}
 end
-if specific_vars and specific_vars.bonus_h_dollars then
+if specific_vars and specific_vars.bonus_h_dollars and _c.effect ~= 'Gold Card' then
 	localize{type = 'other', key = 'card_extra_h_dollars', nodes = desc_nodes, vars = {specific_vars.bonus_h_dollars}}
 end'''
 match_indent = true
 overwrite = false
 
-# generate_UIBox_ability_table(): prime extra chips
+# generate_UIBox_ability_table(): prime locals for easier boolean magic
 [[patches]]
 [patches.pattern]
 target = "card.lua"
 pattern = "loc_vars = { playing_card = not not self.base.colour, value = self.base.value, suit = self.base.suit, colour = self.base.colour,"
 position = "before"
-payload = 'local bonus_chips = self.ability.bonus + (self.ability.perma_bonus or 0)'
-match_indent = true
-overwrite = false
-
-# generate_UIBox_ability_table(): represent extra chips
-[[patches]]
-[patches.pattern]
-target = "card.lua"
-pattern = "bonus_chips = (self.ability.bonus + (self.ability.perma_bonus or 0)) > 0 and (self.ability.bonus + (self.ability.perma_bonus or 0)) or nil,"
-position = "at"
-payload = "bonus_chips = bonus_chips and bonus_chips ~= 0 and (bonus_chips > 0 and '+'..bonus_chips or bonus_chips) or nil"
+payload = '''local bonus_chips = self.ability.bonus + (self.ability.perma_bonus or 0)
+local total_x_mult = self:get_chip_x_mult()
+local total_h_x_mult = self:get_chip_h_x_mult()
+local total_x_chips = self:get_chip_x_bonus()
+local total_h_x_chips = self:get_chip_h_x_bonus()
+local total_h_dollars = self:get_h_dollars()'''
 match_indent = true
 overwrite = false
 
@@ -399,18 +430,24 @@ overwrite = false
 [[patches]]
 [patches.pattern]
 target = "card.lua"
-pattern = "nominal_chips = self.base.nominal > 0 and self.base.nominal or nil,"
-position = "after"
+pattern = "bonus_chips = (self.ability.bonus + (self.ability.perma_bonus or 0)) > 0 and (self.ability.bonus + (self.ability.perma_bonus or 0)) or nil,"
+position = "at"
 payload = '''
 bonus_x_chips = self.ability.perma_x_chips and self.ability.perma_x_chips ~=0 and (self.ability.perma_x_chips or 0) or nil,
+total_x_chips = total_x_chips ~= 0 and total_x_chips ~= 1 and total_x_chips or nil,
 bonus_mult = self.ability.perma_mult and self.ability.perma_mult ~= 0 and (self.ability.perma_mult > 0 and '+'..self.ability.perma_mult or self.ability.perma_mult) or nil,
 bonus_x_mult = self.ability.perma_x_mult and self.ability.perma_x_mult ~= 0 and (self.ability.perma_x_mult or 0) or nil,
+total_x_mult = total_x_mult ~= 0 and total_x_mult ~= 1 and total_x_mult or nil,
 bonus_h_chips = self.ability.perma_h_chips and self.ability.perma_h_chips ~= 0 and (self.ability.perma_h_chips > 0 and '+'..self.ability.perma_h_chips or self.ability.perma_h_chips) or nil,
 bonus_h_x_chips = self.ability.perma_h_x_chips and self.ability.perma_h_x_chips ~= 0 and self.ability.perma_h_x_chips ~= 1 and (self.ability.perma_h_x_chips or 0) or nil,
+total_h_x_chips = total_h_x_chips ~= 0 and total_h_x_chips ~= 1 and total_h_x_chips or nil,
 bonus_h_mult = self.ability.perma_h_mult and self.ability.perma_h_mult ~= 0 and (self.ability.perma_h_mult > 0 and '+'..self.ability.perma_h_mult or self.ability.perma_h_mult) or nil,
 bonus_h_x_mult = self.ability.perma_h_x_mult and self.ability.perma_h_x_mult ~= 0 and (self.ability.perma_h_x_mult or 0) or nil,
+total_h_x_mult = total_h_x_mult ~= 0 and total_h_x_mult ~= 1 and total_h_x_mult or nil,
 bonus_p_dollars = self.ability.perma_p_dollars and self.ability.perma_p_dollars ~= 0 and (self.ability.perma_p_dollars > 0 and '$'.. self.ability.perma_p_dollars or '-$'..-self.ability.perma_p_dollars) or nil,
-bonus_h_dollars = self.ability.perma_h_dollars and self.ability.perma_h_dollars ~= 0 and (self.ability.perma_h_dollars > 0 and '$'.. self.ability.perma_h_dollars or '-$'..-self.ability.perma_h_dollars) or nil,'''
+bonus_h_dollars = self.ability.perma_h_dollars and self.ability.perma_h_dollars ~= 0 and (self.ability.perma_h_dollars > 0 and '$'.. self.ability.perma_h_dollars or '-$'..-self.ability.perma_h_dollars) or nil,
+total_h_dollars = total_h_dollars ~= 0 and total_h_dollars or nil,
+bonus_chips = bonus_chips and bonus_chips ~= 0 and (bonus_chips > 0 and '+'..bonus_chips or bonus_chips) or nil,'''
 match_indent = true
 overwrite = false
 
@@ -429,7 +466,7 @@ perma_h_x_chips = self.ability and self.ability.perma_h_x_chips or 0,
 perma_h_mult = self.ability and self.ability.perma_hmult or 0,
 perma_h_x_mult = self.ability and self.ability.perma_h_x_mult or 0,
 perma_p_dollars = self.ability and self.ability.perma_p_dollars or 0,
-perma_h_dollars = self.ability and self.ability.perma_p_dollars or 0,
+perma_h_dollars = self.ability and self.ability.perma_h_dollars or 0,
 '''
 match_indent = true
 overwrite = false
@@ -478,11 +515,12 @@ if self.ability.h_dollars > 0 then
     ret.card = self
 end
 '''
-position = "before"
+position = "at"
 match_indent = true
 payload = '''
-if (self.ability.h_dollars + self.ability.perma_h_dollars) ~= 0 then
-    ret.h_dollars = (ret.h_dollars or 0) + self.ability.h_dollars + self.ability.perma_h_dollars
+local h_dollars = self:get_h_dollars()
+if h_dollars ~= 0 then
+    ret.h_dollars = h_dollars
     ret.card = self
 end
 '''

--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -2943,6 +2943,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
         -- You will probably want to override this if your enhancement interacts with
         -- those parts of the base card.
         generate_ui = function(self, info_queue, card, desc_nodes, specific_vars, full_UI_table)
+            local always_show = self.config and self.config.always_show or {}
             if specific_vars and specific_vars.nominal_chips and not self.replace_base_card then
                 localize { type = 'other', key = 'card_chips', nodes = desc_nodes, vars = { specific_vars.nominal_chips } }
             end
@@ -2953,29 +2954,32 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
                     localize { type = 'other', key = 'card_extra_chips', nodes = desc_nodes, vars = { specific_vars.bonus_chips - (self.config.bonus or 0) } }
                 end
             end
-            if specific_vars and specific_vars.bonus_xchips then
-                localize{type = 'other', key = 'card_extra_xchips', nodes = desc_nodes, vars = {specific_vars.bonus_xchips}}
+            if specific_vars and specific_vars.total_x_chips and (not self.config.x_chips or self.config.x_chips == 0 or always_show.x_chips) then
+                localize{type = 'other', key = 'card_x_chips', nodes = desc_nodes, vars = {SMODS.signed(specific_vars.total_x_chips)}}
             end
-            if specific_vars and specific_vars.bonus_mult then
-                localize{type = 'other', key = 'card_extra_mult', nodes = desc_nodes, vars = {specific_vars.bonus_mult}}
+            if specific_vars and specific_vars.bonus_mult and (not self.config.mult or self.config.mult == 0 or always_show.mult) then
+                localize{type = 'other', key = 'card_extra_mult', nodes = desc_nodes, vars = {SMODS.signed(specific_vars.bonus_mult + (self.config.mult or 0))}}
             end
-            if specific_vars and specific_vars.bonus_xmult then
-                localize{type = 'other', key = 'card_extra_xmult', nodes = desc_nodes, vars = {specific_vars.bonus_xmult}}
+            if specific_vars and specific_vars.total_x_mult and (not self.config.x_mult or self.config.x_mult == 0 or always_show.x_mult) then
+                localize{type = 'other', key = 'card_x_mult', nodes = desc_nodes, vars = {specific_vars.total_x_mult}}
             end
-            if specific_vars and specific_vars.bonus_hchips then
-                localize{type = 'other', key = 'card_extra_hchips', nodes = desc_nodes, vars = {specific_vars.bonus_hchips}}
+            if specific_vars and specific_vars.bonus_h_chips and (not self.config.h_chips or self.config.h_chips == 0 or always_show.h_chips) then
+                localize{type = 'other', key = 'card_extra_h_chips', nodes = desc_nodes, vars = {SMODS.signed(specific_vars.bonus_h_chips)}}
             end
-            if specific_vars and specific_vars.bonus_hxchips then
-                localize{type = 'other', key = 'card_extra_hxchips', nodes = desc_nodes, vars = {specific_vars.bonus_hxchips}}
+            if specific_vars and specific_vars.total_h_x_chips and (not self.config.h_x_chips or self.config.h_x_chips == 0 or always_show.h_x_chips) then
+                localize{type = 'other', key = 'card_h_x_chips', nodes = desc_nodes, vars = {specific_vars.total_h_x_chips}}
             end
-            if specific_vars and specific_vars.bonus_hmult then
-                localize{type = 'other', key = 'card_extra_hmult', nodes = desc_nodes, vars = {specific_vars.bonus_hmult}}
+            if specific_vars and specific_vars.bonus_h_mult and (not self.config.h_mult or self.config.h_mult == 0 or always_show.h_mult) then
+                localize{type = 'other', key = 'card_extra_h_mult', nodes = desc_nodes, vars = {SMODS.signed(specific_vars.bonus_h_mult)}}
             end
-            if specific_vars and specific_vars.bonus_hxmult then
-                localize{type = 'other', key = 'card_extra_hxmult', nodes = desc_nodes, vars = {specific_vars.bonus_hxmult}}
+            if specific_vars and specific_vars.total_h_x_mult and (not self.config.h_x_mult or self.config.h_x_mult == 0 or always_show.h_x_mult) then
+                localize{type = 'other', key = 'card_h_x_mult', nodes = desc_nodes, vars = {specific_vars.total_h_x_mult}}
             end
-            if specific_vars and specific_vars.bonus_dollars then
-                localize{type = 'other', key = 'card_extra_dollars', nodes = desc_nodes, vars = {specific_vars.bonus_dollars}}
+            if specific_vars and specific_vars.bonus_p_dollars and (not self.config.h_dollars or self.config.h_dollars == 0 or always_show.h_dollars) then
+                localize{type = 'other', key = 'card_extra_p_dollars', nodes = desc_nodes, vars = {SMODS.signed_dollars(specific_vars.bonus_p_dollars)}}
+            end
+            if specific_vars and specific_vars.bonus_h_dollars and (not self.config.p_dollars or self.config.p_dollars == 0 or always_show.p_dollars) then
+                localize{type = 'other', key = 'card_extra_h_dollars', nodes = desc_nodes, vars = {SMODS.signed_dollars(specific_vars.bonus_h_dollars)}}
             end
         end,
         -- other methods:

--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -84,7 +84,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
         if above_stake_cfg ~= false then
             if type(above_stake_cfg) ~= 'table' then above_stake_cfg = {} end
             SMODS.modify_key(obj, mod and mod.prefix, above_stake_cfg.mod, 'above_stake')
-            SMODS.modify_key(obj, cls.class_prefix, above_stake_cfg.class, 'above_stake') 
+            SMODS.modify_key(obj, cls.class_prefix, above_stake_cfg.class, 'above_stake')
         end
         local applied_stakes_cfg = obj.prefix_config.applied_stakes
         if applied_stakes_cfg ~= false and obj.applied_stakes then
@@ -98,7 +98,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
         if unlocked_stake_cfg ~= false then
             if type(unlocked_stake_cfg) ~= 'table' then unlocked_stake_cfg = {} end
             SMODS.modify_key(obj, mod and mod.prefix, unlocked_stake_cfg.mod, 'unlocked_stake')
-            SMODS.modify_key(obj, cls.class_prefix, unlocked_stake_cfg.class, 'unlocked_stake') 
+            SMODS.modify_key(obj, cls.class_prefix, unlocked_stake_cfg.class, 'unlocked_stake')
         end
     end
 
@@ -144,8 +144,8 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
     function SMODS.GameObject:process_loc_text()
         SMODS.process_loc_text(G.localization.descriptions[self.set], self.key, self.loc_txt)
     end
-    
-    --- Starting from this class, recursively searches for 
+
+    --- Starting from this class, recursively searches for
     --- functions with the given key on all subordinate classes
     --- and run all found functions with the given arguments
     function SMODS.GameObject:send_to_subclasses(func, ...)
@@ -374,7 +374,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
             end
         end,
         process_loc_text = function() end,
-        pre_inject_class = function(self) 
+        pre_inject_class = function(self)
             G:set_render_settings() -- restore originals first in case a texture pack was disabled
         end
     }
@@ -422,7 +422,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
                     replace, times = self.replace, -1
                 end
                 self.replace_sounds[replace] = { key = self.key, times = times, args = args }
-            end 
+            end
             -- TODO detect music state based on if select_music_track exists
             assert(not self.select_music_track or self.key:find('music'))
             SMODS.Sound.super.register(self)
@@ -628,7 +628,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
             SMODS.build_stake_chain(G.P_STAKES[s], applied)
         end
         return applied
-    end 
+    end
 
     function SMODS.setup_stake(i)
         local applied_stakes = SMODS.build_stake_chain(G.P_CENTER_POOLS.Stake[i])
@@ -769,21 +769,21 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
         end,
         get_rarity_badge = function(self, rarity)
             local vanilla_rarity_keys = {localize('k_common'), localize('k_uncommon'), localize('k_rare'), localize('k_legendary')}
-            if (vanilla_rarity_keys)[rarity] then 
+            if (vanilla_rarity_keys)[rarity] then
                 return vanilla_rarity_keys[rarity] --compat layer in case function gets the int of the rarity
-            else 
+            else
                 return localize("k_"..rarity:lower())
-            end 
+            end
         end,
     }
 
     function SMODS.inject_rarity(object_type, rarity)
-        if not object_type.rarities then 
+        if not object_type.rarities then
             object_type.rarities = {}
             object_type.rarity_pools = {}
         end
         object_type.rarities[#object_type.rarities+1] = {
-            key = rarity.key, 
+            key = rarity.key,
             weight = type(rarity.pools[object_type.key]) == "table" and rarity.pools[object_type.key].weight or rarity.default_weight
         }
         for _, vv in ipairs(object_type.rarities) do
@@ -858,7 +858,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
         required_params = {
             'key',
         },
-        prefix_config = { key = false }, 
+        prefix_config = { key = false },
         inject = function(self)
             G.P_CENTER_POOLS[self.key] = G.P_CENTER_POOLS[self.key] or {}
             local injected_rarities = {}
@@ -1172,7 +1172,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
             return {}
         end
     }
-    
+
     SMODS.Tarot = SMODS.Consumable:extend {
         set = 'Tarot',
     }
@@ -1208,7 +1208,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
 
     SMODS.Voucher:take_ownership('observatory', {
         calculate = function(self, card, context)
-            if 
+            if
                 context.other_consumeable and
                 context.other_consumeable.ability.set == 'Planet' and
                 context.other_consumeable.ability.consumeable.hand_type == context.scoring_name
@@ -1306,7 +1306,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
             if desc_nodes == full_UI_table.main and not full_UI_table.name then
                 full_UI_table.name = localize{type = 'name', set = 'Other', key = res.name_key or target.key, nodes = full_UI_table.name, vars = res.name_vars or target.vars or {}}
             elseif desc_nodes ~= full_UI_table.main and not desc_nodes.name then
-                desc_nodes.name = localize{type = 'name_text', key = res.name_key or target.key, set = 'Other' } 
+                desc_nodes.name = localize{type = 'name_text', key = res.name_key or target.key, set = 'Other' }
             end
             localize(target)
             desc_nodes.background_colour = res.background_colour
@@ -1320,7 +1320,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
         update_pack = function(self, dt)
             if G.buttons then G.buttons:remove(); G.buttons = nil end
             if G.shop then G.shop.alignment.offset.y = G.ROOM.T.y+11 end
-        
+
             if not G.STATE_COMPLETE then
                 G.STATE_COMPLETE = true
                 G.CONTROLLER.interrupt.focus = true
@@ -1339,7 +1339,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
                             trigger = 'immediate',
                             func = function()
                                 if self.draw_hand == true then G.FUNCS.draw_from_deck_to_hand() end
-        
+
                                 G.E_MANAGER:add_event(Event({
                                     trigger = 'after',
                                     delay = 0.5,
@@ -1349,10 +1349,10 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
                                     end}))
                                 return true
                             end
-                        }))  
+                        }))
                         return true
                     end
-                }))  
+                }))
             end
         end,
         ease_background_colour = function(self)
@@ -1364,7 +1364,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
             G.pack_cards = CardArea(
                 G.ROOM.T.x + 9 + G.hand.T.x, G.hand.T.y,
                 math.max(1,math.min(_size,5))*G.CARD_W*1.1,
-                1.05*G.CARD_H, 
+                1.05*G.CARD_H,
                 {card_limit = _size, type = 'consumeable', highlight_limit = 1})
 
             local t = {n=G.UIT.ROOT, config = {align = 'tm', r = 0.15, colour = G.C.CLEAR, padding = 0.15}, nodes={
@@ -2342,7 +2342,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
                 return
             end
             if self:check_dependencies() then
-                assert(not self.palettes ~= not (self.ranks and self.lc_atlas), 
+                assert(not self.palettes ~= not (self.ranks and self.lc_atlas),
                     ('Error loading DeckSkin %s! Please define your palettes or use the old formatting'):format(self.key))
                 -- for compat with old format
                 self.pos_style = self.posStyle or self.pos_style
@@ -2415,12 +2415,12 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
             if type(key) == "number" then
                 key = G.COLLABS.options[suit][key]
             end
-        
+
             local conv_palette_loc_options = {}
             for k, v in pairs(G.localization.misc.collab_palettes[key]) do
                 conv_palette_loc_options[tonumber(k)] = v
             end
-        
+
             return conv_palette_loc_options
         end,
         post_inject_class = function(self)
@@ -2435,7 +2435,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
                     G.SETTINGS.colour_palettes[k] = skin.palettes[1].key
                 end
             end
-                
+
         end
     }
 
@@ -2600,26 +2600,26 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
         ['Flush House'] = function(parts)
             if #parts._3 < 1 or #parts._2 < 2 or not next(parts._flush) then return {} end
             return { SMODS.merge_lists(parts._all_pairs, parts._flush) }
-        end, 
+        end,
         ['Five of a Kind'] = function(parts) return parts._5 end,
         ['Straight Flush'] = function(parts)
             if not next(parts._straight) or not next(parts._flush) then return end
             return { SMODS.merge_lists(parts._straight, parts._flush) }
-        end, 
-        ['Four of a Kind'] = function(parts) return parts._4 end, 
+        end,
+        ['Four of a Kind'] = function(parts) return parts._4 end,
         ['Full House'] = function(parts)
             if #parts._3 < 1 or #parts._2 < 2 then return {} end
             return parts._all_pairs
         end,
         ['Flush'] = function(parts) return parts._flush end,
         ['Straight'] = function(parts) return parts._straight end,
-        ['Three of a Kind'] = function(parts) return parts._3 end, 
+        ['Three of a Kind'] = function(parts) return parts._3 end,
         ['Two Pair'] = function(parts)
             if #parts._2 < 2 then return {} end
             return parts._all_pairs
-        end, 
-        ['Pair'] = function(parts) return parts._2 end, 
-        ['High Card'] = function(parts) return parts._highest end, 
+        end,
+        ['Pair'] = function(parts) return parts._2 end,
+        ['High Card'] = function(parts) return parts._highest end,
     }
     for _, v in ipairs(handlist) do
         local hand = copy_table(hands[v])
@@ -2747,7 +2747,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
             if desc_nodes == full_UI_table.main and not full_UI_table.name then
                 full_UI_table.name = localize { type = 'name', set = target.set, key = res.name_key or target.key, nodes = full_UI_table.name, vars = res.name_vars or res.vars or {} }
             elseif desc_nodes ~= full_UI_table.main and not desc_nodes.name then
-                desc_nodes.name = localize{type = 'name_text', key = res.name_key or target.key, set = target.set } 
+                desc_nodes.name = localize{type = 'name_text', key = res.name_key or target.key, set = target.set }
             end
             if res.main_start then
                 desc_nodes[#desc_nodes + 1] = res.main_start
@@ -2801,13 +2801,13 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
         -- or handling it in apply
         -- TODO: rename
         should_apply = function(self, card, center, area, bypass_roll)
-            if 
+            if
                 ( not self.sets or self.sets[center.set or {}]) and
                 (
                     center[self.key..'_compat'] or -- explicit marker
                     (self.default_compat and not self.compat_exceptions[center.key]) or -- default yes with no exception
                     (not self.default_compat and self.compat_exceptions[center.key]) -- default no with exception
-                ) and 
+                ) and
                 (not self.needs_enable_flag or G.GAME.modifiers['enable_'..self.key])
             then
                 self.last_roll = pseudorandom((area == G.pack_cards and 'packssj' or 'shopssj')..self.key..G.GAME.round_resets.ante)
@@ -2820,7 +2820,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
     }
 
     -- Create base game stickers
-    -- eternal and perishable follow shared checks for sticker application, therefore omitted 
+    -- eternal and perishable follow shared checks for sticker application, therefore omitted
     SMODS.Sticker{
         key = "eternal",
         badge_colour = HEX 'c75985',
@@ -2893,7 +2893,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
         prefix_config = {key = false},
         pos = { x = 10, y = 10 }, -- Base game has no art, and I haven't made any yet to represent Pinned with
         rate = 0,
-        should_apply = false, 
+        should_apply = false,
         order = 4,
         apply = function(self, card, val)
             card[self.key] = val
@@ -2952,6 +2952,30 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
                 if remaining_bonus_chips > 0 then
                     localize { type = 'other', key = 'card_extra_chips', nodes = desc_nodes, vars = { specific_vars.bonus_chips - (self.config.bonus or 0) } }
                 end
+            end
+            if specific_vars and specific_vars.bonus_xchips then
+                localize{type = 'other', key = 'card_extra_xchips', nodes = desc_nodes, vars = {specific_vars.bonus_xchips}}
+            end
+            if specific_vars and specific_vars.bonus_mult then
+                localize{type = 'other', key = 'card_extra_mult', nodes = desc_nodes, vars = {specific_vars.bonus_mult}}
+            end
+            if specific_vars and specific_vars.bonus_xmult then
+                localize{type = 'other', key = 'card_extra_xmult', nodes = desc_nodes, vars = {specific_vars.bonus_xmult}}
+            end
+            if specific_vars and specific_vars.bonus_hchips then
+                localize{type = 'other', key = 'card_extra_hchips', nodes = desc_nodes, vars = {specific_vars.bonus_hchips}}
+            end
+            if specific_vars and specific_vars.bonus_hxchips then
+                localize{type = 'other', key = 'card_extra_hxchips', nodes = desc_nodes, vars = {specific_vars.bonus_hxchips}}
+            end
+            if specific_vars and specific_vars.bonus_hmult then
+                localize{type = 'other', key = 'card_extra_hmult', nodes = desc_nodes, vars = {specific_vars.bonus_hmult}}
+            end
+            if specific_vars and specific_vars.bonus_hxmult then
+                localize{type = 'other', key = 'card_extra_hxmult', nodes = desc_nodes, vars = {specific_vars.bonus_hxmult}}
+            end
+            if specific_vars and specific_vars.bonus_dollars then
+                localize{type = 'other', key = 'card_extra_dollars', nodes = desc_nodes, vars = {specific_vars.bonus_dollars}}
             end
         end,
         -- other methods:
@@ -3039,7 +3063,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
         },
         -- optional fields:
         extra_cost = nil,
-        
+
         -- TODO badge colours. need to check how Steamodded already does badge colors
         -- other methods:
         calculate = nil, -- function (self)
@@ -3100,7 +3124,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
             if context.pre_joker or (context.main_scoring and context.cardarea == G.play) then
                 return {
                     chips = card.edition.chips
-                }     
+                }
             end
         end
     })
@@ -3131,7 +3155,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
             if context.pre_joker or (context.main_scoring and context.cardarea == G.play) then
                 return {
                     mult = card.edition.mult
-                }     
+                }
             end
         end
     })
@@ -3162,7 +3186,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
             if context.post_joker or (context.main_scoring and context.cardarea == G.play) then
                 return {
                     x_mult = card.edition.x_mult
-                }     
+                }
             end
         end
     })
@@ -3220,7 +3244,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
         end,
         inject = function(_) end
     }
-    
+
     SMODS.Keybind {
         key_pressed = 'm',
         event = 'held',

--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -1799,56 +1799,58 @@ function Card:get_chip_mult()
     return cgcm(self) + (self.ability.perma_mult or 0)
 end
 
--- perma_xmult
+-- perma_x_mult
 local cgcxm = Card.get_chip_x_mult
 function Card:get_chip_x_mult()
     if self.debuff then return 0 end
-	local ret = math.max(cgcxm(self), 1) + (self.ability.perma_xmult - 1)
+	local base = cgcxm(self)
+	local ret = (base ~= 0 and base or 1) + self.ability.perma_x_mult
     return (ret == 1 and 0) or ((ret > 0) and ret) or 0
 end
 
--- perma_hmult
+-- perma_h_mult
 local cgchm = Card.get_chip_h_mult
 function Card:get_chip_h_mult()
     if self.debuff then return 0 end
-    return cgchm(self) + (self.ability.perma_hmult or 0)
+    return cgchm(self) + (self.ability.perma_h_mult or 0)
 end
 
 
--- perma_hxmult
+-- perma_h_x_mult
 local cgchxm = Card.get_chip_h_x_mult
 function Card:get_chip_h_x_mult()
     if self.debuff then return 0 end
-	local ret = math.max(cgchxm(self), 1) + (self.ability.perma_hxmult - 1)
+	local base = cgchxm(self)
+	local ret = (base ~= 0 and base or 1) + self.ability.perma_h_x_mult
     return (ret == 1 and 0) or ((ret > 0) and ret) or 0
 end
 
 -- perma_xbonus
 function Card:get_chip_x_bonus()
     if self.debuff then return 0 end
-    local ret = 1 + (self.ability.perma_xbonus - 1)
+	local ret = 1 + self.ability.perma_x_chips
 	return (ret == 1 and 0) or ((ret > 0) and ret) or 0
 end
 
--- perma_hbonus
+-- perma_h_chips
 function Card:get_chip_h_bonus()
     if self.debuff then return 0 end
-    return self.ability.perma_hbonus or 0
+    return self.ability.perma_h_chips or 0
 end
 
--- perma_hxbonus
+-- perma_h_x_chips
 function Card:get_chip_h_x_bonus()
     if self.debuff then return 0 end
-    local ret = 1 + (self.ability.perma_hxbonus - 1)
+    local ret = 1 + self.ability.perma_h_x_chips
 	return (ret == 1 and 0) or ((ret > 0) and ret) or 0
 end
 
--- perma_dollars
+-- perma_p_dollars
 local cgpd = Card.get_p_dollars
 
 Card.get_p_dollars = function(self)
     if self.debuff then return 0 end
-	return cgpd(self) + (self.ability.perma_dollars or 0)
+	return cgpd(self) + (self.ability.perma_p_dollars or 0)
 end
 
 --#endregion

--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -1853,6 +1853,26 @@ Card.get_p_dollars = function(self)
 	return cgpd(self) + (self.ability.perma_p_dollars or 0)
 end
 
+-- perma_h_dollars
+
+Card.get_h_dollars = function(self)
+	if self.debuff then return 0 end
+	return (self.ability.h_dollars or 0) + (self.ability.perma_h_dollars or 0)
+end
+
+function SMODS.perma_example_card(card)
+	card.ability.perma_bonus = -2.2
+	card.ability.perma_mult = -0.7
+	card.ability.perma_h_chips = 4.6
+	card.ability.perma_x_chips = -4.7
+	card.ability.perma_x_mult = 3.4
+	card.ability.perma_h_x_chips = 4.6
+	card.ability.perma_h_mult = 3.4
+	card.ability.perma_h_x_mult = 0.1
+	card.ability.perma_p_dollars = 2.5
+	card.ability.perma_h_dollars = -4.5
+end
+
 --#endregion
 
 function playing_card_joker_effects(cards)

--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -40,7 +40,7 @@ function create_UIBox_your_collection_blinds(exit)
 	local spacing = 1 - 15*0.06
 	if G.GAME and G.GAME.round_resets and G.GAME.round_resets.ante then
 		local current_ante = G.GAME.round_resets.ante
-	
+
 		if current_ante > 8 then
 			min_ante = current_ante - 8 + 1
 			max_ante = current_ante + 8
@@ -258,7 +258,7 @@ function create_UIBox_your_collection_blinds(exit)
 							},
 							create_option_cycle({
 								options = page_options,
-								w = 4.5, 
+								w = 4.5,
 								cycle_shoulders = true,
 								opt_callback = 'your_collection_blinds_page',
 								focus_args = {snap_to = true, nav = 'wide'},
@@ -363,7 +363,7 @@ function G.FUNCS.your_collection_blinds_page(args)
 		func = (function()
 			for _, v in ipairs(blinds_to_be_alerted) do
 			  v.children.alert = UIBox{
-				definition = create_UIBox_card_alert(), 
+				definition = create_UIBox_card_alert(),
 				config = { align="tri", offset = {x = 0.1, y = 0.1}, parent = v}
 			  }
 			  v.children.alert.states.collide.can = false
@@ -512,7 +512,7 @@ function SMODS.applied_stakes_UI(i, stake_desc_rows, num_added)
 					end
 					_full_desc[#_full_desc] = nil
 					stake_desc_rows[#stake_desc_rows + 1] = {n = G.UIT.R, config = {align = "cm" }, nodes = {
-						{n = G.UIT.C, config = {align = 'cm'}, nodes = { 
+						{n = G.UIT.C, config = {align = 'cm'}, nodes = {
 							{n = G.UIT.C, config = {align = "cm", colour = get_stake_col(i), r = 0.1, minh = 0.35, minw = 0.35, emboss = 0.05 }, nodes = {}},
 							{n = G.UIT.B, config = {w = 0.1, h = 0.1}}}},
 						{n = G.UIT.C, config = {align = "cm", padding = 0.03, colour = G.C.WHITE, r = 0.1, minh = 0.7, minw = 4.8 }, nodes =
@@ -960,9 +960,9 @@ function G.UIDEF.view_deck(unplayed_only)
 		-- base cards
 		{n = G.UIT.R, config = {align = "cm", minh = 0.05, padding = 0.07}, nodes = {
 			{n = G.UIT.O, config = {
-					object = DynaText({ 
-						string = { 
-							{ string = localize('k_base_cards'), colour = G.C.RED }, 
+					object = DynaText({
+						string = {
+							{ string = localize('k_base_cards'), colour = G.C.RED },
 							modded and { string = localize('k_effective'), colour = G.C.BLUE } or nil
 						},
 						colours = { G.C.RED }, silent = true, scale = 0.4, pop_in_rate = 10, pop_delay = 4
@@ -1040,7 +1040,7 @@ function G.UIDEF.view_deck(unplayed_only)
 										definition = G.GAME.selected_back:generate_UI(nil, 0.7, 0.5, G.GAME.challenge), config = {offset = { x = 0, y = 0 } }
 									}
 								}}}}}},
-					{n = G.UIT.R, config = {align = "cm", r = 0.1, outline_colour = G.C.L_BLACK, line_emboss = 0.05, outline = 1.5}, nodes = 
+					{n = G.UIT.R, config = {align = "cm", r = 0.1, outline_colour = G.C.L_BLACK, line_emboss = 0.05, outline = 1.5}, nodes =
 						tally_ui}}},
 				{n = G.UIT.C, config = {align = "cm"}, nodes = rank_cols},
 				{n = G.UIT.B, config = {w = 0.1, h = 0.1}},}},
@@ -1253,7 +1253,7 @@ end
 --#endregion
 
 function Card:set_sprites(_center, _front)
-    if _front then 
+    if _front then
         local _atlas, _pos = get_front_spriteinfo(_front)
         if self.children.front then self.children.front:remove() end
 		self.children.front = Sprite(self.T.x, self.T.y, self.T.w, self.T.h, _atlas, _pos)
@@ -1263,14 +1263,14 @@ function Card:set_sprites(_center, _front)
 		self.children.front.states.collide.can = false
 		self.children.front:set_role({major = self, role_type = 'Glued', draw_major = self})
     end
-    if _center then 
+    if _center then
         if _center.set then
             if self.children.center then self.children.center:remove() end
-			if _center.set == 'Joker' and not _center.unlocked and not self.params.bypass_discovery_center then 
+			if _center.set == 'Joker' and not _center.unlocked and not self.params.bypass_discovery_center then
 				self.children.center = Sprite(self.T.x, self.T.y, self.T.w, self.T.h, G.ASSET_ATLAS["Joker"], G.j_locked.pos)
-			elseif self.config.center.set == 'Voucher' and not self.config.center.unlocked and not self.params.bypass_discovery_center then 
+			elseif self.config.center.set == 'Voucher' and not self.config.center.unlocked and not self.params.bypass_discovery_center then
 				self.children.center = Sprite(self.T.x, self.T.y, self.T.w, self.T.h, G.ASSET_ATLAS["Voucher"], G.v_locked.pos)
-			elseif self.config.center.consumeable and self.config.center.demo then 
+			elseif self.config.center.consumeable and self.config.center.demo then
 				self.children.center = Sprite(self.T.x, self.T.y, self.T.w, self.T.h, G.ASSET_ATLAS["Tarot"], G.c_locked.pos)
 			elseif not self.params.bypass_discovery_center and (_center.set == 'Edition' or _center.set == 'Joker' or _center.consumeable or _center.set == 'Voucher' or _center.set == 'Booster') and not _center.discovered then
 				local atlas = G.ASSET_ATLAS[
@@ -1280,7 +1280,7 @@ function Card:set_sprites(_center, _front)
 					) or
 					(
 						SMODS.UndiscoveredSprites[_center.set] and
-						(SMODS.UndiscoveredSprites[_center.set][G.SETTINGS.colourblind_option and 'hc_atlas' or 'lc_atlas'] or 
+						(SMODS.UndiscoveredSprites[_center.set][G.SETTINGS.colourblind_option and 'hc_atlas' or 'lc_atlas'] or
 						SMODS.UndiscoveredSprites[_center.set].atlas)
 					) or
 					_center.set
@@ -1299,13 +1299,13 @@ function Card:set_sprites(_center, _front)
 			self.children.center.states.drag = self.states.drag
 			self.children.center.states.collide.can = false
 			self.children.center:set_role({major = self, role_type = 'Glued', draw_major = self})
-            if _center.name == 'Half Joker' and (_center.discovered or self.bypass_discovery_center) then 
+            if _center.name == 'Half Joker' and (_center.discovered or self.bypass_discovery_center) then
                 self.children.center.scale.y = self.children.center.scale.y/1.7
             end
-            if _center.name == 'Photograph' and (_center.discovered or self.bypass_discovery_center) then 
+            if _center.name == 'Photograph' and (_center.discovered or self.bypass_discovery_center) then
                 self.children.center.scale.y = self.children.center.scale.y/1.2
             end
-            if _center.name == 'Square Joker' and (_center.discovered or self.bypass_discovery_center) then 
+            if _center.name == 'Square Joker' and (_center.discovered or self.bypass_discovery_center) then
                 self.children.center.scale.y = self.children.center.scale.x
             end
             if _center.pixel_size and _center.pixel_size.h and (_center.discovered or self.bypass_discovery_center) then
@@ -1342,11 +1342,11 @@ local card_init = Card.init
 function Card:init(X, Y, W, H, card, center, params)
 	card_init(self, X, Y, W, H, card, center, params)
 
-	-- This table contains object keys for layers (e.g. edition) 
+	-- This table contains object keys for layers (e.g. edition)
 	-- that dont want base layer to be drawn.
 	-- When layer is removed, layer's value should be set to nil.
 	self.ignore_base_shader = self.ignore_base_shader or {}
-	-- This table contains object keys for layers (e.g. edition) 
+	-- This table contains object keys for layers (e.g. edition)
 	-- that dont want shadow to be drawn.
 	-- When layer is removed, layer's value should be set to nil.
 	self.ignore_shadow = self.ignore_shadow or {}
@@ -1361,7 +1361,7 @@ function Card:should_draw_shadow()
 end
 
 local smods_card_load = Card.load
--- 
+--
 function Card:load(cardTable, other_card)
 	local ret = smods_card_load(self, cardTable, other_card)
 	local on_edition_loaded = self.edition and self.edition.key and G.P_CENTERS[self.edition.key].on_load
@@ -1454,7 +1454,7 @@ function Card:set_edition(edition, immediate, silent)
 	if p_edition.no_shadow or p_edition.disable_shadow then
 		self.ignore_shadow[self.edition.key] = true
 	end
-	
+
 	local on_edition_applied = p_edition.on_apply
 	if type(on_edition_applied) == "function" then
 		on_edition_applied(self)
@@ -1673,7 +1673,7 @@ end
 
 function get_deck_win_sticker(_center)
 	if G.PROFILES[G.SETTINGS.profile].deck_usage[_center.key] and
-	G.PROFILES[G.SETTINGS.profile].deck_usage[_center.key].wins_by_key then 
+	G.PROFILES[G.SETTINGS.profile].deck_usage[_center.key].wins_by_key then
 		local _stake = nil
 		for key, _ in pairs(G.PROFILES[G.SETTINGS.profile].deck_usage[_center.key].wins_by_key) do
 			if (G.P_STAKES[key] and G.P_STAKES[key].stake_level or 0) > (_stake and G.P_STAKES[_stake].stake_level or 0) then
@@ -1709,7 +1709,7 @@ end
 
 function Card:align_h_popup()
 	local focused_ui = self.children.focused_ui and true or false
-	local popup_direction = (self.children.buy_button or (self.area and self.area.config.view_deck) or (self.area and self.area.config.type == 'shop')) and 'cl' or 
+	local popup_direction = (self.children.buy_button or (self.area and self.area.config.view_deck) or (self.area and self.area.config.type == 'shop')) and 'cl' or
 							(self.T.y < G.CARD_H*0.8) and 'bm' or
 							'tm'
 	local sign = 1
@@ -1737,7 +1737,7 @@ function Card:align_h_popup()
 				popup_direction == 'tm' and -0.13 or
 				popup_direction == 'bm' and 0.1 or
 				0
-		},  
+		},
 		type = popup_direction,
 		--lr_clamp = true
 	}
@@ -1754,7 +1754,7 @@ function get_pack(_key, _type)
 		local add
 		v.current_weight = v.get_weight and v:get_weight() or v.weight or 1
         if (not _type or _type == v.kind) then add = true end
-		if v.in_pool and type(v.in_pool) == 'function' then 
+		if v.in_pool and type(v.in_pool) == 'function' then
 			local res, pool_opts = v:in_pool()
 			pool_opts = pool_opts or {}
 			add = res and (add or pool_opts.override_base_checks)
@@ -1763,7 +1763,7 @@ function get_pack(_key, _type)
     end
     local poll = pseudorandom(pseudoseed((_key or 'pack_generic')..G.GAME.round_resets.ante))*cume
     for k, v in ipairs(G.P_CENTER_POOLS['Booster']) do
-        if temp_in_pool[v.key] then 
+        if temp_in_pool[v.key] then
             it = it + (v.current_weight or 1)
             if it >= poll and it - (v.current_weight or 1) <= poll then center = v; break end
         end
@@ -1788,6 +1788,69 @@ function Card:calculate_seal(context)
 	if self.ability.extra_enhancement then return end
 	return ccs(self, context)
 end
+--#endregion
+
+--#region card perma bonuses
+
+-- perma_mult
+local cgcm = Card.get_chip_mult
+function Card:get_chip_mult()
+    if self.debuff then return 0 end
+    return cgcm(self) + (self.ability.perma_mult or 0)
+end
+
+-- perma_xmult
+local cgcxm = Card.get_chip_x_mult
+function Card:get_chip_x_mult()
+    if self.debuff then return 0 end
+	local ret = math.max(cgcxm(self), 1) + (self.ability.perma_xmult - 1)
+    return (ret == 1 and 0) or ((ret > 0) and ret) or 0
+end
+
+-- perma_hmult
+local cgchm = Card.get_chip_h_mult
+function Card:get_chip_h_mult()
+    if self.debuff then return 0 end
+    return cgchm(self) + (self.ability.perma_hmult or 0)
+end
+
+
+-- perma_hxmult
+local cgchxm = Card.get_chip_h_x_mult
+function Card:get_chip_h_x_mult()
+    if self.debuff then return 0 end
+	local ret = math.max(cgchxm(self), 1) + (self.ability.perma_hxmult - 1)
+    return (ret == 1 and 0) or ((ret > 0) and ret) or 0
+end
+
+-- perma_xbonus
+function Card:get_chip_x_bonus()
+    if self.debuff then return 0 end
+    local ret = 1 + (self.ability.perma_xbonus - 1)
+	return (ret == 1 and 0) or ((ret > 0) and ret) or 0
+end
+
+-- perma_hbonus
+function Card:get_chip_h_bonus()
+    if self.debuff then return 0 end
+    return self.ability.perma_hbonus or 0
+end
+
+-- perma_hxbonus
+function Card:get_chip_h_x_bonus()
+    if self.debuff then return 0 end
+    local ret = 1 + (self.ability.perma_hxbonus - 1)
+	return (ret == 1 and 0) or ((ret > 0) and ret) or 0
+end
+
+-- perma_dollars
+local cgpd = Card.get_p_dollars
+
+Card.get_p_dollars = function(self)
+    if self.debuff then return 0 end
+	return cgpd(self) + (self.ability.perma_dollars or 0)
+end
+
 --#endregion
 
 function playing_card_joker_effects(cards)

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -121,12 +121,12 @@ function SMODS.SAVE_UNLOCKS()
 
 	for k, v in pairs(G.P_BLINDS) do
         v.key = k
-        if not v.wip and not v.demo then 
+        if not v.wip and not v.demo then
             if TESTHELPER_unlocks then v.discovered = true; v.alerted = true  end --REMOVE THIS
-            if not v.discovered and meta.discovered[k] then 
+            if not v.discovered and meta.discovered[k] then
                 v.discovered = true
             end
-            if v.discovered and meta.alerted[k] then 
+            if v.discovered and meta.alerted[k] then
                 v.alerted = true
             elseif v.discovered then
                 v.alerted = false
@@ -135,12 +135,12 @@ function SMODS.SAVE_UNLOCKS()
     end
 	for k, v in pairs(G.P_TAGS) do
         v.key = k
-        if not v.wip and not v.demo then 
+        if not v.wip and not v.demo then
             if TESTHELPER_unlocks then v.discovered = true; v.alerted = true  end --REMOVE THIS
-            if not v.discovered and meta.discovered[k] then 
+            if not v.discovered and meta.discovered[k] then
                 v.discovered = true
             end
-            if v.discovered and meta.alerted[k] then 
+            if v.discovered and meta.alerted[k] then
                 v.alerted = true
             elseif v.discovered then
                 v.alerted = false
@@ -235,7 +235,7 @@ function SMODS.insert_pool(pool, center, replace)
 		end
     end
     local prev_order = (pool[#pool] and pool[#pool].order) or 0
-    if prev_order ~= nil then 
+    if prev_order ~= nil then
         center.order = prev_order + 1
     end
     table.insert(pool, center)
@@ -322,11 +322,11 @@ function SMODS.create_card(t)
     SMODS.bypass_create_card_edition = nil
 
     -- Should this be restricted to only cards able to handle these
-    -- or should that be left to the person calling SMODS.create_card to use it correctly? 
+    -- or should that be left to the person calling SMODS.create_card to use it correctly?
     if t.edition then _card:set_edition(t.edition) end
     if t.enhancement then _card:set_ability(G.P_CENTERS[t.enhancement]) end
     if t.seal then _card:set_seal(t.seal) end
-    if t.stickers then 
+    if t.stickers then
         for i, v in ipairs(t.stickers) do
             local s = SMODS.Stickers[v]
             if not s or type(s.should_apply) ~= 'function' or s:should_apply(_card, t.area, true) then
@@ -482,7 +482,7 @@ function serialize(t, indent)
     for k, v in pairs(t) do
 		if type(k) == 'string' then
         	str = str .. indent .. '\t' .. '[' .. serialize_string(k) .. '] = '
-            
+
 			if type(v) == 'number' then
 				str = str .. v
             elseif type(v) == 'boolean' then
@@ -611,7 +611,7 @@ end
 
 function round_number(num, precision)
 	precision = 10^(precision or 0)
-	
+
 	return math.floor(num * precision + 0.4999999999999994) / precision
 end
 
@@ -661,7 +661,7 @@ function SMODS.poll_seal(args)
         v.weight = G.P_SEALS[v.key].get_weight and G.P_SEALS[v.key]:get_weight() or v.weight
         type_weight = type_weight + v.weight
     end
-    
+
     local seal_poll = pseudorandom(pseudoseed(key or 'stdseal'..G.GAME.round_resets.ante))
     if seal_poll > 1 - (type_weight*mod / total_weight) or guaranteed then -- is a seal generated
         local seal_type_poll = pseudorandom(pseudoseed(type_key)) -- which seal is generated
@@ -687,7 +687,7 @@ function SMODS.get_blind_amount(ante)
         10000 + 25000*(scale+1)*((scale/4)^2),
         50000 * (scale+1)^2 * (scale/7)^2
     }
-    
+
     if ante < 1 then return 100 end
     if ante <= 8 then return amounts[ante] - amounts[ante]%(10^math.floor(math.log10(amounts[ante])-1)) end
     local a, b, c, d = amounts[8], amounts[8]/amounts[7], ante-8, 1 + 0.2*(ante-8)
@@ -737,12 +737,12 @@ function SMODS.poll_rarity(_pool_key, _rand_key)
 	local rarity_poll = pseudorandom(pseudoseed(_rand_key or ('rarity'..G.GAME.round_resets.ante))) -- Generate the poll value
 	local available_rarities = copy_table(SMODS.ObjectTypes[_pool_key].rarities) -- Table containing a list of rarities and their rates
     local vanilla_rarities = {["Common"] = 1, ["Uncommon"] = 2, ["Rare"] = 3, ["Legendary"] = 4}
-    
+
     -- Calculate total rates of rarities
     local total_weight = 0
     for _, v in ipairs(available_rarities) do
         v.mod = G.GAME[tostring(v.key):lower().."_mod"] or 1
-        -- Should this fully override the v.weight calcs? 
+        -- Should this fully override the v.weight calcs?
         if SMODS.Rarities[v.key] and SMODS.Rarities[v.key].get_weight and type(SMODS.Rarities[v.key].get_weight) == "function" then
             v.weight = SMODS.Rarities[v.key]:get_weight(v.weight, SMODS.ObjectTypes[_pool_key])
         end
@@ -759,7 +759,7 @@ function SMODS.poll_rarity(_pool_key, _rand_key)
 	for _, v in ipairs(available_rarities) do
 		weight_i = weight_i + v.weight
 		if rarity_poll < weight_i then
-            if vanilla_rarities[v.key] then 
+            if vanilla_rarities[v.key] then
                 return vanilla_rarities[v.key]
             else
 			    return v.key
@@ -810,7 +810,7 @@ function SMODS.poll_enhancement(args)
         v.weight = G.P_CENTERS[v.key].get_weight and G.P_CENTERS[v.key]:get_weight() or v.weight
         type_weight = type_weight + v.weight
     end
-    
+
     local enhance_poll = pseudorandom(pseudoseed(key))
     if enhance_poll > 1 - (type_weight*mod / total_weight) or guaranteed then -- is an enhancement selected
         local seal_type_poll = pseudorandom(pseudoseed(type_key)) -- which enhancement is selected
@@ -1073,7 +1073,7 @@ G.FUNCS.update_collab_cards = function(key, suit, silent)
             local card = Card(G.cdds_cards.T.x+G.cdds_cards.T.w/2, G.cdds_cards.T.y+G.cdds_cards.T.h/2, G.CARD_W*1.2, G.CARD_H*1.2, G.P_CARDS[card_code], G.P_CENTERS.c_base)
             -- Instead of no ui it would be nice to pass info queue to this so that artist credits can be done?
             card.no_ui = true
-    
+
             G.cdds_cards:emplace(card)
         end
     end
@@ -1097,7 +1097,7 @@ end
 -- Can easily be hooked to add more calculation effects ala Talisman
 SMODS.calculate_individual_effect = function(effect, scored_card, key, amount, from_edition)
     if effect.card and effect.card ~= scored_card then juice_card(effect.card) end
-    if (key == 'chips' or key == 'h_chips' or key == 'chip_mod') and amount then 
+    if (key == 'chips' or key == 'h_chips' or key == 'chip_mod') and amount then
         hand_chips = mod_chips(hand_chips + amount)
         update_hand_text({delay = 0}, {chips = hand_chips, mult = mult})
         if not effect.remove_default_message then
@@ -1116,14 +1116,14 @@ SMODS.calculate_individual_effect = function(effect, scored_card, key, amount, f
         return true
     end
 
-    if (key == 'mult' or key == 'h_mult' or key == 'mult_mod') and amount then 
+    if (key == 'mult' or key == 'h_mult' or key == 'mult_mod') and amount then
         mult = mod_mult(mult + amount)
         update_hand_text({delay = 0}, {chips = hand_chips, mult = mult})
         if not effect.remove_default_message then
             if from_edition then
                 card_eval_status_text(scored_card, 'jokers', nil, percent, nil, {message = localize{type = 'variable', key = amount > 0 and 'a_mult' or 'a_mult_minus', vars = {amount}}, mult_mod = amount, colour = G.C.DARK_EDITION, edition = true})
             else
-                if key ~= 'mult_mod' then 
+                if key ~= 'mult_mod' then
                     if effect.mult_message then
                         card_eval_status_text(scored_card or effect.card or effect.focus, 'extra', nil, percent, nil, effect.mult_message)
                     else
@@ -1134,8 +1134,8 @@ SMODS.calculate_individual_effect = function(effect, scored_card, key, amount, f
         end
         return true
     end
-    
-    if (key == 'p_dollars' or key == 'dollars' or key == 'h_dollars') and amount then 
+
+    if (key == 'p_dollars' or key == 'dollars' or key == 'h_dollars') and amount then
         ease_dollars(amount)
         if not effect.remove_default_message then
             if effect.dollar_message then
@@ -1147,7 +1147,7 @@ SMODS.calculate_individual_effect = function(effect, scored_card, key, amount, f
         return true
     end
 
-    if (key == 'x_chips' or key == 'xchips' or key == 'Xchip_mod') and amount ~= 1 then 
+    if (key == 'x_chips' or key == 'xchips' or key == 'Xchip_mod') and amount ~= 1 then
         hand_chips = mod_chips(hand_chips * amount)
         update_hand_text({delay = 0}, {chips = hand_chips, mult = mult})
         if not effect.remove_default_message then
@@ -1165,8 +1165,8 @@ SMODS.calculate_individual_effect = function(effect, scored_card, key, amount, f
         end
         return true
     end
-    
-    if (key == 'x_mult' or key == 'xmult' or key == 'Xmult' or key == 'x_mult_mod' or key == 'Xmult_mod') and amount ~= 1 then 
+
+    if (key == 'x_mult' or key == 'xmult' or key == 'Xmult' or key == 'x_mult_mod' or key == 'Xmult_mod') and amount ~= 1 then
         mult = mod_mult(mult * amount)
         update_hand_text({delay = 0}, {chips = hand_chips, mult = mult})
         if not effect.remove_default_message then
@@ -1195,7 +1195,7 @@ SMODS.calculate_individual_effect = function(effect, scored_card, key, amount, f
         return true
     end
 
-    if key == 'swap' then 
+    if key == 'swap' then
         local old_mult = mult
         mult = mod_mult(hand_chips)
         hand_chips = mod_chips(old_mult)
@@ -1346,7 +1346,7 @@ function Card:calculate_edition(context)
         if edition.calculate and type(edition.calculate) == 'function' then
             local o = edition:calculate(self, context)
             if o then
-                if not o.card then o.card = self end    
+                if not o.card then o.card = self end
                 return o
             end
         end
@@ -1382,7 +1382,7 @@ function SMODS.calculate_context(context, return_table)
                 context.retrigger_joker = false
             end
             if return_table then
-                for _,v in ipairs(effects) do 
+                for _,v in ipairs(effects) do
                     if v.jokers and not v.jokers.card then v.jokers.card = _card end
                     return_table[#return_table+1] = v
                 end
@@ -1396,7 +1396,7 @@ function SMODS.calculate_context(context, return_table)
         context.cardarea = G.play
         for i=1, #context.scoring_hand do
             --calculate the played card effects
-            if return_table then 
+            if return_table then
                 return_table[#return_table+1] = eval_card(context.scoring_hand[i], context)
                 SMODS.calculate_quantum_enhancements(context.scoring_hand[i], return_table, context)
             else
@@ -1413,7 +1413,7 @@ function SMODS.calculate_context(context, return_table)
             end
             for i=1, #unscored_cards do
                 --calculate the played card effects
-                if return_table then 
+                if return_table then
                     return_table[#return_table+1] = eval_card(unscored_cards[i], context)
                     SMODS.calculate_quantum_enhancements(unscored_cards[i], return_table, context)
                 else
@@ -1427,8 +1427,8 @@ function SMODS.calculate_context(context, return_table)
     context.cardarea = G.hand
     for i=1, #G.hand.cards do
         --calculate the held card effects
-        if return_table then 
-            return_table[#return_table+1] = eval_card(G.hand.cards[i], context)    
+        if return_table then
+            return_table[#return_table+1] = eval_card(G.hand.cards[i], context)
         else
             local effects = {eval_card(G.hand.cards[i], context)}
             SMODS.calculate_quantum_enhancements(G.hand.cards[i], effects, context)
@@ -1439,8 +1439,8 @@ function SMODS.calculate_context(context, return_table)
         context.cardarea = G.deck
         for i=1, #G.deck.cards do
             --calculate the held card effects
-            if return_table then 
-                return_table[#return_table+1] = eval_card(G.deck.cards[i], context)    
+            if return_table then
+                return_table[#return_table+1] = eval_card(G.deck.cards[i], context)
             else
                 local effects = {eval_card(G.deck.cards[i], context)}
                 SMODS.calculate_quantum_enhancements(G.deck.cards[i], effects, context)
@@ -1452,8 +1452,8 @@ function SMODS.calculate_context(context, return_table)
         context.cardarea = G.discard
         for i=1, #G.discard.cards do
             --calculate the held card effects
-            if return_table then 
-                return_table[#return_table+1] = eval_card(G.discard.cards[i], context)    
+            if return_table then
+                return_table[#return_table+1] = eval_card(G.discard.cards[i], context)
             else
                 local effects = {eval_card(G.discard.cards[i], context)}
                 SMODS.calculate_quantum_enhancements(G.discard.cards[i], effects, context)
@@ -1583,7 +1583,7 @@ function SMODS.calculate_end_of_round_effects(context)
             card.ability = old_ability
             card.config.center = old_center
             card.config.center_key = old_center_key
-            card:set_sprites(old_center) 
+            card:set_sprites(old_center)
 
             context.playing_card_end_of_round = nil
             context.individual = true
@@ -1591,10 +1591,10 @@ function SMODS.calculate_end_of_round_effects(context)
             -- context.end_of_round individual calculations
             for _, area in ipairs(SMODS.get_card_areas('jokers')) do
                 for _, _card in ipairs(area.cards) do
-                    
+
                     local eval, post = eval_card(_card, context)
                     eval.juice_card = eval.card
-                    if next(eval) then 
+                    if next(eval) then
                         table.insert(effects, eval)
                     end
                     for _, v in ipairs(post) do effects[#effects+1] = v end
@@ -1608,14 +1608,14 @@ function SMODS.calculate_end_of_round_effects(context)
             context.individual = nil
             context.repetition = true
             context.card_effects = effects
-            if reps[j] == 1 then 
+            if reps[j] == 1 then
                 SMODS.calculate_repetitions(card, context, reps)
             end
-            
+
             context.repetition = nil
             context.card_effects = nil
             j = j + (effects.calculated and 1 or #reps)
-            
+
             -- TARGET: effects after end of round evaluation
         end
     end
@@ -1643,7 +1643,7 @@ function SMODS.calculate_destroying_cards(context, cards_destroyed, scoring_hand
                     end
                 end
                 SMODS.trigger_effects({post}, card)
-                if self_destroy then 
+                if self_destroy then
                     destroyed = true
                     should_break = true
                     break
@@ -1651,11 +1651,11 @@ function SMODS.calculate_destroying_cards(context, cards_destroyed, scoring_hand
             end
             if should_break then break end
         end
-        
+
         if scoring_hand and SMODS.has_enhancement(card, 'm_glass') and not card.debuff and pseudorandom('glass') < G.GAME.probabilities.normal/(card.ability.name == 'Glass Card' and card.ability.extra or G.P_CENTERS.m_glass.config.extra) then
             destroyed = true
         end
-        
+
         local eval, post = eval_card(card, context)
         local self_destroy = false
         for key, effect in pairs(eval) do
@@ -1663,7 +1663,7 @@ function SMODS.calculate_destroying_cards(context, cards_destroyed, scoring_hand
         end
         SMODS.trigger_effects({post}, card)
         if self_destroy then destroyed = true end
-        
+
         local deck_effect = G.GAME.selected_back:trigger_effect(context)
         if deck_effect then
             self_destroy = SMODS.calculate_effect(deck_effect, G.deck.cards[1] or G.deck)
@@ -1672,12 +1672,12 @@ function SMODS.calculate_destroying_cards(context, cards_destroyed, scoring_hand
 
         -- TARGET: card destroyed
 
-        if destroyed then 
+        if destroyed then
             if SMODS.shatters(card) then
                 card.shattered = true
-            else 
+            else
                 card.destroyed = true
-            end 
+            end
             cards_destroyed[#cards_destroyed+1] = card
         end
     end
@@ -1809,7 +1809,7 @@ end
 
 G.FUNCS.can_select_from_booster = function(e)
     local area = booster_obj and e.config.ref_table:selectable_from_pack(booster_obj)
-    if area and #G[area].cards < G[area].config.card_limit then 
+    if area and #G[area].cards < G[area].config.card_limit then
         e.config.colour = G.C.GREEN
         e.config.button = 'use_card'
     else
@@ -1859,8 +1859,8 @@ function SMODS.get_next_vouchers(vouchers)
 end
 
 function SMODS.add_voucher_to_shop(key)
-    if key then assert(G.P_CENTERS[key], "Invalid voucher key: "..key) else 
-        key = get_next_voucher_key() 
+    if key then assert(G.P_CENTERS[key], "Invalid voucher key: "..key) else
+        key = get_next_voucher_key()
         G.GAME.current_round.voucher.spawn[key] = true
         G.GAME.current_round.voucher[#G.GAME.current_round.voucher + 1] = key
     end
@@ -1907,4 +1907,12 @@ function SMODS.change_free_rerolls(mod)
     G.GAME.round_resets.free_rerolls = G.GAME.round_resets.free_rerolls + mod
     G.GAME.current_round.free_rerolls = math.max(G.GAME.current_round.free_rerolls + mod, 0)
     calculate_reroll_cost(true)
+end
+
+function SMODS.signed(val)
+    return val and (val > 0 and '+'..val or ''..val) or '0'
+end
+
+function SMODS.signed_dollars(val)
+    return val and (val > 0 and '$'..val or '-$'..-val) or '0'
 end


### PR DESCRIPTION
Code mostly based on AMM (https://github.com/AutumnMood924/AutumnMoodMechanics)

Adds most values as permanent card bonuses similar to Hiker's chip bonus. The justification here is that both my mod and Ice's Kino (https://github.com/icyethics/Kino) mod implement parts of this system. Ice planned to transition to AMM as a dependency for this, but unless I also pull in AMM as a dependency just for this feature, our Card function overrides would run twice, essentially doubling every effect. Since the demand for the feature seems high, this seems like a good candidate to support on an SMODS level.