### PR TITLE
fix: voucher crashes when indexing string as table

### DIFF
--- a/lovely/shop.toml
+++ b/lovely/shop.toml
@@ -64,15 +64,22 @@ end
 '''
 payload = '''
 local vouchers_to_spawn = 0
-for _,_ in pairs(G.GAME.current_round.voucher.spawn) do vouchers_to_spawn = vouchers_to_spawn + 1 end
+for _,_ in pairs(G.GAME.current_round.voucher.spawn or {}) do vouchers_to_spawn = vouchers_to_spawn + 1 end
 if vouchers_to_spawn < G.GAME.starting_params.vouchers_in_shop + (G.GAME.modifiers.extra_vouchers or 0) then
     SMODS.get_next_vouchers(G.GAME.current_round.voucher)
 end
-for _, key in ipairs(G.GAME.current_round.voucher or {}) do
-    if G.P_CENTERS[key] and G.GAME.current_round.voucher.spawn[key] then
-        SMODS.add_voucher_to_shop(key)
-    end
+
+-- this is a band-aid fix for the Multiplayer mod! this will be removed eventually -synical
+if type(G.GAME.current_round.voucher) == "table" then
+	for _, key in ipairs(G.GAME.current_round.voucher or {}) do
+		if G.P_CENTERS[key] and G.GAME.current_round.voucher.spawn[key] then
+			SMODS.add_voucher_to_shop(key)
+		end
+	end
+elseif type(G.GAME.current_round.voucher) == "string" then
+	SMODS.add_voucher_to_shop(G.GAME.current_round.voucher)
 end
+-- end of fix
 '''
 # Modify generating vouchers
 [[patches]]
@@ -148,7 +155,6 @@ card.from_tag = true
 '''
 
 
-
 # Free Rerolls
 [[patches]]
 [patches.pattern]
@@ -213,3 +219,4 @@ pattern = '''G.shop_jokers.T.w = G.GAME.shop.joker_max*1.01*G.CARD_W'''
 position = 'at'
 match_indent = true
 payload = '''G.shop_jokers.T.w = math.min(G.GAME.shop.joker_max*1.02*G.CARD_W,4.08*G.CARD_W)'''
+


### PR DESCRIPTION
This PR addresses 2 issues that stem from the Multiplayer mod. I currently don't know where the root of the issue lies. But from the stack trace it was clear it was a smods issue, but please correct me if I'm wrong.

When spawning vouchers after a new round, it tries to index 'G.GAME.current_round.voucher' assuming it's a table, but from my testing it can either be a string, table, or just nil. This is now fixed to account for the different types.

I also noticed a crash for when indexing 'G.GAME.current_round.voucher.spawn', so it now replaces the pairs() call with an empty table if nil.

I am here for any questions/concerns.