### PR TITLE
Fix a bunch of negative-related bugs

### DIFF
--- a/lovely/booster.toml
+++ b/lovely/booster.toml
@@ -10,7 +10,7 @@ priority = -10
 [patches.pattern]
 target = "card.lua"
 pattern = '''
-if self.ability.name:find('Arcana') then 
+if self.ability.name:find('Arcana') then
             G.STATE = G.STATES.TAROT_PACK
             G.GAME.pack_size = self.ability.extra
         elseif self.ability.name:find('Celestial') then
@@ -45,7 +45,7 @@ G.GAME.pack_choices = self.ability.choose or self.config.center.config.choose or
 target = "card.lua"
 pattern = '''(?<indent>[\t ]*)if self\.ability\.name:find\('Arcana'\) then[\t\n ]*if G\.GAME\.used_vouchers\.v_omen_globe and pseudorandom\('omen_globe'\) > 0\.8 then''' # Possibly try to target something else
 position = "at"
-payload = '''if booster_obj.create_card and type(booster_obj.create_card) == "function" then 
+payload = '''if booster_obj.create_card and type(booster_obj.create_card) == "function" then
     local _card_to_spawn = booster_obj:create_card(self, i)
     if type((_card_to_spawn or {}).is) == 'function' and _card_to_spawn:is(Card) then
         card = _card_to_spawn
@@ -292,3 +292,15 @@ G.FUNCS.end_consumeable(e)
 payload = '''
 booster_obj = nil
 '''
+
+# G.FUNCS.can_select_card
+# Support negative-ish on Jokers
+[[patches]]
+[patches.pattern]
+target = 'functions/button_callbacks.lua'
+match_indent = true
+position = 'at'
+pattern = "if e.config.ref_table.ability.set ~= 'Joker' or (e.config.ref_table.edition and e.config.ref_table.edition.negative) or #G.jokers.cards < G.jokers.config.card_limit then"
+payload = '''local card = e.config.ref_table
+local card_limit = card.edition and card.edition.card_limit or 0
+if card.ability.set ~= 'Joker' or #G.jokers.cards < G.jokers.config.card_limit + card_limit then'''

--- a/lovely/edition.toml
+++ b/lovely/edition.toml
@@ -100,7 +100,7 @@ target = "engine/sprite.lua"
 pattern = "if _send then G.SHADERS[_shader or 'dissolve']:send(_shader,_send) end"
 position = "at"
 payload = '''
-if _send then 
+if _send then
     G.SHADERS[_shader or 'dissolve']:send((SMODS.Shaders[_shader or 'dissolve'] and SMODS.Shaders[_shader or 'dissolve'].original_key) or _shader,_send)
 end'''
 match_indent = true
@@ -130,7 +130,7 @@ pattern = '''(?<indent>[\t ]*)if self\.edition[A-z\.\:\n\t _(',)~=+\-0-9]*limit 
 position = "at"
 payload = '''
 if true then
-    if from_debuff then 
+    if from_debuff then
         self.ability.joker_added_to_deck_but_debuffed = nil
     else
         if self.edition and self.edition.card_limit then
@@ -183,7 +183,6 @@ payload = "joker_added_to_deck_but_debuffed = self.joker_added_to_deck_but_debuf
 match_indent = true
 
 
-
 ## Negative playing card logic
 # CardArea:emplace()
 [[patches]]
@@ -192,7 +191,7 @@ target = "cardarea.lua"
 pattern = "function CardArea:emplace(*"
 position = "after"
 payload = '''
-    if card.edition and card.edition.card_limit and (self == G.hand) then
+    if not card.debuff and card.edition and card.edition.card_limit and (self == G.hand) then
         self.config.real_card_limit = (self.config.real_card_limit or self.config.card_limit) + card.edition.card_limit
         self.config.card_limit = math.max(0, self.config.real_card_limit)
     end'''
@@ -204,7 +203,7 @@ target = "cardarea.lua"
 pattern = "card:remove_from_area()"
 position = "before"
 payload = '''
-if card.edition and card.edition.card_limit and (self == G.hand) then
+if not card.debuff and card.edition and card.edition.card_limit and (self == G.hand) then
     self.config.real_card_limit = (self.config.real_card_limit or self.config.card_limit) - card.edition.card_limit
     self.config.card_limit = math.max(0, self.config.real_card_limit)
 end'''
@@ -222,7 +221,7 @@ if not hand_space then
     local n = 0
     while n < #G.deck.cards do
         local card = G.deck.cards[#G.deck.cards-n]
-        limit = limit - 1 + (card.edition and card.edition.card_limit or 0)
+        limit = limit - 1 + (not card.debuff and card.edition and card.edition.card_limit or 0)
         if limit < 0 then break end
         n = n + 1
     end
@@ -251,7 +250,7 @@ if p_shader and type(p_shader.send_vars) == "function" then
     local sh = G.SHADERS[_shader or 'dissolve']
     local parent_card = self.role.major and self.role.major:is(Card) and self.role.major
     local send_vars = p_shader.send_vars(self, parent_card)
-    
+
     if type(send_vars) == "table" then
         for key, value in pairs(send_vars) do
             sh:send(key, value)
@@ -269,7 +268,7 @@ position = "at"
 payload = '''if v == 'negative_consumable' or v == 'negative_playing_card' then v = 'negative' end'''
 match_indent = true
 
-# 
+#
 [[patches]]
 [patches.regex]
 target = 'functions/common_events.lua'

--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -564,7 +564,7 @@ function get_straight(hand, min_length, skip, wrap)
         local ret = {}
         for _,v in ipairs(rank.next) do
             ret[#ret+1] = v
-            if skip then 
+            if skip then
                 for _,w in ipairs(SMODS.Ranks[v].next) do
                     ret[#ret+1] = w
                 end

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -1471,7 +1471,7 @@ function SMODS.score_card(card, context)
                             eval.jokers.juice_card = eval.jokers.juice_card or eval.jokers.card or _card
                             eval.jokers.message_card = eval.jokers.message_card or eval.jokers.card or card
                         end
-                        
+
                         table.insert(effects, eval)
                         for _, v in ipairs(post) do effects[#effects+1] = v end
                         if eval.retriggers then
@@ -1618,7 +1618,7 @@ function SMODS.calculate_destroying_cards(context, cards_destroyed, scoring_hand
                 context.cardarea = G.play
                 context.destroying_card = card
             else
-                context.cardarea = 'unscored' 
+                context.cardarea = 'unscored'
                 context.destroying_card = nil
             end
         end
@@ -1816,8 +1816,10 @@ SMODS.get_optional_features = function()
 end
 
 G.FUNCS.can_select_from_booster = function(e)
-    local area = booster_obj and e.config.ref_table:selectable_from_pack(booster_obj)
-    if area and #G[area].cards < G[area].config.card_limit then
+    local card = e.config.ref_table
+    local area = booster_obj and card:selectable_from_pack(booster_obj)
+    local edition_card_limit = card.edition and card.edition.card_limit or 0
+    if area and #G[area].cards < G[area].config.card_limit + edition_card_limit then
         e.config.colour = G.C.GREEN
         e.config.button = 'use_card'
     else


### PR DESCRIPTION
- Fix gaining or discarding a negative playing card while it is debuffed adding/subtracting card limits
- Fix adding negative or any other card_limit increasing edition cards from booster pack to respective area not being allowed.
- Fix adding card_limit increasing edition cards that are not negative not being allowed from Buffoon or other Joker-yielding packs.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [X] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [X] I didn't modify api's or I've updated lsp definitions.
- [X] I didn't make new lovely files or all new lovely files have appropriate priority.
