### PR TITLE
fix(select_card): select_card booster packs never add_to_deck on cards

### DIFF
--- a/lovely/booster.toml
+++ b/lovely/booster.toml
@@ -249,6 +249,7 @@ if card.ability.consumeable then
 '''
 payload = '''
 if select_to then
+    card:add_to_deck()
     G[select_to]:emplace(card)
     if card.config.center.on_select and type(card.config.center.on_select) == 'function' then
         card.config.center:on_select(card)


### PR DESCRIPTION

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
