### PR TITLE
Info tabs as GameObject

### DIFF
--- a/lsp_def/classes/tab.lua
+++ b/lsp_def/classes/tab.lua
@@ -1,0 +1,43 @@
+---@meta
+
+---@class SMODS.Tab: SMODS.GameObject
+---@field order? number Sets the order. `Tab` objects are displayed left to right from lowest to highest order.
+---@field chosen? boolean Whether the tab is the one initially selected in the tab group. The leftmost (lowest order) tab with chosen set to true is the default tab.
+---@field conditions? table<string, any> Table of conditions. This object will not draw if any condition is not `true` when evaluated.
+---@field __call? fun(self: SMODS.Tab|table, o: SMODS.Tab|table): nil|table|SMODS.Tab
+---@field extend? fun(self: SMODS.Tab|table, o: SMODS.Tab|table): table Primary method of creating a class.
+---@field check_duplicate_register? fun(self: SMODS.Tab|table): boolean? Ensures objects already registered will not register.
+---@field check_duplicate_key? fun(self: SMODS.Tab|table): boolean? Ensures objects with duplicate keys will not register. Checked on `__call` but not `take_ownership`. For take_ownership, the key must exist.
+---@field register? fun(self: SMODS.Tab|table) Registers the object.
+---@field check_dependencies? fun(self: SMODS.Tab|table): boolean? Returns `true` if there's no failed dependencies.
+---@field process_loc_text? fun(self: SMODS.Tab|table) Called during `inject_class`. Handles injecting loc_text.
+---@field send_to_subclasses? fun(self: SMODS.Tab|table, func: string, ...: any) Starting from this class, recusively searches for functions with the given key on all subordinate classes and run all found functions with the given arguments.
+---@field pre_inject_class? fun(self: SMODS.Tab|table) Called before `inject_class`. Injects and manages class information before object injection.
+---@field post_inject_class? fun(self: SMODS.Tab|table) Called after `inject_class`. Injects and manages class information after object injection.
+---@field inject_class? fun(self: SMODS.Tab|table) Injects all direct instances of class objects by calling `obj:inject` and `obj:process_loc_text`. Also injects anything necessary for the class itself. Only called if class has defined both `obj_table` and `obj_buffer`.
+---@field inject? fun(self: SMODS.Tab|table, i?: number) Called during `inject_class`. Injects the object into the game.
+---@field take_ownership? fun(self: SMODS.Tab|table, key: string, obj: SMODS.Tab|table, silent?: boolean): nil|table|SMODS.Tab Takes control of vanilla objects. Child class must have get_obj for this to function
+---@field get_obj? fun(self: SMODS.Tab|table, key: string): SMODS.Tab|table? Returns an object if one matches the `key`.
+---@field func? fun(self: SMODS.Tab|table) Handles generating the contents of the `Tab`. Must return a UI table starting from a G.UIT.ROOT element.
+---@field is_visible? fun(self: SMODS.Tab|table, args: table): boolean? If undefined or nil, the tab is always visible. Otherwise must be a function that returns true if the tab should be visible. Args are the table of arguments passed to the tab group function.
+---@overload fun(self: SMODS.Tab): SMODS.Tab
+SMODS.Tab = setmetatable({}, {
+    __call = function(self)
+        return self
+    end
+})
+
+---@type table<string, SMODS.Tab|table>
+SMODS.Tabs = {}
+
+---@param tab_group string
+---@param args table
+---@return table
+--- Returns all visible tabs which belong to `tab_group` as an array sorted by order correctly formatted to pass to create_tabs argument args.tabs.
+function SMODS.filter_visible_tabs(tab_group, args) end
+
+---@param tab_group string
+---@param args table
+---@return table
+--- Returns a UIBox with all visible tabs from `tab_group` rendered.
+function SMODS.generate_tabs_uibox(tab_group, args) end

--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -3361,6 +3361,12 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
     assert(load(NFS.read(SMODS.path..'src/card_draw.lua'), ('=[SMODS _ "src/card_draw.lua"]')))()
 
     -------------------------------------------------------------------------------------------------
+    ----- API IMPORT GameObject.Tab
+    -------------------------------------------------------------------------------------------------
+
+    assert(load(NFS.read(SMODS.path..'src/ui_tabs.lua'), ('=[SMODS _ "src/ui_tabs.lua"]')))()
+
+    -------------------------------------------------------------------------------------------------
     ----- INTERNAL API CODE GameObject._Loc_Post
     -------------------------------------------------------------------------------------------------
 

--- a/src/ui_tabs.lua
+++ b/src/ui_tabs.lua
@@ -1,0 +1,139 @@
+SMODS.Tabs = {}
+SMODS.Tab = SMODS.GameObject:extend {
+    obj_table = SMODS.Tabs,
+    obj_buffer = {},
+    required_params = {
+        'key',
+        'tab_group',
+        'order',
+        'func',
+    },
+    chosen = false,
+    -- func = function(self) end, -- -> table
+    -- is_visible = function(self, args) end, -- -> bool
+
+    set = "Tab",
+    register = function(self)
+        if self.registered then
+            sendWarnMessage(('Detected duplicate register call on object %s'):format(self.key), self.set)
+            return
+        end
+        SMODS.Tab.super.register(self)
+    end,
+    inject = function() end,
+    post_inject_class = function(self)
+        table.sort(self.obj_buffer, function(_self, _other) return self.obj_table[_self].order < self.obj_table[_other].order end)
+    end,
+}
+
+SMODS.Tab{
+    key = 'remaining',
+    tab_group = 'deck_info',
+    order = 0,
+    chosen = true,
+    func = function(self)
+        return G.UIDEF.view_deck(true)
+    end,
+    is_visible = function(self, args)
+        return args.show_remaining
+    end,
+}
+
+SMODS.Tab{
+    key = 'full_deck',
+    tab_group = 'deck_info',
+    order = 10,
+    func = function(self)
+        return G.UIDEF.view_deck()
+    end,
+}
+
+SMODS.Tab{
+    key = 'poker_hands',
+    tab_group = 'run_info',
+    order = 0,
+    chosen = true,
+    func = function(self)
+        return create_UIBox_current_hands()
+    end,
+}
+
+SMODS.Tab{
+    key = 'blinds',
+    tab_group = 'run_info',
+    order = 10,
+    func = function(self)
+        return G.UIDEF.current_blinds()
+    end,
+}
+
+SMODS.Tab{
+    key = 'vouchers',
+    tab_group = 'run_info',
+    order = 20,
+    func = function(self)
+        return G.UIDEF.used_vouchers()
+    end,
+}
+
+SMODS.Tab{
+    key = 'stake',
+    tab_group = 'run_info',
+    order = 30,
+    func = function(self)
+        return G.UIDEF.current_stake()
+    end,
+    is_visible = function(self, args)
+        return G.GAME.stake > 1
+    end,
+}
+
+-- Returns all visible tabs which belong to `tab_group` as an array sorted by order correctly formatted to pass to create_tabs argument args.tabs.
+function SMODS.filter_visible_tabs(tab_group, args)
+    local tabs = {}
+    local chosen_seen = nil
+    for _, key in ipairs(SMODS.Tab.obj_buffer) do
+        local tab = SMODS.Tabs[key]
+        if tab.tab_group == tab_group and (tab.is_visible == nil or (type(tab.is_visible) == 'function' and tab:is_visible(args or {}))) then
+            local chosen = not chosen_seen and tab.chosen or nil
+            chosen_seen = chosen_seen or chosen
+            tabs[#tabs+1] = {
+                label = localize('b_' .. tab.key),
+                order = tab.order,
+                chosen = chosen,
+                tab_definition_function = function() return tab:func() end,
+            }
+        end
+    end
+    if not chosen_seen and #tabs > 0 then tabs[1].chosen = true end
+    return tabs
+end
+
+-- Returns a UIBox with all visible tabs from `tab_group` rendered.
+function SMODS.generate_tabs_uibox(tab_group, args)
+    local tabs = SMODS.filter_visible_tabs(tab_group, args)
+    if #tabs > 0 then
+        return create_UIBox_generic_options{
+            contents = {create_tabs{
+                tabs = tabs,
+                tab_h = 8,
+                snap_to_nav = true,
+            }}
+        }
+    else
+        sendDebugMessage("Tab group '" .. tab_group .. "' returned no matching tabs.", 'SMODS.Tabs')
+    end
+    return {n = G.UIT.ROOT, config = {align="cm", colour = {G.C.GREY[1], G.C.GREY[2], G.C.GREY[3],0.7}}, nodes = {
+        {n=G.UIT.R, config={padding = 0.0, align = "cm", colour = G.C.CLEAR}, nodes={
+            {n=G.UIT.T, config={config={text='!ERROR!', scale=1, colour=G.C.UI.TEXT_DARK}}}
+        }}
+    }}
+end
+
+function G.UIDEF.deck_info(_show_remaining)
+    return SMODS.generate_tabs_uibox('deck_info', {show_remaining = _show_remaining})
+end
+
+function G.UIDEF.run_info()
+    return SMODS.generate_tabs_uibox('run_info')
+end


### PR DESCRIPTION
Adds SMODS.Tab GameObject. Does nothing on its own, but objectifies tab-based dialog rendering. Implements Run Info and Deck Info as tab groups, allowing mods to add their own tabs quickly.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [X] I didn't modify api's or I've updated lsp definitions.
- [X] I didn't make new lovely files or all new lovely files have appropriate priority.
