### PR TITLE
Give _compat values precedence

### DIFF
--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -2821,8 +2821,11 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
                 ( not self.sets or self.sets[center.set or {}]) and
                 (
                     center[self.key..'_compat'] or -- explicit marker
-                    (self.default_compat and not self.compat_exceptions[center.key]) or -- default yes with no exception
-                    (not self.default_compat and self.compat_exceptions[center.key]) -- default no with exception
+                    (
+                        center[self.key..'_compat'] == nil and
+                        ((self.default_compat and not self.compat_exceptions[center.key]) or -- default yes with no exception
+                        (not self.default_compat and self.compat_exceptions[center.key]))
+                    ) -- default no with exception
                 ) and
                 (not self.needs_enable_flag or G.GAME.modifiers['enable_'..self.key])
             then


### PR DESCRIPTION
Stickers don't consider the three cases for `_compat`
If the value is `false` or `nil`, the default value will be used.

This should correct that for all custom stickers.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
