### PR TITLE
Implement Prototype Values with Meta Tables

### DIFF
--- a/lovely/center.toml
+++ b/lovely/center.toml
@@ -12,6 +12,14 @@ target = "card.lua"
 pattern = "(?<indent>[\t ]*)if not G\\.OVERLAY_MENU then \n"
 position = 'before'
 payload = '''
+local meta_table = getmetatable(self.ability) or {}
+meta_table.__index = self.config.center.config
+setmetatable(self.ability, meta_table)
+if type(self.ability.extra) == "table" then
+    local meta_table2 = getmetatable(self.ability.extra) or {}
+    meta_table2.__index = self.config.center.config.extra
+    setmetatable(self.ability.extra, meta_table2)
+end
 local obj = self.config.center
 if obj.set_ability and type(obj.set_ability) == 'function' then
     obj:set_ability(self, initial, delay_sprites)

--- a/lovely/fixes.toml
+++ b/lovely/fixes.toml
@@ -108,7 +108,7 @@ match_indent = true
 [[patches]]
 [patches.pattern]
 target = 'card.lua'
-pattern = "self.bypass_lock = cardTable.bypass_lock"
+pattern = "self.ability = cardTable.ability"
 position = "after"
 payload = """
 self.unique_val = cardTable.unique_val or self.unique_val
@@ -117,7 +117,17 @@ if cardTable.unique_val__saved_ID and G.ID <= cardTable.unique_val__saved_ID the
 end
 
 self.ignore_base_shader = cardTable.ignore_base_shader or {}
-self.ignore_shadow = cardTable.ignore_shadow or {}"""
+self.ignore_shadow = cardTable.ignore_shadow or {}
+
+local meta_table = getmetatable(self.ability) or {}
+meta_table.__index = self.config.center.config
+setmetatable(self.ability, meta_table)
+if type(self.ability.extra) == "table" then
+    local meta_table2 = getmetatable(self.ability.extra) or {}
+    meta_table2.__index = self.config.center.config.extra
+    setmetatable(self.ability.extra, meta_table2)
+end
+"""
 match_indent = true
 
 ## Vars in card descriptions should use `card.ability` instead of `_c.config` where possible


### PR DESCRIPTION
Meta Tables have the ability to allow "fall-through" checks for values, which simulate having "default" values.
By adding this during the `card.ability` table creation, the cards won't error out if a value hasn't been initialized, or if the card center has been modified since the save was loaded.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
