### PR TITLE
Add empty card area to deck viewer to fix visual issue with 0 cards left

### DIFF
--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -870,6 +870,21 @@ function G.UIDEF.view_deck(unplayed_only)
 		end
 	end
 
+	-- Add empty card area if there's none, to fix a visual issue with no cards left
+	if not next(deck_tables) then
+		local view_deck = CardArea(
+			G.ROOM.T.x + 0.2*G.ROOM.T.w/2,G.ROOM.T.h,
+			6.5*G.CARD_W,
+			0.6*G.CARD_H,
+			{card_limit = 1, type = 'title', view_deck = true, highlight_limit = 0, card_w = G.CARD_W*0.7, draw_layers = {'card'}})
+		table.insert(
+			deck_tables,
+			{n=G.UIT.R, config={align = "cm", padding = 0}, nodes={
+				{n=G.UIT.O, config={object = view_deck}}
+			}}
+		)
+	end
+
 	local flip_col = G.C.WHITE
 
 	local suit_tallies = {}


### PR DESCRIPTION

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
