### PR TITLE
Revert a change to SMODS.calculate_destroying_cards to fix a bug related to glass cards

### DIFF
--- a/src/utils.lua
+++ b/src/utils.lua
@@ -1621,7 +1621,7 @@ function SMODS.calculate_end_of_round_effects(context)
 end
 
 function SMODS.calculate_destroying_cards(context, cards_destroyed, scoring_hand)
-    for i,card in ipairs(context.cardarea.cards) do
+    for i,card in ipairs(scoring_hand or context.cardarea.cards) do
         local destroyed = nil
         --un-highlight all cards
         if scoring_hand and SMODS.in_scoring(card, context.scoring_hand) then 


### PR DESCRIPTION
Fix a bug where if you play a High Card hand with five glass cards in the Fragile challenge, all of them break.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
