### PR TITLE
add discovery overrides to SMODS.create_card

### DIFF
--- a/lovely/center.toml
+++ b/lovely/center.toml
@@ -374,6 +374,33 @@ payload = '''
         end
     end'''
 
+[[patches]]
+[patches.pattern]
+target = 'functions/common_events.lua'
+pattern = "{bypass_discovery_center = area==G.shop_jokers or area == G.pack_cards or area == G.shop_vouchers or (G.shop_demo and area==G.shop_demo) or area==G.jokers or area==G.consumeables,"
+match_indent = true
+position = 'at'
+payload = '''
+{bypass_discovery_center = SMODS.bypass_create_card_discovery_center or area==G.shop_jokers or area == G.pack_cards or area == G.shop_vouchers or (G.shop_demo and area==G.shop_demo) or area==G.jokers or area==G.consumeables,'''
+
+[[patches]]
+[patches.pattern]
+target = 'functions/common_events.lua'
+pattern = "bypass_discovery_ui = area==G.shop_jokers or area == G.pack_cards or area==G.shop_vouchers or (G.shop_demo and area==G.shop_demo),"
+match_indent = true
+position = 'at'
+payload = '''
+bypass_discovery_ui = SMODS.bypass_create_card_discovery_center or area==G.shop_jokers or area == G.pack_cards or area==G.shop_vouchers or (G.shop_demo and area==G.shop_demo),'''
+
+[[patches]]
+[patches.pattern]
+target = 'functions/common_events.lua'
+pattern = "discover = area==G.jokers or area==G.consumeables, "
+match_indent = true
+position = 'at'
+payload = '''
+discover = SMODS.bypass_create_card_discover or area==G.jokers or area==G.consumeables, '''
+
 # Card:add_to_deck()
 [[patches]]
 [patches.regex]

--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -285,6 +285,8 @@ function SMODS.find_card(key, count_debuffed) end
 ---@field soulable? boolean Card could be replace by a legendary version, if applicable. 
 ---@field key? string Created card is forced to have a center matching this key. 
 ---@field key_append? string Appends this string to seeds. 
+---@field discover? boolean Discovers the card when created.
+---@field bypass_discovery_center? boolean Creates the card's proper sprites and UI even if it hasn't been discovered.
 ---@field no_edition? boolean Ignore natural edition application. 
 ---@field edition? string Apply this edition. 
 ---@field enhancement? string Apply this enhancement. 

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -317,8 +317,12 @@ function SMODS.create_card(t)
         t.area = G.consumeables
     end
     SMODS.bypass_create_card_edition = t.no_edition or t.edition
+    SMODS.bypass_create_card_discover = t.discover
+    SMODS.bypass_create_card_discovery_center = t.bypass_discovery_center
     local _card = create_card(t.set, t.area, t.legendary, t.rarity, t.skip_materialize, t.soulable, t.key, t.key_append)
     SMODS.bypass_create_card_edition = nil
+    SMODS.bypass_create_card_discover = nil
+    SMODS.bypass_create_card_discovery_center = nil
 
     -- Should this be restricted to only cards able to handle these
     -- or should that be left to the person calling SMODS.create_card to use it correctly?


### PR DESCRIPTION
can now specify `t.bypass_discovery_center` and `t.discover` into SMODS.create_card to define those respective parameters when creating the Card. `bypass_discovery_center` is used for both `bypass_discovery_center` and `bypass_discovery_ui` to avoid excessive fields that all look the same but i'm not confident that that's the best approach

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
