### PR TITLE
Better calc 2.3

### DIFF
--- a/lovely/better_calc.toml
+++ b/lovely/better_calc.toml
@@ -2,7 +2,6 @@
 version = "1.0.0"
 dump_lua = true
 priority = -10
-# temp solution, nothing matches if -10
 
 ## G.FUNCS.evaluate_play()
 # evaluate main scoring
@@ -1389,15 +1388,9 @@ for i=1, #G.play.cards do
     end
     local effects = {}
     SMODS.calculate_context({modify_scoring_hand = true, other_card =  G.play.cards[i], full_hand = G.play.cards, scoring_hand = scoring_hand}, effects)
-    SMODS.trigger_effects(effects, G.play.cards[i])
-    for _, eval in pairs(effects) do
-        if type(eval) == 'table' then
-            for key, eval2 in pairs(eval) do
-                if key == 'add_to_hand' or (type(eval2) == 'table' and eval2.add_to_hand) then splashed = true end
-                if key == 'remove_from_hand' or (type(eval2) == 'table' and eval2.remove_from_hand) then unsplashed = true end
-            end
-        end
-    end
+    local flags = SMODS.trigger_effects(effects, G.play.cards[i])
+    if flags.add_to_hand then splashed = true end
+	if flags.remove_from_hand then unsplashed = true end
     if splashed and not unsplashed then table.insert(final_scoring_hand, G.play.cards[i]) end
 end
 -- TARGET: adding to hand effects
@@ -1557,3 +1550,10 @@ match_indent = true
 position = 'at'
 pattern = 'if context.cardarea == G.jokers then'
 payload = 'do'
+
+[[patches]]
+[patches.regex]
+target = 'game.lua'
+position = 'at'
+pattern = 'G.GAME.blind:get_loc_debuff_text()'
+payload = 'SMODS.debuff_text or G.GAME.blind:get_loc_debuff_text()'

--- a/lovely/better_calc.toml
+++ b/lovely/better_calc.toml
@@ -398,8 +398,6 @@ payload = '''
             if eval.edition then effects[#effects+1] = eval end
 
             SMODS.trigger_effects(effects, _card)
-            local deck_effect = G.GAME.selected_back:trigger_effect({full_hand = G.play.cards, scoring_hand = scoring_hand, scoring_name = text, poker_hands = poker_hands, other_joker = _card.ability.set == 'Joker' and _card or false, other_consumeable = _card.ability.set ~= 'Joker' and _card or false})
-            if deck_effect then SMODS.calculate_effect(deck_effect, G.deck.cards[1] or G.deck) end
         end end
 '''
 # Joker effects
@@ -492,6 +490,27 @@ for _, _area in ipairs(SMODS.get_card_areas('jokers')) do
                     table.insert(effects, rt_eval)
                     for _, v in ipairs(rt_post) do effects[#effects+1] = v end
                 end
+            end
+        end
+    end
+end
+for _, _area in ipairs(SMODS.get_card_areas('individual')) do
+    local other_key = 'other_unknown'
+    if _card.ability.set == 'Joker' then other_key = 'other_joker' end
+    if _card.ability.consumeable then other_key = 'other_consumeable' end
+    if _card.ability.set == 'Voucher' then other_key = 'other_voucher' end
+    -- TARGET: add context.other_something identifier to your cards
+    local _eval,post = SMODS.eval_individual(_area, {full_hand = G.play.cards, scoring_hand = scoring_hand, scoring_name = text, poker_hands = poker_hands, [other_key] = _card, other_main = _card })
+    if next(_eval) then
+        _eval.individual.juice_card = _joker
+        table.insert(effects, _eval)
+        for _, v in ipairs(post) do effects[#effects+1] = v end
+        if _eval.retriggers then
+            for rt = 1, #_eval.retriggers do
+                local rt_eval, rt_post = SMODS.eval_individual(_area, {full_hand = G.play.cards, scoring_hand = scoring_hand, scoring_name = text, poker_hands = poker_hands, [other_key] = _card, retrigger_joker = true})
+                table.insert(effects, {_eval.retriggers[rt]})
+                table.insert(effects, rt_eval)
+                for _, v in ipairs(rt_post) do effects[#effects+1] = v end
             end
         end
     end
@@ -1528,3 +1547,13 @@ G.E_MANAGER:add_event(Event({
 
 playing_card_joker_effects({card})
 '''
+
+## Remove unneeded area check
+# Card:calculate_joker
+[[patches]]
+[patches.pattern]
+target = 'card.lua'
+match_indent = true
+position = 'at'
+pattern = 'if context.cardarea == G.jokers then'
+payload = 'do'

--- a/lovely/better_calc.toml
+++ b/lovely/better_calc.toml
@@ -33,8 +33,8 @@ position = 'at'
 match_indent = true
 payload = '''
 function eval_card(card, context)
-    if card.ability.set ~= 'Joker' and not card:can_calculate() then return {}, {} end
     context = context or {}
+    if card.ability.set ~= 'Joker' and not card:can_calculate(context.ignore_debuff) then return {}, {} end
     local ret = {}
 '''
 

--- a/lovely/blind.toml
+++ b/lovely/blind.toml
@@ -119,6 +119,15 @@ elseif not self.disabled and obj.debuff_card and type(obj.debuff_card) == 'funct
 end'''
 
 # Blind:stay_flipped()
+
+[[patches]]
+[patches.pattern]
+target = 'blind.lua'
+pattern = "function Blind:stay_flipped(area, card)"
+position = 'at'
+match_indent = true
+payload = '''function Blind:stay_flipped(area, card, from_area)'''
+
 [[patches]]
 [patches.pattern]
 target = 'blind.lua'
@@ -128,8 +137,25 @@ match_indent = true
 payload = '''
 local obj = self.config.blind
 if obj.stay_flipped and type(obj.stay_flipped) == 'function' then
-    return obj:stay_flipped(area, card)
+    return obj:stay_flipped(area, card, from_area)
 end'''
+
+
+[[patches]]
+[patches.pattern]
+target = 'cardarea.lua'
+pattern = "local stay_flipped = G.GAME and G.GAME.blind and G.GAME.blind:stay_flipped(self, card)"
+position = 'at'
+match_indent = true
+payload = '''local stay_flipped = G.GAME and G.GAME.blind and G.GAME.blind:stay_flipped(self, card, area)'''
+
+[[patches]]
+[patches.pattern]
+target = 'functions/common_events.lua'
+pattern = "local stay_flipped = G.GAME and G.GAME.blind and G.GAME.blind:stay_flipped(to, card)"
+position = 'at'
+match_indent = true
+payload = '''local stay_flipped = G.GAME and G.GAME.blind and G.GAME.blind:stay_flipped(to, card, from)'''
 
 # Blind:drawn_to_hand()
 [[patches]]
@@ -170,6 +196,22 @@ local obj = self.config.blind
 if obj.modify_hand and type(obj.modify_hand) == 'function' then
     return obj:modify_hand(cards, poker_hands, text, mult, hand_chips)
 end'''
+
+[[patches]]
+[patches.pattern]
+target = 'blind.lua'
+pattern = "function Blind:modify_hand(cards, poker_hands, text, mult, hand_chips)"
+position = 'at'
+match_indent = true
+payload = '''function Blind:modify_hand(cards, poker_hands, text, mult, hand_chips, scoring_hand)'''
+
+[[patches]]
+[patches.pattern]
+target = 'functions/state_events.lua'
+pattern = "mult, hand_chips, modded = G.GAME.blind:modify_hand(G.play.cards, poker_hands, text, mult, hand_chips)"
+position = 'at'
+match_indent = true
+payload = '''mult, hand_chips, modded = G.GAME.blind:modify_hand(G.play.cards, poker_hands, text, mult, hand_chips, scoring_hand)'''
 
 # Blind:press_play()
 [[patches]]

--- a/lovely/blind_ui.toml
+++ b/lovely/blind_ui.toml
@@ -141,6 +141,28 @@ position = 'at'
 payload = 'SMODS.juice_up_blind()'
 line_prepend = '$indent'
 
+[[patches]]
+[patches.regex]
+target = "functions/state_events.lua"
+pattern = '''hand_chips = mod_chips\(0\)(\n.*)*?\n[\t ]*(?<juice>SMODS.juice_up_blind\(\))'''
+position = 'at'
+root_capture = 'juice'
+payload = 'if SMODS.hand_debuff_source then SMODS.hand_debuff_source:juice_up(0.3,0) else SMODS.juice_up_blind() end'
+times = 1
+
+[[patches]]
+[patches.pattern]
+target = 'game.lua'
+pattern = 'G.GAME.blind.children.animatedSprite:juice_up(0.05, 0.02)'
+position = 'at'
+match_indent = true
+payload = '''if SMODS.hand_debuff_source then
+    SMODS.hand_debuff_source:juice_up(0.05, 0.1)
+else
+    G.GAME.blind.children.animatedSprite:juice_up(0.05, 0.02)
+end
+'''
+
 # remove statically added 1 from The Wheel's collection description
 [[patches]]
 [patches.regex]

--- a/lovely/can_calculate.toml
+++ b/lovely/can_calculate.toml
@@ -11,8 +11,7 @@ pattern = '''function Card:get_end_of_round_effect(context)
 position = "at"
 match_indent = true
 payload = '''
-function Card:get_end_of_round_effect(context)
-    if not self:can_calculate() then return {} end'''
+function Card:get_end_of_round_effect(context)'''
 
 [[patches]]
 [patches.pattern]
@@ -33,21 +32,17 @@ pattern = '''function Card:calculate_seal(context)
 position = "at"
 match_indent = true
 payload = '''
-function Card:calculate_seal(context)
-    if not self:can_calculate() then return {} end'''
+function Card:calculate_seal(context)'''
 
 [[patches]]
 [patches.pattern]
 target = "card.lua"
 pattern = '''function Card:calculate_joker(context)
-    if self.debuff then return nil end
-    if self.ability.set == "Planet" and not self.debuff then'''
+    if self.debuff then return nil end'''
 position = "at"
 match_indent = true
 payload = '''
-function Card:calculate_joker(context)
-    if not self:can_calculate() then return {} end
-    if self.ability.set == "Planet" and self:can_calculate() then'''
+function Card:calculate_joker(context)'''
 
 [[patches]]
 [patches.pattern]
@@ -55,5 +50,13 @@ target = "card.lua"
 pattern = '''if self.ability.set == "Joker" and not self.debuff then'''
 position = "at"
 match_indent = true
-payload = '''if self.ability.set == "Joker" and self:can_calculate() then'''
+payload = '''if self.ability.set == "Joker" then'''
 
+
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''if self.debuff then return 0 end'''
+position = "at"
+match_indent = true
+payload = ''

--- a/lovely/enhancement.toml
+++ b/lovely/enhancement.toml
@@ -282,3 +282,12 @@ pattern = "if self.seal == 'Blue' and #G.consumeables.cards + G.GAME.consumeable
 position = "at"
 payload = "if self.seal == 'Blue' and #G.consumeables.cards + G.GAME.consumeable_buffer < G.consumeables.config.card_limit and not self.ability.extra_enhancement then"
 match_indent = true
+
+# Reset extra_enhancements on set_ability
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = "function Card:set_ability(center, initial, delay_sprites)"
+position = "after"
+payload = "self.extra_enhancements = nil"
+match_indent = true

--- a/lovely/enhancement.toml
+++ b/lovely/enhancement.toml
@@ -160,7 +160,8 @@ if delay_sprites then
     })) 
 '''
 payload = '''
-if delay_sprites then 
+if delay_sprites == 'quantum' then
+elseif delay_sprites then 
     self.ability.delayed = true
     G.E_MANAGER:add_event(Event({
         func = function()

--- a/lovely/seal.toml
+++ b/lovely/seal.toml
@@ -59,6 +59,7 @@ pattern = 'function Card:calculate_seal\(context\)\n(?<indent>[\t ]*)if self.deb
 position = 'after'
 line_prepend = '$indent'
 payload = '''
+
 local obj = G.P_SEALS[self.seal] or {}
 if obj.calculate and type(obj.calculate) == 'function' then
 	local o = obj:calculate(self, context)

--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -1850,14 +1850,16 @@ function Blind:press_play()
 end
 
 local debuff_card = Blind.debuff_card
-function Blind:debuff_card(card)
-	debuff_card(self, card)
-	local flags = SMODS.calculate_context({ debuff_card = card })
+function Blind:debuff_card(card, from_blind)
+	local flags = SMODS.calculate_context({ debuff_card = card, ignore_debuff = true })
 	if flags.prevent_debuff then 
-		card:set_debuff(false)
+		if card.debuff then card:set_debuff(false) end
+		return
 	elseif flags.debuff then
-		card:set_debuff(true)
+		if not card.debuff then card:set_debuff(true) end
+		return
 	end
+	debuff_card(self, card, from_blind)
 end
 
 local debuff_hand = Blind.debuff_hand

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -1233,8 +1233,12 @@ SMODS.calculate_individual_effect = function(effect, scored_card, key, amount, f
         return true
     end
     
-    if key == 'remove' or key == 'debuff' or key == 'prevent_debuff' or key == 'add_to_hand' or key == 'remove_from_hand' then
+    if key == 'remove' or key == 'prevent_debuff' or key == 'add_to_hand' or key == 'remove_from_hand' or key == 'stay_flipped' or key == 'prevent_stay_flipped' then
         return key
+    end
+
+    if key == 'debuff' then
+        return { [key] = amount, debuff_source = scored_card }
     end
 
     if key == 'debuff_text' then 
@@ -1286,6 +1290,7 @@ SMODS.calculation_keys = {
     'saved', 'effect', 'remove',
     'debuff', 'prevent_debuff', 'debuff_text',
     'add_to_hand', 'remove_from_hand',
+    'stay_flipped', 'prevent_stay_flipped',
     'message',
     'level_up', 'func', 'extra',
 }

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -1386,13 +1386,22 @@ SMODS.calculate_retriggers = function(card, context, _ret)
             end
         end
     end
-    local deck_effect = G.GAME.selected_back:trigger_effect({retrigger_joker_check = true, other_card = card, other_context = context, other_ret = _ret})
-    if deck_effect and deck_effect.repetitions then
-        deck_effect.retrigger_card = G.GAME.selected_back
-        deck_effect.message_card = deck_effect.message_card or G.deck.cards[1] or G.deck
-        deck_effect.message = deck_effect.message or (not deck_effect.remove_default_message and localize('k_again_ex'))
-        retriggers[#retriggers + 1] = deck_effect
+
+    for _, area in ipairs(SMODS.get_card_areas('individual')) do
+        local eval, post = SMODS.eval_individual(area, {retrigger_joker_check = true, other_card = card, other_context = context, other_ret = _ret})
+        if next(post) then SMODS.trigger_effects({post}, _card) end
+        for key, value in pairs(eval) do
+            if value.repetitions then
+                for h=1, value.repetitions do
+                    value.retrigger_card = G.GAME.selected_back
+                    value.message_card = value.message_card or value.scored_card
+                    value.message = value.message or (not value.remove_default_message and localize('k_again_ex'))
+                    retriggers[#retriggers + 1] = value
+                end
+            end
+        end
     end
+
     return retriggers
 end
 

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -1111,9 +1111,9 @@ SMODS.calculate_individual_effect = function(effect, scored_card, key, amount, f
             else
                 if key ~= 'chip_mod' then
                     if effect.chip_message then
-                        card_eval_status_text(scored_card or effect.card or effect.focus, 'extra', nil, percent, nil, effect.chip_message)
+                        card_eval_status_text(effect.message_card or effect.juice_card or scored_card or effect.card or effect.focus, 'extra', nil, percent, nil, effect.chip_message)
                     else
-                        card_eval_status_text(scored_card or effect.card or effect.focus, 'chips', amount, percent)
+                        card_eval_status_text(effect.message_card or effect.juice_card or scored_card or effect.card or effect.focus, 'chips', amount, percent)
                     end
                 end
             end
@@ -1130,9 +1130,9 @@ SMODS.calculate_individual_effect = function(effect, scored_card, key, amount, f
             else
                 if key ~= 'mult_mod' then
                     if effect.mult_message then
-                        card_eval_status_text(scored_card or effect.card or effect.focus, 'extra', nil, percent, nil, effect.mult_message)
+                        card_eval_status_text(effect.message_card or effect.juice_card or scored_card or effect.card or effect.focus, 'extra', nil, percent, nil, effect.mult_message)
                     else
-                        card_eval_status_text(scored_card or effect.card or effect.focus, 'mult', amount, percent)
+                        card_eval_status_text(effect.message_card or effect.juice_card or scored_card or effect.card or effect.focus, 'mult', amount, percent)
                     end
                 end
             end
@@ -1144,9 +1144,9 @@ SMODS.calculate_individual_effect = function(effect, scored_card, key, amount, f
         ease_dollars(amount)
         if not effect.remove_default_message then
             if effect.dollar_message then
-                card_eval_status_text(scored_card or effect.card or effect.focus, 'extra', nil, percent, nil, effect.dollar_message)
+                card_eval_status_text(effect.message_card or effect.juice_card or scored_card or effect.card or effect.focus, 'extra', nil, percent, nil, effect.dollar_message)
             else
-                card_eval_status_text(scored_card or effect.card or effect.focus, 'dollars', amount, percent)
+                card_eval_status_text(effect.message_card or effect.juice_card or scored_card or effect.card or effect.focus, 'dollars', amount, percent)
             end
         end
         return true
@@ -1161,9 +1161,9 @@ SMODS.calculate_individual_effect = function(effect, scored_card, key, amount, f
             else
                 if key ~= 'Xchip_mod' then
                     if effect.xchip_message then
-                        card_eval_status_text(scored_card or effect.card or effect.focus, 'extra', nil, percent, nil, effect.xchip_message)
+                        card_eval_status_text(effect.message_card or effect.juice_card or scored_card or effect.card or effect.focus, 'extra', nil, percent, nil, effect.xchip_message)
                     else
-                        card_eval_status_text(scored_card or effect.card or effect.focus, 'x_chips', amount, percent)
+                        card_eval_status_text(effect.message_card or effect.juice_card or scored_card or effect.card or effect.focus, 'x_chips', amount, percent)
                     end
                 end
             end
@@ -1180,9 +1180,9 @@ SMODS.calculate_individual_effect = function(effect, scored_card, key, amount, f
             else
                 if key ~= 'Xmult_mod' then
                     if effect.xmult_message then
-                        card_eval_status_text(scored_card or effect.card or effect.focus, 'extra', nil, percent, nil, effect.xmult_message)
+                        card_eval_status_text(effect.message_card or effect.juice_card or scored_card or effect.card or effect.focus, 'extra', nil, percent, nil, effect.xmult_message)
                     else
-                        card_eval_status_text(scored_card or effect.card or effect.focus, 'x_mult', amount, percent)
+                        card_eval_status_text(effect.message_card or effect.juice_card or scored_card or effect.card or effect.focus, 'x_mult', amount, percent)
                     end
                 end
             end
@@ -1428,7 +1428,7 @@ function SMODS.calculate_card_areas(_type, context, return_table, args)
                 local eval, post = eval_card(_card, context)
                 if args and args.main_scoring and eval.jokers then
                     eval.jokers.juice_card = eval.jokers.juice_card or eval.jokers.card or _card
-                    eval.jokers.message_card = eval.jokers.message_card or eval.jokers.card or card
+                    eval.jokers.message_card = eval.jokers.message_card or eval.jokers.card or context.other_card
                 end
 
                 local effects = {eval}
@@ -1447,7 +1447,7 @@ function SMODS.calculate_card_areas(_type, context, return_table, args)
                         local rt_eval, rt_post = eval_card(_card, context)
                         if args and args.main_scoring and rt_eval.jokers then
                             rt_eval.jokers.juice_card = rt_eval.jokers.juice_card or rt_eval.jokers.card or _card
-                            rt_eval.jokers.message_card = rt_eval.jokers.message_card or rt_eval.jokers.card or card
+                            rt_eval.jokers.message_card = rt_eval.jokers.message_card or rt_eval.jokers.card or context.other_card
                         end
                         table.insert(effects, {eval.retriggers[rt]})
                         table.insert(effects, rt_eval)
@@ -1492,6 +1492,10 @@ function SMODS.calculate_card_areas(_type, context, return_table, args)
     if _type == 'individual' then
         for _, area in ipairs(SMODS.get_card_areas('individual')) do
             local eval, post = SMODS.eval_individual(area, context)
+            if args and args.main_scoring and eval.individual then
+                eval.individual.juice_card = eval.individual.juice_card or eval.individual.card or area.scored_card
+                eval.individual.message_card = eval.individual.message_card or eval.individual.card or context.other_card
+            end
             local effects = {eval}
             for _,v in ipairs(post) do effects[#effects+1] = v end
             if effects[1].retriggers then
@@ -1618,8 +1622,8 @@ function SMODS.calculate_end_of_round_effects(context)
             context.other_card = card
             -- context.end_of_round individual calculations
 
-            SMODS.calculate_card_areas('jokers', context, effects)
-            SMODS.calculate_card_areas('individual', context, effects)
+            SMODS.calculate_card_areas('jokers', context, effects, { main_scoring = true })
+            SMODS.calculate_card_areas('individual', context, effects, { main_scoring = true })
 
             local flags = SMODS.trigger_effects(effects, card)
 
@@ -1771,7 +1775,7 @@ function SMODS.eval_individual(individual, context)
     if type(eff) ~= 'table' then eff = nil end
 
     if (eff and not eff.no_retrigger) or triggered then
-        if type(eff) == 'table' then eff.scored_card = eff.scored_card or individual.scored_card end
+        if type(eff) == 'table' then eff.juice_card = eff.juice_card or individual.scored_card end
         ret.individual = eff
 
         if not (context.retrigger_joker_check or context.retrigger_joker) then

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -862,7 +862,7 @@ function Card:can_calculate(ignore_debuff)
 end
 
 function Card:calculate_enhancement(context)
-    if not self:can_calculate() or self.ability.set ~= 'Enhanced' then return nil end
+    if self.ability.set ~= 'Enhanced' then return nil end
     local center = self.config.center
     if center.calculate and type(center.calculate) == 'function' then
         local o = center:calculate(self, context)
@@ -1100,8 +1100,8 @@ end
 -- This function handles the calculation of each effect returned to evaluate play.
 -- Can easily be hooked to add more calculation effects ala Talisman
 SMODS.calculate_individual_effect = function(effect, scored_card, key, amount, from_edition)
-    if effect.card and effect.card ~= scored_card then juice_card(effect.card) end
     if (key == 'chips' or key == 'h_chips' or key == 'chip_mod') and amount then
+        if effect.card and effect.card ~= scored_card then juice_card(effect.card) end
         hand_chips = mod_chips(hand_chips + amount)
         update_hand_text({delay = 0}, {chips = hand_chips, mult = mult})
         if not effect.remove_default_message then
@@ -1121,6 +1121,7 @@ SMODS.calculate_individual_effect = function(effect, scored_card, key, amount, f
     end
 
     if (key == 'mult' or key == 'h_mult' or key == 'mult_mod') and amount then
+        if effect.card and effect.card ~= scored_card then juice_card(effect.card) end
         mult = mod_mult(mult + amount)
         update_hand_text({delay = 0}, {chips = hand_chips, mult = mult})
         if not effect.remove_default_message then
@@ -1140,6 +1141,7 @@ SMODS.calculate_individual_effect = function(effect, scored_card, key, amount, f
     end
 
     if (key == 'p_dollars' or key == 'dollars' or key == 'h_dollars') and amount then
+        if effect.card and effect.card ~= scored_card then juice_card(effect.card) end
         ease_dollars(amount)
         if not effect.remove_default_message then
             if effect.dollar_message then
@@ -1152,6 +1154,7 @@ SMODS.calculate_individual_effect = function(effect, scored_card, key, amount, f
     end
 
     if (key == 'x_chips' or key == 'xchips' or key == 'Xchip_mod') and amount ~= 1 then
+        if effect.card and effect.card ~= scored_card then juice_card(effect.card) end
         hand_chips = mod_chips(hand_chips * amount)
         update_hand_text({delay = 0}, {chips = hand_chips, mult = mult})
         if not effect.remove_default_message then
@@ -1171,6 +1174,7 @@ SMODS.calculate_individual_effect = function(effect, scored_card, key, amount, f
     end
 
     if (key == 'x_mult' or key == 'xmult' or key == 'Xmult' or key == 'x_mult_mod' or key == 'Xmult_mod') and amount ~= 1 then
+        if effect.card and effect.card ~= scored_card then juice_card(effect.card) end
         mult = mod_mult(mult * amount)
         update_hand_text({delay = 0}, {chips = hand_chips, mult = mult})
         if not effect.remove_default_message then
@@ -1190,6 +1194,7 @@ SMODS.calculate_individual_effect = function(effect, scored_card, key, amount, f
     end
 
     if key == 'message' then
+        if effect.card and effect.card ~= scored_card then juice_card(effect.card) end
         card_eval_status_text(effect.message_card or effect.juice_card or scored_card or effect.card or effect.focus, 'extra', nil, percent, nil, effect)
         return true
     end
@@ -1200,6 +1205,7 @@ SMODS.calculate_individual_effect = function(effect, scored_card, key, amount, f
     end
 
     if key == 'swap' then
+        if effect.card and effect.card ~= scored_card then juice_card(effect.card) end
         local old_mult = mult
         mult = mod_mult(hand_chips)
         hand_chips = mod_chips(old_mult)
@@ -1208,6 +1214,7 @@ SMODS.calculate_individual_effect = function(effect, scored_card, key, amount, f
     end
 
     if key == 'level_up' then
+        if effect.card and effect.card ~= scored_card then juice_card(effect.card) end
         local hand_type = effect.level_up_hand or G.GAME.last_hand_played
         level_up_hand(scored_card, hand_type, effect.instant, type(amount) == 'number' and amount or 1)
         return true
@@ -1276,11 +1283,11 @@ SMODS.calculation_keys = {
     'x_mult', 'Xmult', 'xmult', 'x_mult_mod', 'Xmult_mod',
     'p_dollars', 'dollars', 'h_dollars',
     'swap',
-    'message',
-    'level_up', 'func', 'extra',
     'saved', 'effect', 'remove',
     'debuff', 'prevent_debuff', 'debuff_text',
     'add_to_hand', 'remove_from_hand',
+    'message',
+    'level_up', 'func', 'extra',
 }
 
 SMODS.calculate_repetitions = function(card, context, reps)
@@ -1411,7 +1418,6 @@ SMODS.calculate_retriggers = function(card, context, _ret)
 end
 
 function Card:calculate_edition(context)
-    if not self:can_calculate() then return end
     if self.edition then
         local edition = G.P_CENTERS[self.edition.key]
         if edition.calculate and type(edition.calculate) == 'function' then
@@ -1541,7 +1547,7 @@ end
 function SMODS.calculate_context(context, return_table)
     local flags = {}
     context.main_eval = true
-    flags[#flags+1] = SMODS.calculate_card_areas('jokers', context, return_table, { joker_area = true})
+    flags[#flags+1] = SMODS.calculate_card_areas('jokers', context, return_table, { joker_area = true })
     context.main_eval = nil
     
     flags[#flags+1] = SMODS.calculate_card_areas('playing_cards', context, return_table)


### PR DESCRIPTION
## What's changed
- Structural changes to functions processing calculations
  - Reorganized `SMODS.calculate_context` using a helper function
  - "Flags" returned by `SMODS.trigger_effects`
  - `Card:can_calculate` is no longer called inside functions called from `eval_card`. `context.ignore_debuff` can be used to make debuffed cards be calculated in a context.
- Cards are no longer juiced up independently of the effect key in `SMODS.calculate_individual_effect` to account for new return values
- Added "individual objects" into the calculation pipeline. Deck effects have been integrated into this system. 
- Added the current blind as an individual object
- Added blind functions as calculation contexts: `blind_disabled`, `blind_defeated`, `press_play`, `debuff_card`, `debuff_hand`, `stay_flipped`, `modify_hand` 


## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
