### PR TITLE
Fast restart the game

### DIFF
--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -3270,11 +3270,21 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
         end,
         inject = function(_) end
     }
-
+    
     SMODS.Keybind {
         key_pressed = 'm',
         event = 'held',
         held_duration = 1.1,
+        action = function(self)
+            SMODS.save_all_config()
+		    SMODS.restart_game()
+        end
+    }
+
+    SMODS.Keybind {
+        key_pressed = 'm',
+        held_keys = { "lctrl" },
+        event = 'pressed',
         action = function(self)
             SMODS.save_all_config()
 		    SMODS.restart_game()


### PR DESCRIPTION
Added `CTRL + M` to quickly restart the game rather than a press and hold of the `M` key. Found this to be a nice addition in development.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
