### PR TITLE
Add context for adding cards to the deck

### DIFF
--- a/lovely/calculate_card_added.toml
+++ b/lovely/calculate_card_added.toml
@@ -1,0 +1,35 @@
+[manifest]
+version = "1.0.0"
+dump_lua = true
+priority = -5
+
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''if true then
+            if from_debuff then
+                self.ability.joker_added_to_deck_but_debuffed = nil
+            else
+                if self.edition and self.edition.card_limit then
+                    if self.ability.consumeable then
+                        G.consumeables.config.card_limit = G.consumeables.config.card_limit + self.edition.card_limit
+                    else
+                        G.jokers.config.card_limit = G.jokers.config.card_limit + self.edition.card_limit
+                    end
+                end
+            end
+        end
+        if G.GAME.blind and G.GAME.blind.in_blind then G.E_MANAGER:add_event(Event({ func = function() G.GAME.blind:set_blind(nil, true, nil); return true end })) end'''
+position = "after"
+match_indent = true
+payload = '''
+if not from_debuff and G.hand then
+    local is_playing_card = self.ability.set == 'Default' or self.ability.set == 'Enhanced'
+    
+    -- TARGET: calculate card_added
+
+    if not is_playing_card then
+        SMODS.calculate_context({card_added = true, card = self})
+    end
+end
+'''

--- a/lovely/calculate_card_added.toml
+++ b/lovely/calculate_card_added.toml
@@ -3,23 +3,11 @@ version = "1.0.0"
 dump_lua = true
 priority = -5
 
+# Add card_added context
 [[patches]]
 [patches.pattern]
 target = "card.lua"
-pattern = '''if true then
-            if from_debuff then
-                self.ability.joker_added_to_deck_but_debuffed = nil
-            else
-                if self.edition and self.edition.card_limit then
-                    if self.ability.consumeable then
-                        G.consumeables.config.card_limit = G.consumeables.config.card_limit + self.edition.card_limit
-                    else
-                        G.jokers.config.card_limit = G.jokers.config.card_limit + self.edition.card_limit
-                    end
-                end
-            end
-        end
-        if G.GAME.blind and G.GAME.blind.in_blind then G.E_MANAGER:add_event(Event({ func = function() G.GAME.blind:set_blind(nil, true, nil); return true end })) end'''
+pattern = '''if G.GAME.blind and G.GAME.blind.in_blind then G.E_MANAGER:add_event(Event({ func = function() G.GAME.blind:set_blind(nil, true, nil); return true end })) end'''
 position = "after"
 match_indent = true
 payload = '''
@@ -33,3 +21,4 @@ if not from_debuff and G.hand then
     end
 end
 '''
+times = 1 


### PR DESCRIPTION
Patches `Card:add_to_deck` to provide a new calculation context when adding (non-playing) cards to the deck. In addition to the card area, this context provides `context.card_added` (Boolean) and `context.card` (Card). A patch target is provided for mods that create new playing card types to exclude them manually.

I ran a simple test with a modded Joker that triggers when a Joker is obtained through any means, and it seems to work fine.

Documentation can be added if the PR is approved as is, or after changes are made.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
