### PR TITLE
added nil checks to blind calculations

### DIFF
--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -1869,10 +1869,10 @@ end
 local debuff_card = Blind.debuff_card
 function Blind:debuff_card(card, from_blind)
 	local flags = SMODS.calculate_context({ debuff_card = card, ignore_debuff = true })
-	if flags.prevent_debuff then 
+	if flags and flags.prevent_debuff then 
 		if card.debuff then card:set_debuff(false) end
 		return
-	elseif flags.debuff then
+	elseif flags and flags.debuff then
 		if not card.debuff then card:set_debuff(true) end
 		return
 	end
@@ -1896,13 +1896,13 @@ function Blind:debuff_hand(cards, hand, handname, check)
         local effects = {}
         SMODS.calculate_context({modify_scoring_hand = true, other_card =  cards[i], full_hand = cards, scoring_hand = scoring_hand}, effects)
         local flags = SMODS.trigger_effects(effects, cards[i])
-		if flags.add_to_hand then splashed = true end
-		if flags.remove_from_hand then unsplashed = true end
+		if flags and flags.add_to_hand then splashed = true end
+		if flags and flags.remove_from_hand then unsplashed = true end
         if splashed and not unsplashed then table.insert(final_scoring_hand, G.play.cards[i]) end
     end
 	local flags = SMODS.calculate_context({ debuff_hand = true, full_hand = cards, scoring_hand = final_scoring_hand, poker_hands = hand, scoring_name = handname, check = check })
-	if flags.prevent_debuff then return false end
-	if flags.debuff then
+	if flags and flags.prevent_debuff then return false end
+	if flags and flags.debuff then
 		SMODS.debuff_text = flags.debuff_text
 		SMODS.hand_debuff_source = flags.debuff_source
 		return true
@@ -1914,12 +1914,12 @@ end
 local stay_flipped = Blind.stay_flipped
 function Blind:stay_flipped(to_area, card, from_area)
 	local ret = stay_flipped(self, to_area, card, from_area)
-	local flags = SMODS.calculate_context({ to_area = to_area, from_area = from_area, other_card = card, stay_flipped = true })
+	local flags = SMODS.calculate_context({ to_area = to_area, from_area = from_area, other_card = card, stay_flipped = true }) or {}
 	local self_eval, self_post = eval_card(card, { to_area = to_area, from_area = from_area, other_card = card, stay_flipped = true })
-	local self_flags = SMODS.trigger_effects({ self_eval, self_post })
+	local self_flags = SMODS.trigger_effects({ self_eval, self_post }) or {}
 	for k,v in pairs(self_flags) do flags[k] = flags[k] or v end
-	if flags.prevent_stay_flipped then return false end
-	if flags.stay_flipped then return true end
+	if flags and flags.prevent_stay_flipped then return false end
+	if flags and flags.stay_flipped then return true end
 	return ret
 end
 
@@ -1928,5 +1928,5 @@ function Blind:modify_hand(cards, poker_hands, text, mult, hand_chips, scoring_h
 	local modded
 	_G.mult, _G.hand_chips, modded = modify_hand(self, cards, poker_hands, text, mult, hand_chips, scoring_hand)
 	local flags = SMODS.calculate_context({ modify_hand = true, poker_hands = poker_hands, scoring_name = text, scoring_hand = scoring_hand, full_hand = cards })
-	return _G.mult, _G.hand_chips, modded or flags.calculated
+	return _G.mult, _G.hand_chips, modded or (flags and flags.calculated) or false
 end


### PR DESCRIPTION
This PR adds nil checks to the new blind calculations so current mods don't break when `flags` are nil

Tested with latest Cryptid. Should fix the crash at least for now if nothing else needed attention.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ / ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ / ] I didn't modify api's or I've updated lsp definitions.
- [ / ] I didn't make new lovely files or all new lovely files have appropriate priority.
