### PR TITLE
fix deprecated gradient warn crash

### DIFF
--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -765,7 +765,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
             G.C.RARITY[self.key] = self.badge_colour
             -- Called every frame, moving deprecated prints here
             if self.gradient and type(self.gradient) == "function" then
-                sendWarnMessage(('Found `gradient` function on SMODS.Rarity object "%s". This field is deprecated; please use `SMODS.Gradient` API instead.'):format(obj.key), 'Rarity')
+                sendWarnMessage(('Found `gradient` function on SMODS.Rarity object "%s". This field is deprecated; please use `SMODS.Gradient` API instead.'):format(self.key), 'Rarity')
             end
         end,
         process_loc_text = function(self)


### PR DESCRIPTION

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
