### PR TITLE
setting playing cards to negative only draws cards during blind

### DIFF
--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -1489,7 +1489,7 @@ function Card:set_edition(edition, immediate, silent)
 							G.hand.config.real_card_limit = G.hand.config.real_card_limit + v
 						end
 						G.hand.config.card_limit = G.hand.config.card_limit + v
-						if not is_in_pack then
+						if not is_in_pack and G.GAME.blind.in_blind then
 							G.FUNCS.draw_from_deck_to_hand(v)
 						end
 						return true


### PR DESCRIPTION
prevents an issue where setting cards to negative during round end draws cards to the hand that doesn't exist
## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
