### PR TITLE
Add PreDraw function

### DIFF
--- a/src/card_draw.lua
+++ b/src/card_draw.lua
@@ -458,6 +458,12 @@ function Card:draw(layer)
     self.hover_tilt = 1
     if not self.states.visible then return end
     for _, k in ipairs(SMODS.DrawStep.obj_buffer) do
-        if SMODS.DrawSteps[k]:check_conditions(self, layer) then SMODS.DrawSteps[k].func(self, layer) end
+        if SMODS.DrawSteps[k]:check_conditions(self, layer) then 
+            local center = self.config.center
+            if center.pre_draw and type(center.pre_draw) == 'function' then
+                center:pre_draw(self, SMODS.DrawSteps[k])
+            end
+            SMODS.DrawSteps[k].func(self, layer) 
+        end
     end
 end


### PR DESCRIPTION
This function will allow code to be ran before each DrawStep, such as modifying the draw parameters for weird sized cards.
Purpose:
I have a 290 x 285 card that I want stickers to show up at normal size, which requires resizing them in the middle of a card draw.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
