### PR TITLE
Blue Seal crash fix

### DIFF
--- a/lovely/fixes.toml
+++ b/lovely/fixes.toml
@@ -691,3 +691,13 @@ payload = """if SMODS.seeing_double_check(context.scoring_hand, 'Clubs') then
 end"""
 overwrite = true
 match_indent = true
+
+# Card:get_end_of_round_effect
+# prevents Blue Seal crash from a hand with no matching planet card (spawns random planet card)
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = """local card = create_card(card_type,G.consumeables, nil, nil, nil, nil, _planet, 'blusl')"""
+position = 'before'
+payload = """if _planet == 0 then _planet = nil end"""
+match_indent = true


### PR DESCRIPTION
Prevents crash from Blue Seal attempting to create a non-existent planet card for a custom winning hand that lacks one. (Causes a random planet card to be rewarded instead.)



## Additional Info:
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [X] I didn't make new lovely files or all new lovely files have appropriate priority.
