### PR TITLE
Fix crash when area.cards is nil in SMODS.find_card

### DIFF
--- a/src/utils.lua
+++ b/src/utils.lua
@@ -344,9 +344,11 @@ function SMODS.find_card(key, count_debuffed)
     local results = {}
     if not G.jokers or not G.jokers.cards then return {} end
     for _, area in ipairs(SMODS.get_card_areas('jokers')) do
-        for _, v in pairs(area.cards) do
-            if v and type(v) == 'table' and v.config.center.key == key and (count_debuffed or not v.debuff) then
-                table.insert(results, v)
+        if area.cards then
+            for _, v in pairs(area.cards) do
+                if v and type(v) == 'table' and v.config.center.key == key and (count_debuffed or not v.debuff) then
+                    table.insert(results, v)
+                end
             end
         end
     end


### PR DESCRIPTION
In rare cases, the `cards` field of the `area` variable in `SMODS.find_card` can be nil, which causes a crash when calling `pairs(area.cards)`.

Crash example clip:
https://www.twitch.tv/edzyttv/clip/ColdAliveTruffleGingerPower-6tN0hLfSlknG8t_4

A simple nil check has been added to prevent the issue.