### PR TITLE
Fix to crash upon loading a new profile

### DIFF
--- a/lovely/enhancement.toml
+++ b/lovely/enhancement.toml
@@ -323,5 +323,5 @@ match_indent = true
 target = 'card.lua'
 pattern = 'if not initial then G.GAME.blind:debuff_card(self) end'
 position = 'at'
-payload = 'if not initial and delay_sprites ~= "quantum" then G.GAME.blind:debuff_card(self) end'
+payload = 'if not initial and delay_sprites ~= "quantum" and G.GAME.blind then G.GAME.blind:debuff_card(self) end'
 match_indent = true


### PR DESCRIPTION
# Issue
Game crash upon loading a new profile

# Fix
Add a check within `set_ability` to make sure that `G.GAME.blind` exists before attempting to debuff cards. There's some gamestates where `set_ability` is called outside of a blind existing. 

# Files modified
`lovely/enhancement.toml`
* Added check for `G.GAME.blind` before calling upon it to debuff cards. 

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
