### PR TITLE
Fix incorrect removal of used_jokers

### DIFF
--- a/lovely/pool.toml
+++ b/lovely/pool.toml
@@ -142,7 +142,7 @@ end
 [[patches]]
 [patches.pattern]
 target = "card.lua"
-pattern = "local old_center = self.config.center"
+pattern = "self.config.center = center"
 position = 'after'
 payload = '''
 if old_center and not next(SMODS.find_card(old_center.key, true)) then


### PR DESCRIPTION
When a card is changed into a new joker, the old joker is still set in `G.GAME.used_jokers`
This is due to the location of the `G.GAME.used_jokers[old_center.key] = nil` code.
It occurs before you change the current card's key, so there will still be a joker present to be found with `SMODS.find_card(old_center.key, true)`.

I shifted the code to be after changing the `self.config.center` which will remove it from any `find_card` search and will remove it from `used_jokers` correctly.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
