### PR TITLE
Hand limit API

### DIFF
--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -218,6 +218,7 @@ return {
             b_deckskins_lc = 'Low Contrast Colors',
             b_deckskins_hc = 'High Contrast Colors',
             b_deckskins_def = 'Default Colors',
+            b_limit = 'Limit: '
 		},
 		v_dictionary = {
 			c_types = '#1# Types',

--- a/lovely/hand_limit.toml
+++ b/lovely/hand_limit.toml
@@ -1,0 +1,82 @@
+[manifest]
+version = "1.0.0"
+dump_lua = true
+priority = -10
+
+# Add starting params
+[[patches]]
+[patches.pattern]
+target = 'functions/misc_functions.lua'
+match_indent = true
+position = 'before'
+pattern = '''
+consumable_slots = 2,
+'''
+payload = '''
+play_limit = 5,
+discard_limit = 5,
+'''
+
+
+# Change hand limit
+[[patches]]
+[patches.pattern]
+target = 'functions/button_callbacks.lua'
+match_indent = true
+position = 'at'
+pattern = '''
+if #G.hand.highlighted <= 0 or G.GAME.blind.block_play or #G.hand.highlighted > 5 then 
+'''
+payload = '''
+if #G.hand.highlighted <= 0 or G.GAME.blind.block_play or #G.hand.highlighted > G.GAME.starting_params.play_limit then 
+'''
+
+# Change discard limit
+[[patches]]
+[patches.pattern]
+target = 'functions/button_callbacks.lua'
+match_indent = true
+position = 'at'
+pattern = '''
+if G.GAME.current_round.discards_left <= 0 or #G.hand.highlighted <= 0 then 
+'''
+payload = '''
+if G.GAME.current_round.discards_left <= 0 or #G.hand.highlighted <= 0 or #G.hand.highlighted > G.GAME.starting_params.discard_limit then 
+'''
+
+# Add play limit indicator to UI
+[[patches]]
+[patches.pattern]
+target = 'functions/UI_definitions.lua'
+match_indent = true
+position = 'after'
+pattern = '''
+{n=G.UIT.R, config={align = "bcm", padding = 0}, nodes={
+    {n=G.UIT.T, config={text = localize('b_play_hand'), scale = text_scale, colour = G.C.UI.TEXT_LIGHT, focus_args = {button = 'x', orientation = 'bm'}, func = 'set_button_pip'}}
+}},
+'''
+payload = '''
+{n=G.UIT.R, config={align = "bcm", padding = 0}, nodes = {
+    {n=G.UIT.T, config={text = localize('b_limit'), scale = text_scale * 0.65, colour = G.C.UI.TEXT_LIGHT}},
+    {n=G.UIT.T, config={ref_table = G.GAME.starting_params, ref_value = 'play_limit', scale = text_scale * 0.65, colour = G.C.UI.TEXT_LIGHT}}
+}},
+'''
+# Add discard limit indicator to UI
+[[patches]]
+[patches.pattern]
+target = 'functions/UI_definitions.lua'
+match_indent = true
+position = 'at'
+pattern = '''
+{n=G.UIT.R, config={align = "cm", padding = 0}, nodes={
+    {n=G.UIT.T, config={text = localize('b_discard'), scale = text_scale, colour = G.C.UI.TEXT_LIGHT, focus_args = {button = 'y', orientation = 'bm'}, func = 'set_button_pip'}}
+}}'''
+payload = '''
+{n=G.UIT.R, config={align = "cm", padding = 0}, nodes={
+    {n=G.UIT.T, config={text = localize('b_discard'), scale = text_scale, colour = G.C.UI.TEXT_LIGHT, focus_args = {button = 'y', orientation = 'bm'}, func = 'set_button_pip'}}
+}},
+{n=G.UIT.R, config={align = "cm", padding = 0}, nodes={
+    {n=G.UIT.T, config={text = localize('b_limit'), scale = text_scale * 0.65, colour = G.C.UI.TEXT_LIGHT}},
+    {n=G.UIT.T, config={ref_table = G.GAME.starting_params, ref_value = 'discard_limit', scale = text_scale * 0.65, colour = G.C.UI.TEXT_LIGHT}}
+}},
+'''

--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -454,6 +454,14 @@ function SMODS.change_booster_limit(mod) end
 --- Modifies the current amount of free shop rerolls by `mod`. 
 function SMODS.change_free_rerolls(mod) end
 
+---@param mod number
+--- Modifies the amount of cards you are allowed to play by `mod`. 
+function SMODS.change_play_limit(mod) end
+
+---@param mod number
+--- Modifies the amount of cards you are allowed to discard by `mod`. 
+function SMODS.change_discard_limit(mod) end
+
 ---@param message string
 ---@param logger? string
 --- Prints to the console at "DEBUG" level

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2194,3 +2194,22 @@ function SMODS.seeing_double_check(hand, suit)
     end
     if saw_double(suit_tally, suit) then return true else return false end
 end
+
+-- Hand Limit API
+function SMODS.change_play_limit(mod)
+    G.GAME.starting_params.play_limit = G.GAME.starting_params.play_limit + mod
+    if G.GAME.starting_params.play_limit < 1 then
+        sendErrorMessage('Play limit cannot be less than 1', 'HandLimitAPI')
+        G.GAME.starting_params.play_limit = 1
+    end
+    G.hand.config.highlighted_limit = math.max(G.GAME.starting_params.discard_limit, G.GAME.starting_params.play_limit, 5)
+end
+
+function SMODS.change_discard_limit(mod)
+    G.GAME.starting_params.discard_limit = G.GAME.starting_params.discard_limit + mod
+    if G.GAME.starting_params.discard_limit < 0 then
+        sendErrorMessage('Discard limit cannot be less than 0', 'HandLimitAPI')
+        G.GAME.starting_params.discard_limit = 0
+    end
+    G.hand.config.highlighted_limit = math.max(G.GAME.starting_params.discard_limit, G.GAME.starting_params.play_limit, 5)
+end


### PR DESCRIPTION
Adds `SMODS.change_play_limit(mod)` and `SMODS.change_discard_limit(mod)` to control the number of cards you are able to play and discard independently of each other.

Adding as a PR then I don't scuff up everyone's lovely patches that do this effect in their own ways, and people can be prepared to adjust when it's merged.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [X] I didn't modify api's or I've updated lsp definitions.
- [X] I didn't make new lovely files or all new lovely files have appropriate priority.
