### PR TITLE
Add in_scoring field to modify_scoring_hand context

### DIFF
--- a/lovely/better_calc.toml
+++ b/lovely/better_calc.toml
@@ -1417,7 +1417,7 @@ for i=1, #G.play.cards do
         end
     end
     local effects = {}
-    SMODS.calculate_context({modify_scoring_hand = true, other_card =  G.play.cards[i], full_hand = G.play.cards, scoring_hand = scoring_hand}, effects)
+    SMODS.calculate_context({modify_scoring_hand = true, other_card =  G.play.cards[i], full_hand = G.play.cards, scoring_hand = scoring_hand, in_scoring = true}, effects)
     local flags = SMODS.trigger_effects(effects, G.play.cards[i])
     if flags.add_to_hand then splashed = true end
 	if flags.remove_from_hand then unsplashed = true end


### PR DESCRIPTION
This allows for selectively deciding which card effects trigger in modify_scoring_hand when the blind checks if the hand should be debuffed (such as selecting a card in hand or just before scoring) vs when the final hand is actually decided. I believe a flag is better than a cardarea check because debuff_hand happens both in hand and in play, but maybe there's a better way.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
