### PR TITLE
Fixed card_limit cards not being buyable at full room

### DIFF
--- a/lovely/edition.toml
+++ b/lovely/edition.toml
@@ -182,6 +182,35 @@ position = "after"
 payload = "joker_added_to_deck_but_debuffed = self.joker_added_to_deck_but_debuffed,"
 match_indent = true
 
+## Buying card_limit cards fix
+# G.FUNCS.check_for_buy_space
+[[patches]]
+[patches.pattern]
+target = "functions/button_callbacks.lua"
+pattern = "    not (card.ability.consumeable and #G.consumeables.cards < G.consumeables.config.card_limit + ((card.edition and card.edition.negative) and 1 or 0)) then"
+position = "at"
+match_indent = true
+payload = '''
+    not (card.ability.consumeable and #G.consumeables.cards < G.consumeables.config.card_limit + ((card.edition and card.edition.card_limit and card.edition.card_limit >= 1) and 1 or 0)) then
+'''
+times = 1
+
+# G.FUNCS.check_for_buy_space
+[[patches]]
+[patches.pattern]
+target = "functions/button_callbacks.lua"
+pattern = "not (card.ability.set == 'Joker' and #G.jokers.cards < G.jokers.config.card_limit + ((card.edition and card.edition.negative) and 1 or 0)) and"
+position = "at"
+match_indent = true
+payload = '''
+    not (card.ability.set == 'Joker' and #G.jokers.cards < G.jokers.config.card_limit + ((card.edition and card.edition.card_limit and card.edition.card_limit >= 1) and 1 or 0)) and
+'''
+times = 1
+
+
+
+
+
 
 ## Negative playing card logic
 # CardArea:emplace()


### PR DESCRIPTION
Small fix to G.FUNCS.check_for_buy_space to allow cards with an edition that changes your card limit to be bought in the shop.



## Additional Info:
- [V] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [V] I didn't modify api's or I've updated lsp definitions.
- [V] I didn't make new lovely files or all new lovely files have appropriate priority.
