### PR TITLE
Add rotation/offset support for shiny stickers in SMODS.DrawStep

### DIFF
--- a/src/card_draw.lua
+++ b/src/card_draw.lua
@@ -414,7 +414,7 @@ SMODS.DrawStep {
             local sticker_offset = self.sticker_offset or {}
             G.shared_stickers[self.sticker]:draw_shader('dissolve', nil, nil, true, self.children.center, nil, self.sticker_rotation, sticker_offset.x, sticker_offset.y)
             local stake = G.P_STAKES['stake_'..string.lower(self.sticker)] or {}
-            if stake.shiny then G.shared_stickers[self.sticker]:draw_shader('voucher', nil, self.ARGS.send_to_shader, true, self.children.center) end
+            if stake.shiny then G.shared_stickers[self.sticker]:draw_shader('voucher', nil, self.ARGS.send_to_shader, true, self.children.center, nil, self.sticker_rotation, sticker_offset.x, sticker_offset.y) end
         end
     end,
     conditions = { vortex = false, facing = 'back' },


### PR DESCRIPTION
Adds support for sticker rotation/offset for shiny stickers in SMODS.DrawStep by properly rotating/offsetting both the sticker itself and the "shiny" shader instead of only the sticker.

Also, this code was originally my badly implemented way to rotate/offset the sticker and can result in visual issues, so if there's a better method I don't know about let me know.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [X] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [X] I didn't modify api's or I've updated lsp definitions.
- [X] I didn't make new lovely files or all new lovely files have appropriate priority.
