### PR TITLE
Better catch for non-vanilla scaling factors

### DIFF
--- a/lovely/stake.toml
+++ b/lovely/stake.toml
@@ -123,7 +123,7 @@ match_indent = true
 target = "functions/misc_functions.lua"
 pattern = 'function get_blind_amount(ante)'
 position = "after"
-payload = '''if G.GAME.modifiers.scaling and G.GAME.modifiers.scaling > 3 then return SMODS.get_blind_amount(ante) end'''
+payload = '''if G.GAME.modifiers.scaling and (G.GAME.modifiers.scaling ~= 1 and G.GAME.modifiers.scaling ~= 2 and G.GAME.modifiers.scaling ~= 3) then return SMODS.get_blind_amount(ante) end'''
 match_indent = true
 
 # set_joker_usage


### PR DESCRIPTION
Vanilla `get_blind_amount` expects exactly 1, 2, 3, or nil; call `SMODS.get_blind_amount` for _any_ other value rather than only values exceeding 3. (e.g. decimal, negative, zero)
## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
