### PR TITLE
Dedicated functions for listed probabilities

### DIFF
--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -167,6 +167,15 @@ return {
                     "{C:mult}#1#{} Mult",
                 },
             },
+            m_lucky={
+                name="Lucky Card",
+                text={
+                    "{C:green}#1# in #3#{} chance",
+                    "for {C:mult}+#2#{} Mult",
+                    "{C:green}#6# in #5#{} chance",
+                    "to win {C:money}$#4#",
+                },
+            },
         }
     },
     misc = {

--- a/lovely/better_calc.toml
+++ b/lovely/better_calc.toml
@@ -603,7 +603,7 @@ for j = 1, #G.jokers.cards do
 
 end
 
-if SMODS.has_enhancement(scoring_hand[i], 'm_glass') and scoring_hand[i]:can_calculate() and pseudorandom('glass') < G.GAME.probabilities.normal/(scoring_hand[i].ability.name == 'Glass Card' and scoring_hand[i].ability.extra or G.P_CENTERS.m_glass.config.extra) then
+if SMODS.has_enhancement(scoring_hand[i], 'm_glass') and scoring_hand[i]:can_calculate() and SMODS.pseudorandom_probability(scoring_hand[i], 'glass', 1, scoring_hand[i].ability.name == 'Glass Card' and scoring_hand[i].ability.extra or G.P_CENTERS.m_glass.config.extra) then
     destroyed = true
 end
 

--- a/lovely/listed_probabilities.toml
+++ b/lovely/listed_probabilities.toml
@@ -1,0 +1,52 @@
+[manifest]
+version = "1.0.0"
+dump_lua = true
+priority = -5
+
+# Listed pseudorandom probabilities in cards
+[[patches]]
+[patches.regex]
+target = 'card.lua'
+pattern = '''pseudorandom\((.*?)\) ?< ?G\.GAME\.probabilities\.normal ?\/ ?(.*?)( |\)|$)'''
+position = 'at'
+payload = "SMODS.pseudorandom_probability(self, $1, 1, $2)$3"
+
+# The Wheel
+# Don't have to modify loc_debuff_text since that's already done via override
+# Also don't have for HUD_blind_debuff_prefix since SMODS makes it unused
+[[patches]]
+[patches.pattern]
+target = "blind.lua"
+pattern = '''if self.name == 'The Wheel' and pseudorandom(pseudoseed('wheel')) < G.GAME.probabilities.normal/7 then'''
+position = "at"
+match_indent = true
+payload = '''if self.name == 'The Wheel' and SMODS.pseudorandom_probability(self, pseudoseed('wheel'), 1, 7) then'''
+
+# Listed probabilities vars in Jokers
+[[patches]]
+[patches.regex]
+target = 'card.lua'
+pattern = '''''\.\.\(G.GAME and G.GAME.probabilities.normal or 1\), ?([a-z.]+)'''
+position = 'at'
+payload = "''..SMODS.get_probability_vars_table(self, 1, $1)[1], SMODS.get_probability_vars_table(self, 1, $1)[2]"
+
+# Listed probabilities vars in Hallucination (it's formatted differently for some reason)
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''elseif self.ability.name == 'Hallucination' then loc_vars = {G.GAME.probabilities.normal, self.ability.extra}'''
+position = "at"
+match_indent = true
+payload = '''elseif self.ability.name == 'Hallucination' then loc_vars = {''..SMODS.get_probability_vars_table(self, 1, self.ability.extra)[1], SMODS.get_probability_vars_table(self, 1, self.ability.extra)[2]}'''
+
+# Listed probabilities vars in Glass Card and Wheel of Fortune
+# Using regex to match inside a line
+[[patches]]
+[patches.regex]
+target = 'functions/common_events.lua'
+pattern = '''G.GAME.probabilities.normal, cfg.extra'''
+position = 'at'
+payload = "SMODS.get_probability_vars_table(card, 1, cfg.extra)[1], SMODS.get_probability_vars_table(card, 1, cfg.extra)[2]"
+
+# Listed probabilities vars in Lucky Card
+# TODO: Must add another loc var

--- a/lovely/listed_probabilities.toml
+++ b/lovely/listed_probabilities.toml
@@ -47,6 +47,3 @@ target = 'functions/common_events.lua'
 pattern = '''G.GAME.probabilities.normal, cfg.extra'''
 position = 'at'
 payload = "SMODS.get_probability_vars_table(card, 1, cfg.extra)[1], SMODS.get_probability_vars_table(card, 1, cfg.extra)[2]"
-
-# Listed probabilities vars in Lucky Card
-# TODO: Must add another loc var

--- a/lovely/perma_bonus.toml
+++ b/lovely/perma_bonus.toml
@@ -211,7 +211,7 @@ position = "at"
 match_indent = true
 payload = '''local ret = self.ability.perma_mult or 0
 if self.ability.effect == "Lucky Card" then
-    if pseudorandom('lucky_mult') < G.GAME.probabilities.normal/5 then
+    if SMODS.pseudorandom_probability(self, 'lucky_mult', 1, 5) then
         self.lucky_trigger = true
         ret = ret + self.ability.mult
     end

--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -510,3 +510,25 @@ function SMODS.signed_dollars(val) end
 ---@return number
 --- Returns result of multiplying `base` and `perma + 1`. 
 function SMODS.multiplicative_stacking(base, perma) end
+
+---@param card table|nil
+---@param base_numerator number
+---@param base_denominator number
+---@return number numerator
+---@return number denominator
+--- Returns a *`numerator` in `denominator`* listed probability opportunely modified by in-game effects
+--- starting from a *`base_numerator` in `base_denominator`* probability. 
+--- 
+--- Can be hooked for more complex probability behaviour. `card` is optionally the object that queues the probability.
+function SMODS.get_probability_vars(card, base_numerator, base_denominator) end
+
+---@param card table|nil
+---@param seed string|number
+---@param base_numerator number
+---@param base_denominator number
+---@return boolean
+--- Sets the seed to `seed` and runs a *`base_numerator` in `base_denominator`* listed probability check. 
+--- Returns `true` if the probability succeeds. You do not need to multiply `base_numerator` by `G.GAME.probabilities.normal`. 
+--- 
+--- Can be hooked to run code when a listed probability succeeds and/or fails. `card` is optionally the object that queues the probability.
+function SMODS.pseudorandom_probability(card, seed, base_numerator, base_denominator) end

--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -523,6 +523,14 @@ function SMODS.multiplicative_stacking(base, perma) end
 function SMODS.get_probability_vars(trigger_obj, base_numerator, base_denominator) end
 
 ---@param trigger_obj table|nil
+---@param base_numerator number
+---@param base_denominator number
+---@return [number, number]
+--- Has the same functionality of `SMODS.get_probability_vars`, but returns a table in the form `{[1] = numerator, [2] = denominator}`. 
+--- This function calls `SMODS.get_probability_vars()`, hook that instead. 
+function SMODS.get_probability_vars_table(trigger_obj, base_numerator, base_denominator) end
+
+---@param trigger_obj table|nil
 ---@param seed string|number
 ---@param base_numerator number
 ---@param base_denominator number

--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -511,7 +511,7 @@ function SMODS.signed_dollars(val) end
 --- Returns result of multiplying `base` and `perma + 1`. 
 function SMODS.multiplicative_stacking(base, perma) end
 
----@param card table|nil
+---@param trigger_obj table|nil
 ---@param base_numerator number
 ---@param base_denominator number
 ---@return number numerator
@@ -519,10 +519,10 @@ function SMODS.multiplicative_stacking(base, perma) end
 --- Returns a *`numerator` in `denominator`* listed probability opportunely modified by in-game effects
 --- starting from a *`base_numerator` in `base_denominator`* probability. 
 --- 
---- Can be hooked for more complex probability behaviour. `card` is optionally the object that queues the probability.
-function SMODS.get_probability_vars(card, base_numerator, base_denominator) end
+--- Can be hooked for more complex probability behaviour. `trigger_obj` is optionally the object that queues the probability.
+function SMODS.get_probability_vars(trigger_obj, base_numerator, base_denominator) end
 
----@param card table|nil
+---@param trigger_obj table|nil
 ---@param seed string|number
 ---@param base_numerator number
 ---@param base_denominator number
@@ -530,5 +530,5 @@ function SMODS.get_probability_vars(card, base_numerator, base_denominator) end
 --- Sets the seed to `seed` and runs a *`base_numerator` in `base_denominator`* listed probability check. 
 --- Returns `true` if the probability succeeds. You do not need to multiply `base_numerator` by `G.GAME.probabilities.normal`. 
 --- 
---- Can be hooked to run code when a listed probability succeeds and/or fails. `card` is optionally the object that queues the probability.
-function SMODS.pseudorandom_probability(card, seed, base_numerator, base_denominator) end
+--- Can be hooked to run code when a listed probability succeeds and/or fails. `trigger_obj` is optionally the object that queues the probability.
+function SMODS.pseudorandom_probability(trigger_obj, seed, base_numerator, base_denominator) end

--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -1647,16 +1647,19 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
     SMODS.Blind:take_ownership('wheel', {
         -- TODO: Have to add a new loc var
         loc_vars = function(self)
-            return { vars = { G.GAME.probabilities.normal } }
+            local numerator, denominator = SMODS.get_probability_vars(self, 1, 7)
+            return { vars = { numerator, denominator } }
         end,
         collection_loc_vars = function(self)
-            return { vars = { '1' }}
+            return { vars = { '1', '7' }}
         end,
         process_loc_text = function(self)
             local text = G.localization.descriptions.Blind[self.key].text[1]
             if string.sub(text, 1, 3) ~= '#1#' then
                 G.localization.descriptions.Blind[self.key].text[1] = "#1#"..text
             end
+            -- Is this too much hacky?
+            G.localization.descriptions.Blind[self.key].text[1] = string.gsub(G.localization.descriptions.Blind[self.key].text[1], "7", "#2#")
             SMODS.Blind.process_loc_text(self)
         end,
         get_loc_debuff_text = function() return G.GAME.blind.loc_debuff_text end,

--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -1645,7 +1645,6 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
         end
     })
     SMODS.Blind:take_ownership('wheel', {
-        -- TODO: Have to add a new loc var
         loc_vars = function(self)
             local numerator, denominator = SMODS.get_probability_vars(self, 1, 7)
             return { vars = { numerator, denominator } }

--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -1645,6 +1645,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
         end
     })
     SMODS.Blind:take_ownership('wheel', {
+        -- TODO: Have to add a new loc var
         loc_vars = function(self)
             return { vars = { G.GAME.probabilities.normal } }
         end,
@@ -3031,7 +3032,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
 
     SMODS.Enhancement:take_ownership('glass', {
         calculate = function(self, card, context)
-            if context.destroy_card and context.cardarea == G.play and context.destroy_card == card and pseudorandom('glass') < G.GAME.probabilities.normal/card.ability.extra then
+            if context.destroy_card and context.cardarea == G.play and context.destroy_card == card and SMODS.pseudorandom_probability(card, 'glass', 1, card.ability.extra) then
                 return { remove = true }
             end
         end,

--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -3037,6 +3037,14 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
             end
         end,
     })
+    SMODS.Enhancement:take_ownership('lucky', {
+        loc_vars = function (self, info_queue, card)
+            local cfg = (card and card.ability) or self.config
+            local numerator_mult, denominator_mult = SMODS.get_probability_vars(card, 1, 5)
+            local numerator_dollars, denominator_dollars = SMODS.get_probability_vars(card, 1, 15)
+            return {vars = {numerator_mult, cfg.mult, denominator_mult, cfg.p_dollars, denominator_dollars, numerator_dollars}}
+        end,
+    })
 
     -------------------------------------------------------------------------------------------------
     ----- API CODE GameObject.Shader

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2279,3 +2279,15 @@ function SMODS.get_multi_boxes(multi_box)
     end
     return multi_boxes
 end
+
+function SMODS.get_probability_ratio(base_ratio, card)
+    return base_ratio * G.GAME.probabilities.normal
+end
+
+function SMODS.probability_calculate(seed, ratio, card)
+    return pseudorandom(seed) < SMODS.get_probability_ratio(ratio, card)
+end
+
+function SMODS.get_probability_vars(numerator, denominator, card)
+    return {numerator * G.GAME.probabilities.normal, denominator}
+end

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2281,7 +2281,7 @@ function SMODS.get_multi_boxes(multi_box)
 end
 
 function SMODS.get_probability_vars(trigger_obj, base_numerator, base_denominator)
-    return base_numerator * G.GAME.probabilities.normal, base_denominator
+    return base_numerator * (G.GAME and G.GAME.probabilities.normal or 1), base_denominator
 end
 
 function SMODS.get_probability_vars_table(trigger_obj, base_numerator, base_denominator)

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2284,6 +2284,11 @@ function SMODS.get_probability_vars(trigger_obj, base_numerator, base_denominato
     return base_numerator * G.GAME.probabilities.normal, base_denominator
 end
 
+function SMODS.get_probability_vars_table(trigger_obj, base_numerator, base_denominator)
+    local numerator, denominator = SMODS.get_probability_vars(trigger_obj, base_numerator, base_denominator)
+    return {numerator, denominator}
+end
+
 function SMODS.pseudorandom_probability(trigger_obj, seed, base_numerator, base_denominator)
     print("TODO: REMOVE THIS!")
     local numerator, denominator = SMODS.get_probability_vars(trigger_obj, base_numerator, base_denominator)

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2285,6 +2285,6 @@ function SMODS.get_probability_vars(card, base_numerator, base_denominator)
 end
 
 function SMODS.pseudorandom_probability(card, seed, base_numerator, base_denominator)
-    local numerator, denominator = SMODS.get_probability_vars(base_numerator, base_denominator, card)
+    local numerator, denominator = SMODS.get_probability_vars(card, base_numerator, base_denominator)
     return pseudorandom(seed) < numerator / denominator
 end

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2289,5 +2289,5 @@ function SMODS.probability_calculate(seed, ratio, card)
 end
 
 function SMODS.get_probability_vars(numerator, denominator, card)
-    return {numerator * G.GAME.probabilities.normal, denominator}
+    return numerator * G.GAME.probabilities.normal, denominator
 end

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2280,11 +2280,11 @@ function SMODS.get_multi_boxes(multi_box)
     return multi_boxes
 end
 
-function SMODS.get_probability_vars(numerator, denominator, card)
-    return numerator * G.GAME.probabilities.normal, denominator
+function SMODS.get_probability_vars(card, base_numerator, base_denominator)
+    return base_numerator * G.GAME.probabilities.normal, base_denominator
 end
 
-function SMODS.pseudorandom_probability(seed, base_numerator, base_denominator, card)
+function SMODS.pseudorandom_probability(card, seed, base_numerator, base_denominator)
     local numerator, denominator = SMODS.get_probability_vars(base_numerator, base_denominator, card)
     return pseudorandom(seed) < numerator / denominator
 end

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2280,14 +2280,11 @@ function SMODS.get_multi_boxes(multi_box)
     return multi_boxes
 end
 
-function SMODS.get_probability_ratio(base_ratio, card)
-    return base_ratio * G.GAME.probabilities.normal
-end
-
-function SMODS.probability_calculate(seed, ratio, card)
-    return pseudorandom(seed) < SMODS.get_probability_ratio(ratio, card)
-end
-
 function SMODS.get_probability_vars(numerator, denominator, card)
     return numerator * G.GAME.probabilities.normal, denominator
+end
+
+function SMODS.pseudorandom_probability(seed, base_numerator, base_denominator, card)
+    local numerator, denominator = SMODS.get_probability_vars(base_numerator, base_denominator, card)
+    return pseudorandom(seed) < numerator / denominator
 end

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2290,7 +2290,6 @@ function SMODS.get_probability_vars_table(trigger_obj, base_numerator, base_deno
 end
 
 function SMODS.pseudorandom_probability(trigger_obj, seed, base_numerator, base_denominator)
-    print("TODO: REMOVE THIS!")
     local numerator, denominator = SMODS.get_probability_vars(trigger_obj, base_numerator, base_denominator)
     return pseudorandom(seed) < numerator / denominator
 end

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2280,11 +2280,12 @@ function SMODS.get_multi_boxes(multi_box)
     return multi_boxes
 end
 
-function SMODS.get_probability_vars(card, base_numerator, base_denominator)
+function SMODS.get_probability_vars(trigger_obj, base_numerator, base_denominator)
     return base_numerator * G.GAME.probabilities.normal, base_denominator
 end
 
-function SMODS.pseudorandom_probability(card, seed, base_numerator, base_denominator)
-    local numerator, denominator = SMODS.get_probability_vars(card, base_numerator, base_denominator)
+function SMODS.pseudorandom_probability(trigger_obj, seed, base_numerator, base_denominator)
+    print("TODO: REMOVE THIS!")
+    local numerator, denominator = SMODS.get_probability_vars(trigger_obj, base_numerator, base_denominator)
     return pseudorandom(seed) < numerator / denominator
 end


### PR DESCRIPTION
Some functions have been added to SMODS:

- `SMODS.get_probability_vars(trigger_obj, base_numerator, base_denominator)`: Returns the numerator and denominator of a listed probability with appropriate modifications.
- `SMODS.pseudorandom_probability(trigger_obj, seed, base_numerator, base_denominator)`: Runs a listed probability check. Basically equal to `pseudorandom(seed) < G.GAME.probabilities.normal*base_numerator/base_denominator`.
- `SMODS.get_probability_vars_table(trigger_obj, base_numerator, base_denominator)`: An alternate version of `SMODS.get_probability_vars` that returns a tuple instead of two numbers.

This PR also includes LSP definitions and all the patches and overrides needed such that these methods are used in vanilla.

This suggestions makes working with listed probabilities generally much easier. Not only the pseudorandom comparisions are made by a function instead of manually, but you can hook `SMODS.get_probability_vars` for greater control of listed probabilities (for example +probabilities or fixed probabilities) or hook `SMODS.pseudorandom_probability` to run code when a listed probability succeeds or fails.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
