### PR TITLE
Unlock deck popup now includes unlock description

### DIFF
--- a/lovely/ui_elements.toml
+++ b/lovely/ui_elements.toml
@@ -128,3 +128,24 @@ pattern = "if self.highlighted[1] then"
 position = "at"
 payload = "if #self.highlighted >= self.config.highlighted_limit then"
 match_indent = true
+
+# Deck unlock popup shows custom unlock descriptions
+# create_UIBox_deck_unlock()
+[[patches]]
+[patches.pattern]
+target = 'functions/UI_definitions.lua'
+pattern = "if deck_center.unlock_condition.type == 'win_deck' then"
+position = "before"
+payload = """
+if deck_center.check_for_unlock and type(deck_center.check_for_unlock) == "function" then
+    local loc_args = {}
+    local key_override
+    if deck_center.locked_loc_vars and type(deck_center.locked_loc_vars) == 'function' then
+        local res = deck_center:locked_loc_vars() or {}
+        loc_args = res.vars or {}
+        key_override = res.key
+    end
+    localize{type = 'unlocks', key = key_override or deck_center.key, set = "Back", nodes = deck_criteria, vars = loc_args, default_col = G.C.WHITE, shadow = true}
+end
+"""
+match_indent = true


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/122fb5b7-9280-4b36-b787-3306ebe06797)

Currently the unlock blurb does not show up on these pop-ups in the main menu unless it used one of the game's default ones (e.g. Win X stake on any deck). This PR patches this in.)

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
