### PR TITLE
Mod UI config

### DIFF
--- a/lovely/ui.toml
+++ b/lovely/ui.toml
@@ -36,14 +36,14 @@ target = "functions/UI_definitions.lua"
 pattern = '''local t = create_UIBox_generic_options({ back_func = 'your_collection', contents = {'''
 position = "at"
 payload = '''local t = create_UIBox_generic_options({ 
-colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_colour or
-    (G.ACTIVE_MOD_UI.ui_config or {}).colour,
-bg_colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_bg_colour or
-    (G.ACTIVE_MOD_UI.ui_config or {}).bg_colour,
-back_colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_back_colour or
-    (G.ACTIVE_MOD_UI.ui_config or {}).back_colour,
-outline_colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_outline_colour or
-    (G.ACTIVE_MOD_UI.ui_config or {}).outline_colour,
+colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_colour or
+    (G.ACTIVE_MOD_UI.ui_config or {}).colour),
+bg_colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_bg_colour or
+    (G.ACTIVE_MOD_UI.ui_config or {}).bg_colour),
+back_colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_back_colour or
+    (G.ACTIVE_MOD_UI.ui_config or {}).back_colour),
+outline_colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_outline_colour or
+    (G.ACTIVE_MOD_UI.ui_config or {}).outline_colour),
 back_func = G.ACTIVE_MOD_UI and "openModUI_"..G.ACTIVE_MOD_UI.id or 'your_collection', contents = {'''
 match_indent = true
 

--- a/lovely/ui.toml
+++ b/lovely/ui.toml
@@ -36,12 +36,14 @@ target = "functions/UI_definitions.lua"
 pattern = '''local t = create_UIBox_generic_options({ back_func = 'your_collection', contents = {'''
 position = "at"
 payload = '''local t = create_UIBox_generic_options({ 
-colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_colour or
-            (G.ACTIVE_MOD_UI.ui_config or {}).colour) or nil,
-bg_colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_bg_colour or
-    (G.ACTIVE_MOD_UI.ui_config or {}).bg_colour) or nil,
-back_colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_back_colour or
-    (G.ACTIVE_MOD_UI.ui_config or {}).back_colour) or nil,
+colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_colour or
+    (G.ACTIVE_MOD_UI.ui_config or {}).colour,
+bg_colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_bg_colour or
+    (G.ACTIVE_MOD_UI.ui_config or {}).bg_colour,
+back_colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_back_colour or
+    (G.ACTIVE_MOD_UI.ui_config or {}).back_colour,
+outline_colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_outline_colour or
+    (G.ACTIVE_MOD_UI.ui_config or {}).outline_colour,
 back_func = G.ACTIVE_MOD_UI and "openModUI_"..G.ACTIVE_MOD_UI.id or 'your_collection', contents = {'''
 match_indent = true
 

--- a/lovely/ui.toml
+++ b/lovely/ui.toml
@@ -35,7 +35,23 @@ line_prepend = '$indent'
 target = "functions/UI_definitions.lua"
 pattern = '''local t = create_UIBox_generic_options({ back_func = 'your_collection', contents = {'''
 position = "at"
-payload = '''local t = create_UIBox_generic_options({ back_func = G.ACTIVE_MOD_UI and "openModUI_"..G.ACTIVE_MOD_UI.id or 'your_collection', contents = {'''
+payload = '''local t = create_UIBox_generic_options({ 
+colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_colour or
+            (G.ACTIVE_MOD_UI.ui_config or {}).colour) or nil,
+bg_colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_bg_colour or
+    (G.ACTIVE_MOD_UI.ui_config or {}).bg_colour) or nil,
+back_colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_back_colour or
+    (G.ACTIVE_MOD_UI.ui_config or {}).back_colour) or nil,
+back_func = G.ACTIVE_MOD_UI and "openModUI_"..G.ACTIVE_MOD_UI.id or 'your_collection', contents = {'''
+match_indent = true
+
+# create_UIBox_your_collection_decks()
+[[patches]]
+[patches.pattern]
+target = "functions/UI_definitions.lua"
+pattern = '''create_option_cycle({options = ordered_names, opt_callback = 'change_viewed_back', current_option = 1, colour = G.C.RED, w = 4.5, focus_args = {snap_to = true}, mid = '''
+position = "at"
+payload = '''create_option_cycle({options = ordered_names, opt_callback = 'change_viewed_back', current_option = 1, colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_option_cycle_colour or G.C.RED, w = 4.5, focus_args = {snap_to = true}, mid = '''
 match_indent = true
 
 # G.FUNCS.your_collection_deck_page

--- a/lsp_def/smods_core.lua
+++ b/lsp_def/smods_core.lua
@@ -35,6 +35,7 @@ SMODS.path = ""
 ---@field custom_collection_tabs? fun(): table[] Creates additional buttons displayed inside the "Other" tab in collections. 
 ---@field description_loc_vars? fun(self: Mod|table): table Allows dynamic display of this mod's description. 
 ---@field custom_ui? fun(mod_nodes: table) Allows manipulating this mod's description tab. 
+---@field ui_config? fun(mod_nodes: table) Allows specifying custom values for this mod's menu UI elements.
 ---@field set_ability_reset_keys? fun(): table When a card's `ability` table is changed, values with a key matching inside this table will not persist. 
 ---@field reset_game_globals? fun(run_start: boolean) Allows resetting global values every new run or round. 
 ---@field set_debuff? fun(card: Card|table): boolean|string? Allows controlling when a card is debuffed or not. Return `"prevent_debuff"` to force a card to be undebuffable. 

--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -195,7 +195,13 @@ function create_UIBox_your_collection_blinds(exit)
 	end
 
 	local extras = nil
-	local t = create_UIBox_generic_options({
+    local t = create_UIBox_generic_options({
+		colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_colour or
+            (G.ACTIVE_MOD_UI.ui_config or {}).colour) or nil,
+        bg_colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_bg_colour or
+            (G.ACTIVE_MOD_UI.ui_config or {}).bg_colour) or nil,
+        back_colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_back_colour or
+            (G.ACTIVE_MOD_UI.ui_config or {}).back_colour) or nil,
 		back_func = G.ACTIVE_MOD_UI and "openModUI_"..G.ACTIVE_MOD_UI.id or exit or 'your_collection',
 		contents = {
 			{
@@ -263,7 +269,7 @@ function create_UIBox_your_collection_blinds(exit)
 								opt_callback = 'your_collection_blinds_page',
 								focus_args = {snap_to = true, nav = 'wide'},
 								current_option = page,
-								colour = G.C.RED,
+								colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_option_cycle_colour or G.C.RED,
 								no_pips = true
 							})
 						},
@@ -446,7 +452,13 @@ function create_UIBox_your_collection_tags_content(page)
 	for i = 1, math.ceil(#tag_tab/(rows*cols)) do
 		table.insert(page_options, localize('k_page')..' '..tostring(i)..'/'..tostring(math.ceil(#tag_tab/(rows*cols))))
 	end
-	local t = create_UIBox_generic_options({
+    local t = create_UIBox_generic_options({
+		colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_colour or
+            (G.ACTIVE_MOD_UI.ui_config or {}).colour) or nil,
+        bg_colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_bg_colour or
+            (G.ACTIVE_MOD_UI.ui_config or {}).bg_colour) or nil,
+        back_colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_back_colour or
+            (G.ACTIVE_MOD_UI.ui_config or {}).back_colour) or nil,
 		back_func = G.ACTIVE_MOD_UI and "openModUI_" .. G.ACTIVE_MOD_UI.id or 'your_collection',
 		contents = {
 			{
@@ -473,7 +485,7 @@ function create_UIBox_your_collection_tags_content(page)
 						opt_callback = 'your_collection_tags_page',
 						focus_args = { snap_to = true, nav = 'wide' },
 						current_option = page,
-						colour = G.C.RED,
+						colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_option_cycle_colour or G.C.RED,
 						no_pips = true
 					})
 				}

--- a/src/ui.lua
+++ b/src/ui.lua
@@ -190,7 +190,7 @@ function create_UIBox_mods(args)
                 nodes = {
                     create_tabs({
                         snap_to_nav = true,
-                        colour = (mod.ui_config or {}).tab_colour or G.C.BOOSTER,
+                        colour = (mod.ui_config or {}).tab_button_colour or G.C.BOOSTER,
                         tabs = mod_tabs
                     })
                 }
@@ -223,7 +223,7 @@ function buildModDescTab(mod)
 
             local authors = localize('b_author' .. (#mod.author > 1 and 's' or '')) .. ': ' .. concatAuthors(mod.author)
 
-            -- Authors names in blue
+            -- Authors names
             table.insert(modNodes, {
                 n = G.UIT.R,
                 config = {
@@ -240,7 +240,7 @@ function buildModDescTab(mod)
                             text = authors,
                             shadow = true,
                             scale = scale * 0.65,
-                            colour = G.C.BLUE,
+                            colour = (mod.ui_config or {}).author_colour or G.C.BLUE,
                         }
                     }
                 }
@@ -483,7 +483,15 @@ function create_UIBox_Other_GameObjects()
             {n=G.UIT.R, config={align = "cm", padding = 0.15}, nodes = custom_gameobject_rows}
         }}
     
-        return create_UIBox_generic_options({ back_func = G.ACTIVE_MOD_UI and "openModUI_"..G.ACTIVE_MOD_UI.id or 'your_collection', contents = {t}})
+        return create_UIBox_generic_options({
+            colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_colour or
+            (G.ACTIVE_MOD_UI.ui_config or {}).colour) or nil,
+            bg_colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_bg_colour or
+                (G.ACTIVE_MOD_UI.ui_config or {}).bg_colour) or nil,
+            back_colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_back_colour or
+                (G.ACTIVE_MOD_UI.ui_config or {}).back_colour) or nil,
+            back_func = G.ACTIVE_MOD_UI and "openModUI_" .. G.ACTIVE_MOD_UI.id or 'your_collection', contents = { t } }
+        )
     else
         return nil
     end
@@ -497,7 +505,14 @@ G.FUNCS.your_collection_consumables = function(e)
 end
 
 function create_UIBox_your_collection_consumables()
-    local t = create_UIBox_generic_options({ back_func = G.ACTIVE_MOD_UI and "openModUI_"..G.ACTIVE_MOD_UI.id or 'your_collection', contents = {
+    local t = create_UIBox_generic_options({
+        colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_colour or
+            (G.ACTIVE_MOD_UI.ui_config or {}).colour) or nil,
+        bg_colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_bg_colour or
+            (G.ACTIVE_MOD_UI.ui_config or {}).bg_colour) or nil,
+        back_colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_back_colour or
+            (G.ACTIVE_MOD_UI.ui_config or {}).back_colour) or nil,
+        back_func = G.ACTIVE_MOD_UI and "openModUI_"..G.ACTIVE_MOD_UI.id or 'your_collection', contents = {
         { n = G.UIT.C, config = { align = 'cm', minw = 11.5, minh = 6 }, nodes = {
             { n = G.UIT.O, config = { id = 'consumable_collection', object = Moveable() },}
         }},
@@ -549,7 +564,7 @@ G.UIDEF.consumable_collection_page = function(page)
         opt_callback = 'your_collection_consumables_page',
         focus_args = { snap_to = true, nav = 'wide' },
         current_option = page or 1,
-        colour = G.C.RED,
+        colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_option_cycle_colour or G.C.RED,
         no_pips = true
     }) }
     local function create_consumable_nodes(_start, _end)
@@ -1789,13 +1804,13 @@ SMODS.card_collection_UIBox = function(_pool, rows, args)
     G.FUNCS.SMODS_card_collection_page{ cycle_config = { current_option = 1 }}
     
     local t = create_UIBox_generic_options({
-        colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_colour or (G.ACTIVE_MOD_UI.ui_config or {}).colour or nil,
-        bg_colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_bg_colour or (G.ACTIVE_MOD_UI.ui_config or {}).bg_colour or nil,
-        back_colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_back_colour or (G.ACTIVE_MOD_UI.ui_config or {}).back_colour or nil,
+        colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_colour or (G.ACTIVE_MOD_UI.ui_config or {}).colour) or nil,
+        bg_colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_bg_colour or (G.ACTIVE_MOD_UI.ui_config or {}).bg_colour) or nil,
+        back_colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_back_colour or (G.ACTIVE_MOD_UI.ui_config or {}).back_colour) or nil,
         back_func = (args and args.back_func) or G.ACTIVE_MOD_UI and "openModUI_"..G.ACTIVE_MOD_UI.id or 'your_collection', snap_back = args.snap_back, infotip = args.infotip, contents = {
           {n=G.UIT.R, config={align = "cm", r = 0.1, colour = G.C.BLACK, emboss = 0.05}, nodes=deck_tables}, 
           (not args.hide_single_page or cards_per_page < #pool) and {n=G.UIT.R, config={align = "cm"}, nodes={
-            create_option_cycle({options = options, w = 4.5, cycle_shoulders = true, opt_callback = 'SMODS_card_collection_page', current_option = 1, colour = G.C.RED, no_pips = true, focus_args = {snap_to = true, nav = 'wide'}})
+            create_option_cycle({options = options, w = 4.5, cycle_shoulders = true, opt_callback = 'SMODS_card_collection_page', current_option = 1, colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_option_cycle_colour or G.C.RED, no_pips = true, focus_args = {snap_to = true, nav = 'wide'}})
           }} or nil,
       }})
     return t

--- a/src/ui.lua
+++ b/src/ui.lua
@@ -179,6 +179,7 @@ function create_UIBox_mods(args)
         colour = (mod.ui_config or {}).colour,
         bg_colour = (mod.ui_config or {}).bg_colour,
         back_colour = (mod.ui_config or {}).back_colour,
+        outline_colour = (mod.ui_config or {}).outline_colour,
         back_func = "mods_button",
         contents = {
             {
@@ -231,7 +232,9 @@ function buildModDescTab(mod)
                     r = 0.1,
                     emboss = 0.1,
                     outline = 1,
-                    padding = 0.07
+                    padding = 0.07,
+                    outline_colour = (mod.ui_config or {}).author_outline_colour,
+                    colour = (mod.ui_config or {}).author_bg_colour,
                 },
                 nodes = {
                     {
@@ -484,12 +487,14 @@ function create_UIBox_Other_GameObjects()
         }}
     
         return create_UIBox_generic_options({
-            colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_colour or
-            (G.ACTIVE_MOD_UI.ui_config or {}).colour) or nil,
-            bg_colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_bg_colour or
-                (G.ACTIVE_MOD_UI.ui_config or {}).bg_colour) or nil,
-            back_colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_back_colour or
-                (G.ACTIVE_MOD_UI.ui_config or {}).back_colour) or nil,
+            colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_colour or
+            (G.ACTIVE_MOD_UI.ui_config or {}).colour,
+            bg_colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_bg_colour or
+                (G.ACTIVE_MOD_UI.ui_config or {}).bg_colour,
+            back_colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_back_colour or
+                (G.ACTIVE_MOD_UI.ui_config or {}).back_colour,
+            outline_colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_outline_colour or
+                (G.ACTIVE_MOD_UI.ui_config or {}).outline_colour,
             back_func = G.ACTIVE_MOD_UI and "openModUI_" .. G.ACTIVE_MOD_UI.id or 'your_collection', contents = { t } }
         )
     else
@@ -506,12 +511,14 @@ end
 
 function create_UIBox_your_collection_consumables()
     local t = create_UIBox_generic_options({
-        colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_colour or
-            (G.ACTIVE_MOD_UI.ui_config or {}).colour) or nil,
-        bg_colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_bg_colour or
-            (G.ACTIVE_MOD_UI.ui_config or {}).bg_colour) or nil,
-        back_colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_back_colour or
-            (G.ACTIVE_MOD_UI.ui_config or {}).back_colour) or nil,
+        colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_colour or
+            (G.ACTIVE_MOD_UI.ui_config or {}).colour,
+        bg_colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_bg_colour or
+            (G.ACTIVE_MOD_UI.ui_config or {}).bg_colour,
+        back_colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_back_colour or
+            (G.ACTIVE_MOD_UI.ui_config or {}).back_colour,
+        outline_colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_outline_colour or
+                (G.ACTIVE_MOD_UI.ui_config or {}).outline_colour,
         back_func = G.ACTIVE_MOD_UI and "openModUI_"..G.ACTIVE_MOD_UI.id or 'your_collection', contents = {
         { n = G.UIT.C, config = { align = 'cm', minw = 11.5, minh = 6 }, nodes = {
             { n = G.UIT.O, config = { id = 'consumable_collection', object = Moveable() },}
@@ -1804,9 +1811,11 @@ SMODS.card_collection_UIBox = function(_pool, rows, args)
     G.FUNCS.SMODS_card_collection_page{ cycle_config = { current_option = 1 }}
     
     local t = create_UIBox_generic_options({
-        colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_colour or (G.ACTIVE_MOD_UI.ui_config or {}).colour) or nil,
-        bg_colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_bg_colour or (G.ACTIVE_MOD_UI.ui_config or {}).bg_colour) or nil,
-        back_colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_back_colour or (G.ACTIVE_MOD_UI.ui_config or {}).back_colour) or nil,
+        colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_colour or (G.ACTIVE_MOD_UI.ui_config or {}).colour,
+        bg_colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_bg_colour or (G.ACTIVE_MOD_UI.ui_config or {}).bg_colour,
+        back_colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_back_colour or (G.ACTIVE_MOD_UI.ui_config or {}).back_colour,
+        outline_colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_outline_colour or
+                (G.ACTIVE_MOD_UI.ui_config or {}).outline_colour,
         back_func = (args and args.back_func) or G.ACTIVE_MOD_UI and "openModUI_"..G.ACTIVE_MOD_UI.id or 'your_collection', snap_back = args.snap_back, infotip = args.infotip, contents = {
           {n=G.UIT.R, config={align = "cm", r = 0.1, colour = G.C.BLACK, emboss = 0.05}, nodes=deck_tables}, 
           (not args.hide_single_page or cards_per_page < #pool) and {n=G.UIT.R, config={align = "cm"}, nodes={

--- a/src/ui.lua
+++ b/src/ui.lua
@@ -176,6 +176,9 @@ function create_UIBox_mods(args)
     end
 
     return (create_UIBox_generic_options({
+        colour = (mod.ui_config or {}).colour,
+        bg_colour = (mod.ui_config or {}).bg_colour,
+        back_colour = (mod.ui_config or {}).back_colour,
         back_func = "mods_button",
         contents = {
             {
@@ -187,7 +190,7 @@ function create_UIBox_mods(args)
                 nodes = {
                     create_tabs({
                         snap_to_nav = true,
-                        colour = G.C.BOOSTER,
+                        colour = (mod.ui_config or {}).tab_colour or G.C.BOOSTER,
                         tabs = mod_tabs
                     })
                 }
@@ -1785,7 +1788,11 @@ SMODS.card_collection_UIBox = function(_pool, rows, args)
 
     G.FUNCS.SMODS_card_collection_page{ cycle_config = { current_option = 1 }}
     
-    local t =  create_UIBox_generic_options({ back_func = (args and args.back_func) or G.ACTIVE_MOD_UI and "openModUI_"..G.ACTIVE_MOD_UI.id or 'your_collection', snap_back = args.snap_back, infotip = args.infotip, contents = {
+    local t = create_UIBox_generic_options({
+        colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_colour or (G.ACTIVE_MOD_UI.ui_config or {}).colour or nil,
+        bg_colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_bg_colour or (G.ACTIVE_MOD_UI.ui_config or {}).bg_colour or nil,
+        back_colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_back_colour or (G.ACTIVE_MOD_UI.ui_config or {}).back_colour or nil,
+        back_func = (args and args.back_func) or G.ACTIVE_MOD_UI and "openModUI_"..G.ACTIVE_MOD_UI.id or 'your_collection', snap_back = args.snap_back, infotip = args.infotip, contents = {
           {n=G.UIT.R, config={align = "cm", r = 0.1, colour = G.C.BLACK, emboss = 0.05}, nodes=deck_tables}, 
           (not args.hide_single_page or cards_per_page < #pool) and {n=G.UIT.R, config={align = "cm"}, nodes={
             create_option_cycle({options = options, w = 4.5, cycle_shoulders = true, opt_callback = 'SMODS_card_collection_page', current_option = 1, colour = G.C.RED, no_pips = true, focus_args = {snap_to = true, nav = 'wide'}})

--- a/src/ui.lua
+++ b/src/ui.lua
@@ -487,14 +487,14 @@ function create_UIBox_Other_GameObjects()
         }}
     
         return create_UIBox_generic_options({
-            colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_colour or
-            (G.ACTIVE_MOD_UI.ui_config or {}).colour,
-            bg_colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_bg_colour or
-                (G.ACTIVE_MOD_UI.ui_config or {}).bg_colour,
-            back_colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_back_colour or
-                (G.ACTIVE_MOD_UI.ui_config or {}).back_colour,
-            outline_colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_outline_colour or
-                (G.ACTIVE_MOD_UI.ui_config or {}).outline_colour,
+            colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_colour or
+            (G.ACTIVE_MOD_UI.ui_config or {}).colour),
+            bg_colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_bg_colour or
+                (G.ACTIVE_MOD_UI.ui_config or {}).bg_colour),
+            back_colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_back_colour or
+                (G.ACTIVE_MOD_UI.ui_config or {}).back_colour),
+            outline_colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_outline_colour or
+                (G.ACTIVE_MOD_UI.ui_config or {}).outline_colour),
             back_func = G.ACTIVE_MOD_UI and "openModUI_" .. G.ACTIVE_MOD_UI.id or 'your_collection', contents = { t } }
         )
     else
@@ -511,14 +511,14 @@ end
 
 function create_UIBox_your_collection_consumables()
     local t = create_UIBox_generic_options({
-        colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_colour or
-            (G.ACTIVE_MOD_UI.ui_config or {}).colour,
-        bg_colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_bg_colour or
-            (G.ACTIVE_MOD_UI.ui_config or {}).bg_colour,
-        back_colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_back_colour or
-            (G.ACTIVE_MOD_UI.ui_config or {}).back_colour,
-        outline_colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_outline_colour or
-                (G.ACTIVE_MOD_UI.ui_config or {}).outline_colour,
+        colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_colour or
+            (G.ACTIVE_MOD_UI.ui_config or {}).colour),
+        bg_colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_bg_colour or
+            (G.ACTIVE_MOD_UI.ui_config or {}).bg_colour),
+        back_colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_back_colour or
+            (G.ACTIVE_MOD_UI.ui_config or {}).back_colour),
+        outline_colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_outline_colour or
+                (G.ACTIVE_MOD_UI.ui_config or {}).outline_colour),
         back_func = G.ACTIVE_MOD_UI and "openModUI_"..G.ACTIVE_MOD_UI.id or 'your_collection', contents = {
         { n = G.UIT.C, config = { align = 'cm', minw = 11.5, minh = 6 }, nodes = {
             { n = G.UIT.O, config = { id = 'consumable_collection', object = Moveable() },}
@@ -1811,11 +1811,11 @@ SMODS.card_collection_UIBox = function(_pool, rows, args)
     G.FUNCS.SMODS_card_collection_page{ cycle_config = { current_option = 1 }}
     
     local t = create_UIBox_generic_options({
-        colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_colour or (G.ACTIVE_MOD_UI.ui_config or {}).colour,
-        bg_colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_bg_colour or (G.ACTIVE_MOD_UI.ui_config or {}).bg_colour,
-        back_colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_back_colour or (G.ACTIVE_MOD_UI.ui_config or {}).back_colour,
-        outline_colour = G.ACTIVE_MOD_UI and (G.ACTIVE_MOD_UI.ui_config or {}).collection_outline_colour or
-                (G.ACTIVE_MOD_UI.ui_config or {}).outline_colour,
+        colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_colour or (G.ACTIVE_MOD_UI.ui_config or {}).colour),
+        bg_colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_bg_colour or (G.ACTIVE_MOD_UI.ui_config or {}).bg_colour),
+        back_colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_back_colour or (G.ACTIVE_MOD_UI.ui_config or {}).back_colour),
+        outline_colour = G.ACTIVE_MOD_UI and ((G.ACTIVE_MOD_UI.ui_config or {}).collection_outline_colour or
+                (G.ACTIVE_MOD_UI.ui_config or {}).outline_colour),
         back_func = (args and args.back_func) or G.ACTIVE_MOD_UI and "openModUI_"..G.ACTIVE_MOD_UI.id or 'your_collection', snap_back = args.snap_back, infotip = args.infotip, contents = {
           {n=G.UIT.R, config={align = "cm", r = 0.1, colour = G.C.BLACK, emboss = 0.05}, nodes=deck_tables}, 
           (not args.hide_single_page or cards_per_page < #pool) and {n=G.UIT.R, config={align = "cm"}, nodes={


### PR DESCRIPTION
Added SMODS.current_mod.ui_config to be able to customize the colours of the UI elements in a mod's menu. This could maybe be expanded to include the addition buttons or setting text scaling in the future.

![Captura de pantalla 2025-05-04 202135](https://github.com/user-attachments/assets/ce6390b4-571e-4f7a-81a4-eb639bae3656)

![2379780_20250504201910_1](https://github.com/user-attachments/assets/8a2f42b4-c32c-4f40-8eff-d40d70e56af9)

![2379780_20250504201913_1](https://github.com/user-attachments/assets/cda40918-50ac-4fbb-af24-5b727f5dbe19)

![2379780_20250504201923_1](https://github.com/user-attachments/assets/4504fb80-c76a-440d-9443-8afa95c219fd)
![2379780_20250504201925_1](https://github.com/user-attachments/assets/47c43fa8-3a5b-4097-9c3b-94ef7d4c5bec)
![2379780_20250504201928_1](https://github.com/user-attachments/assets/5dbe4c00-5fd0-4e72-8b07-856ce645c658)

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
