### PR TITLE
Add context.hand_space

### DIFF
--- a/lovely/better_calc.toml
+++ b/lovely/better_calc.toml
@@ -1001,7 +1001,7 @@ end
 payload = '''
 local flags = SMODS.calculate_context({hand_space = hand_space})
 print(flags)
-hand_space = flags.hand_space or hand_space
+hand_space = math.min(#G.deck.cards, flags.hand_space or hand_space)
 '''
 
 # Used to identify first hand of round

--- a/lovely/better_calc.toml
+++ b/lovely/better_calc.toml
@@ -130,7 +130,7 @@ if context.cardarea == G.hand then
     end
 
     local jokers = card:calculate_joker(context)
-    if jokers then 
+    if jokers then
         ret.jokers = jokers
     end
 '''
@@ -984,6 +984,26 @@ G.E_MANAGER:add_event(Event({
 }))
 '''
 
+# context.hand_space
+[[patches]]
+[patches.pattern]
+target = 'functions/state_events.lua'
+match_indent = true
+position = 'after'
+pattern = '''
+if G.GAME.blind.name == 'The Serpent' and
+    not G.GAME.blind.disabled and
+    (G.GAME.current_round.hands_played > 0 or
+    G.GAME.current_round.discards_used > 0) then
+        hand_space = math.min(#G.deck.cards, 3)
+end
+'''
+payload = '''
+local flags = SMODS.calculate_context({hand_space = hand_space})
+print(flags)
+hand_space = flags.hand_space or hand_space
+'''
+
 # Used to identify first hand of round
 # new_round
 [[patches]]
@@ -1150,12 +1170,11 @@ target = 'functions/button_callbacks.lua'
 match_indent = true
 position = 'before'
 pattern = '''
-if G.GAME.current_round.reroll_cost > 0 then 
+if G.GAME.current_round.reroll_cost > 0 then
 '''
 payload = '''
 local reroll_cost = G.GAME.current_round.reroll_cost
 '''
-
 
 
 # Fix purple seal calc

--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -69,6 +69,7 @@
 ---@field to_area? CardArea|table CardArea the card is being drawn to. 
 ---@field from_area? CardArea|table CardArea the card is being drawn from. 
 ---@field modify_hand? true Check if `true` for modifying the chips and mult of the played hand. 
+---@field hand_space? integer Amount of cards about to be drawn from deck to hand. Check for modifying amount of cards drawn.
 
 --- Util Functions
 

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -1379,7 +1379,11 @@ SMODS.calculate_individual_effect = function(effect, scored_card, key, amount, f
         return { [key] = amount, debuff_source = scored_card }
     end
 
-    if key == 'debuff_text' then 
+    if key == 'debuff_text' then
+        return { [key] = amount }
+    end
+    
+    if key == 'hand_space' then
         return { [key] = amount }
     end
 end
@@ -1447,6 +1451,7 @@ SMODS.calculation_keys = {
     'debuff', 'prevent_debuff', 'debuff_text',
     'add_to_hand', 'remove_from_hand',
     'stay_flipped', 'prevent_stay_flipped',
+    'hand_space',
     'message',
     'level_up', 'func', 'extra',
 }


### PR DESCRIPTION
Added context.hand_space to recreate effects like The Serpent. `context.hand_space` has the amount of cards about to be drawn (after serpent calculates). `hand_space = integer` can be returned in that context to change the number of cards drawn.

Maybe it could have a more descriptive name but I couldn't come up with one :P

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
