### PR TITLE
Add support for negative chips/mult

### DIFF
--- a/lovely/ui.toml
+++ b/lovely/ui.toml
@@ -215,3 +215,25 @@ match_indent = true
 position = 'at'
 pattern = 'colour = loc_colour(part.control.C or nil),'
 payload = 'colour = part.control.V and args.vars.colours[tonumber(part.control.V)] or loc_colour(part.control.C or nil),' 
+
+
+# Makes negative chips work
+[[patches]]
+[patches.pattern]
+target = "functions/button_callbacks.lua"
+pattern = '''if not G.TAROT_INTERRUPT_PULSE then G.FUNCS.text_super_juice(e, math.max(0,math.floor(math.log10(type(G.GAME.current_round.current_hand.chips) == 'number' and G.GAME.current_round.current_hand.chips or 1)))) end'''
+position = "at"
+overwrite = true
+match_indent = true
+payload = '''if not G.TAROT_INTERRUPT_PULSE then G.FUNCS.text_super_juice(e, math.max(0,math.floor(math.log10(type(G.GAME.current_round.current_hand.chips) == 'number' and math.abs(G.GAME.current_round.current_hand.chips) or 1)))) end'''
+
+
+# Makes negative mult work
+[[patches]]
+[patches.pattern]
+target = "functions/button_callbacks.lua"
+pattern = '''if not G.TAROT_INTERRUPT_PULSE then G.FUNCS.text_super_juice(e, math.max(0,math.floor(math.log10(type(G.GAME.current_round.current_hand.mult) == 'number' and G.GAME.current_round.current_hand.mult or 1)))) end'''
+position = "at"
+overwrite = true
+match_indent = true
+payload = '''if not G.TAROT_INTERRUPT_PULSE then G.FUNCS.text_super_juice(e, math.max(0,math.floor(math.log10(type(G.GAME.current_round.current_hand.mult) == 'number' and math.abs(G.GAME.current_round.current_hand.mult) or 1)))) end'''

--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -1927,3 +1927,13 @@ function Blind:modify_hand(cards, poker_hands, text, mult, hand_chips, scoring_h
 	local flags = SMODS.calculate_context({ modify_hand = true, poker_hands = poker_hands, scoring_name = text, scoring_hand = scoring_hand, full_hand = cards })
 	return _G.mult, _G.hand_chips, modded or flags.calculated
 end
+
+
+-- hook to fix scaling for negative numbers
+local scale_number_ref = scale_number
+scale_number = function(number, scale, max, e_switch_point)
+  if(number < 0) then
+    number = math.abs(number) * 10
+  end
+  return scale_number_ref(number, scale, max, e_switch_point)
+end


### PR DESCRIPTION
Added a hook for scale_number that accounts for the negative sign when determining the scale for a number
Added patches for the chip and mult update functions that prevent domain errors on the math.log10 calls by taking the absolute value

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
