### PR TITLE
Fix deck preview not using suit icon

### DIFF
--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -741,7 +741,8 @@ function G.UIDEF.deck_preview(args)
 						G.ASSET_ATLAS[SMODS.Suits[v][G.SETTINGS.colour_palettes[v] == 'hc' and "hc_ui_atlas" or G.SETTINGS.colour_palettes[v] == 'lc' and "lc_ui_atlas"]] or
 						G.ASSET_ATLAS[("ui_" .. (G.SETTINGS.colourblind_option and "2" or "1"))], SMODS.Suits[v].ui_pos)
 			else
-				t_s = Sprite(0, 0, 0.3, 0.3, G.ASSET_ATLAS[("ui_" .. (G.SETTINGS.colourblind_option and "2" or "1"))], SMODS.Suits[v].ui_pos)
+				local atlas = G.SETTINGS.colour_palettes[v] == "hc" and SMODS.Suits[v].hc_ui_atlas or SMODS.Suits[v].lc_ui_atlas
+				t_s = Sprite(0, 0, 0.3, 0.3, G.ASSET_ATLAS[atlas and atlas or ("ui_" .. (G.SETTINGS.colourblind_option and "2" or "1"))], SMODS.Suits[v].ui_pos)
 			end
 
 			t_s.states.drag.can = false


### PR DESCRIPTION

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.

## Synopsis
When I was programming my own suit I encountered this problem with deck preview numbers.
![Deck Preview Bug on development](https://github.com/user-attachments/assets/b1895f64-f1dc-46b0-af0b-acf742c29e56)
which does not match with what's being showin in deck view
![Deck View](https://github.com/user-attachments/assets/ec20b568-9dce-4f6e-9970-fec177c4a7c7)
So I made a small change by make the logic inside deck preview UI to consider the suit's icon defined in SMODS.Suit
![Fixed Deck Preview](https://github.com/user-attachments/assets/02ef1793-fc00-4c0f-aa59-203cf06aedc3)

Feel free to make changes to this PR and if this is not wanted feel free to close it.
