### PR TITLE
Add more text formatting options

### DIFF
--- a/lovely/ui_additional_text_props.toml
+++ b/lovely/ui_additional_text_props.toml
@@ -1,0 +1,211 @@
+[manifest]
+version = "1.2"
+dump_lua = true
+priority = 0
+
+[[patches]]
+[patches.pattern]
+target = "functions/misc_functions.lua"
+pattern = """              spacing = math.max(0, 0.32*(17 - #assembled_string)),"""
+position = "after"
+payload = """font = SMODS.Fonts[part.control.font] and SMODS.Fonts[part.control.font] or (tonumber(part.control.font) and G.FONTS[tonumber(part.control.font)]),"""
+overwrite = true
+match_indent = true
+
+[[patches]]
+[patches.pattern]
+target = "functions/misc_functions.lua"
+pattern = """            spacing = _spacing,"""
+position = "after"
+payload = """font = SMODS.Fonts[part.control.font] and SMODS.Fonts[part.control.font] or (tonumber(part.control.font) and G.FONTS[tonumber(part.control.font)]),"""
+overwrite = true
+match_indent = true
+
+[[patches]]
+[patches.pattern]
+target = "functions/misc_functions.lua"
+pattern = """                text = assembled_string,"""
+position = "after"
+payload = """font = SMODS.Fonts[part.control.font] and SMODS.Fonts[part.control.font] or (tonumber(part.control.font) and G.FONTS[tonumber(part.control.font)]),"""
+overwrite = true
+match_indent = true
+
+[[patches]]
+[patches.pattern]
+target = "functions/misc_functions.lua"
+pattern = """    loc_target = G.localization.descriptions[(args.set or args.node.config.center.set)][args.key or args.node.config.center.key]"""
+position = "at"
+payload = """
+loc_target = loc_target or {}
+loc_target.name_parsed = {loc_parse_string(G.localization.descriptions[(args.set or args.node.config.center.set)][args.key or args.node.config.center.key].name)}"""
+overwrite = true
+match_indent = true
+
+[[patches]]
+[patches.pattern]
+target = "functions/misc_functions.lua"
+pattern = """  if ret_string then return ret_string end"""
+position = "before"
+payload = """if ret_string and type(ret_string) == 'string' then ret_string = string.gsub(ret_string, "{.-}", "") end"""
+overwrite = true
+match_indent = true
+
+[[patches]]
+[patches.pattern]
+target = "engine/ui.lua"
+pattern = """        self.config.text_drawable = love.graphics.newText(self.config.lang.font.FONT, {G.C.WHITE,self.config.text})"""
+position = "before"
+payload = """if self.config.font then
+    self.config.text_drawable = love.graphics.newText(self.config.font.FONT, {G.C.WHITE,self.config.text})
+else
+"""
+overwrite = true
+match_indent = true
+
+[[patches]]
+[patches.pattern]
+target = "engine/ui.lua"
+pattern = """        self.config.text_drawable = love.graphics.newText(self.config.lang.font.FONT, {G.C.WHITE,self.config.text})"""
+position = "after"
+payload = """end"""
+overwrite = true
+match_indent = true
+
+[[patches]]
+[patches.pattern]
+target = "engine/ui.lua"
+pattern = """            local tx = node.config.lang.font.FONT:getWidth(node.config.text)*node.config.lang.font.squish*scale*G.TILESCALE*node.config.lang.font.FONTSCALE
+            local ty = node.config.lang.font.FONT:getHeight()*scale*G.TILESCALE*node.config.lang.font.FONTSCALE*node.config.lang.font.TEXT_HEIGHT_SCALE"""
+position = "at"
+payload = """
+local tx,ty
+if node.config.font then
+    tx = node.config.font.FONT:getWidth(node.config.text)*node.config.font.squish*scale*G.TILESCALE*node.config.font.FONTSCALE
+    ty = node.config.font.FONT:getHeight()*scale*G.TILESCALE*node.config.font.FONTSCALE*node.config.font.TEXT_HEIGHT_SCALE
+else
+    tx = node.config.lang.font.FONT:getWidth(node.config.text)*node.config.lang.font.squish*scale*G.TILESCALE*node.config.lang.font.FONTSCALE
+    ty = node.config.lang.font.FONT:getHeight()*scale*G.TILESCALE*node.config.lang.font.FONTSCALE*node.config.lang.font.TEXT_HEIGHT_SCALE
+end
+"""
+overwrite = true
+match_indent = true
+
+[[patches]]
+[patches.pattern]
+target = "engine/ui.lua"
+pattern = """            self.ARGS.text_parallax.sx = -self.shadow_parrallax.x*0.5/(self.config.scale*self.config.lang.font.FONTSCALE)
+            self.ARGS.text_parallax.sy = -self.shadow_parrallax.y*0.5/(self.config.scale*self.config.lang.font.FONTSCALE)"""
+position = "before"
+payload = """
+if self.config.font then
+    self.ARGS.text_parallax.sx = -self.shadow_parrallax.x*0.5/(self.config.scale*self.config.font.FONTSCALE)
+    self.ARGS.text_parallax.sy = -self.shadow_parrallax.y*0.5/(self.config.scale*self.config.font.FONTSCALE)
+else
+"""
+overwrite = true
+match_indent = true
+
+[[patches]]
+[patches.pattern]
+target = "engine/ui.lua"
+pattern = """            self.ARGS.text_parallax.sx = -self.shadow_parrallax.x*0.5/(self.config.scale*self.config.lang.font.FONTSCALE)
+            self.ARGS.text_parallax.sy = -self.shadow_parrallax.y*0.5/(self.config.scale*self.config.lang.font.FONTSCALE)"""
+position = "after"
+payload = """
+end
+"""
+overwrite = true
+match_indent = true
+
+[[patches]]
+[patches.pattern]
+target = "engine/ui.lua"
+pattern = """                    love.graphics.setColor(0, 0, 0, 0.3*self.config.colour[4])
+                    love.graphics.draw(
+                        self.config.text_drawable,
+                        (self.config.lang.font.TEXT_OFFSET.x + (self.config.vert and -self.ARGS.text_parallax.sy or self.ARGS.text_parallax.sx))*(self.config.scale or 1)*self.config.lang.font.FONTSCALE/G.TILESIZE,
+                        (self.config.lang.font.TEXT_OFFSET.y + (self.config.vert and self.ARGS.text_parallax.sx or self.ARGS.text_parallax.sy))*(self.config.scale or 1)*self.config.lang.font.FONTSCALE/G.TILESIZE,
+                        0,
+                        (self.config.scale)*self.config.lang.font.squish*self.config.lang.font.FONTSCALE/G.TILESIZE,
+                        (self.config.scale)*self.config.lang.font.FONTSCALE/G.TILESIZE
+                    )"""
+position = "before"
+payload = """
+if self.config.font then
+    love.graphics.setColor(0, 0, 0, 0.3*self.config.colour[4])
+    love.graphics.draw(
+        self.config.text_drawable,
+        (self.config.font.TEXT_OFFSET.x + (self.config.vert and -self.ARGS.text_parallax.sy or self.ARGS.text_parallax.sx))*(self.config.scale or 1)*self.config.font.FONTSCALE/G.TILESIZE,
+        (-self.config.font.FONTSCALE+self.config.font.TEXT_OFFSET.y + (self.config.vert and self.ARGS.text_parallax.sx or self.ARGS.text_parallax.sy))*(self.config.scale or 1)*self.config.font.FONTSCALE/G.TILESIZE,
+        0,
+        (self.config.scale)*self.config.font.squish*self.config.font.FONTSCALE/G.TILESIZE,
+        (self.config.scale)*self.config.font.FONTSCALE/G.TILESIZE
+    )
+else
+"""
+overwrite = true
+match_indent = true
+
+[[patches]]
+[patches.pattern]
+target = "engine/ui.lua"
+pattern = """                    love.graphics.setColor(0, 0, 0, 0.3*self.config.colour[4])
+                    love.graphics.draw(
+                        self.config.text_drawable,
+                        (self.config.lang.font.TEXT_OFFSET.x + (self.config.vert and -self.ARGS.text_parallax.sy or self.ARGS.text_parallax.sx))*(self.config.scale or 1)*self.config.lang.font.FONTSCALE/G.TILESIZE,
+                        (self.config.lang.font.TEXT_OFFSET.y + (self.config.vert and self.ARGS.text_parallax.sx or self.ARGS.text_parallax.sy))*(self.config.scale or 1)*self.config.lang.font.FONTSCALE/G.TILESIZE,
+                        0,
+                        (self.config.scale)*self.config.lang.font.squish*self.config.lang.font.FONTSCALE/G.TILESIZE,
+                        (self.config.scale)*self.config.lang.font.FONTSCALE/G.TILESIZE
+                    )"""
+position = "after"
+payload = """
+end
+"""
+overwrite = true
+match_indent = true
+
+[[patches]]
+[patches.pattern]
+target = "engine/ui.lua"
+pattern = """            love.graphics.draw(
+                self.config.text_drawable,
+                self.config.lang.font.TEXT_OFFSET.x*(self.config.scale)*self.config.lang.font.FONTSCALE/G.TILESIZE,
+                self.config.lang.font.TEXT_OFFSET.y*(self.config.scale)*self.config.lang.font.FONTSCALE/G.TILESIZE,
+                0,
+                (self.config.scale)*self.config.lang.font.squish*self.config.lang.font.FONTSCALE/G.TILESIZE,
+                (self.config.scale)*self.config.lang.font.FONTSCALE/G.TILESIZE
+            )"""
+position = "before"
+payload = """
+if self.config.font then
+    love.graphics.draw(
+        self.config.text_drawable,
+        self.config.font.TEXT_OFFSET.x*(self.config.scale)*self.config.font.FONTSCALE/G.TILESIZE,
+        self.config.font.TEXT_OFFSET.y*(self.config.scale)*self.config.font.FONTSCALE/G.TILESIZE,
+        0,
+        (self.config.scale)*self.config.font.squish*self.config.font.FONTSCALE/G.TILESIZE,
+        (self.config.scale)*self.config.font.FONTSCALE/G.TILESIZE
+    )
+else
+"""
+overwrite = true
+match_indent = true
+
+[[patches]]
+[patches.pattern]
+target = "engine/ui.lua"
+pattern = """            love.graphics.draw(
+                self.config.text_drawable,
+                self.config.lang.font.TEXT_OFFSET.x*(self.config.scale)*self.config.lang.font.FONTSCALE/G.TILESIZE,
+                self.config.lang.font.TEXT_OFFSET.y*(self.config.scale)*self.config.lang.font.FONTSCALE/G.TILESIZE,
+                0,
+                (self.config.scale)*self.config.lang.font.squish*self.config.lang.font.FONTSCALE/G.TILESIZE,
+                (self.config.scale)*self.config.lang.font.FONTSCALE/G.TILESIZE
+            )"""
+position = "after"
+payload = """
+end
+"""
+overwrite = true
+match_indent = true

--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -274,6 +274,51 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
     end
 
     -------------------------------------------------------------------------------------------------
+    ----- API CODE GameObject.Font
+    -------------------------------------------------------------------------------------------------
+    
+    SMODS.Fonts = {}
+    SMODS.Font = SMODS.GameObject:extend {
+        obj_table = SMODS.Fonts,
+        set = 'Fonts',
+        obj_buffer = {},
+        disable_mipmap = false,
+        required_params = {
+            'key',
+            'path',
+            'render_scale',
+            'TEXT_HEIGHT_SCALE',
+            'TEXT_OFFSET',
+            'FONTSCALE',
+            'squish',
+            'DESCSCALE',
+        },
+        register = function(self)
+            if self.registered then
+                sendWarnMessage(('Detected duplicate register call on object %s'):format(self.key), self.set)
+                return
+            end
+            self.name = self.key
+            SMODS.Font.super.register(self)
+        end,
+        inject = function(self)
+            local file_path = self.path
+            if file_path == 'DEFAULT' then return end
+
+            self.full_path = (self.mod and self.mod.path or SMODS.path) ..
+                'assets/fonts/' .. file_path
+            local file_data = assert(NFS.newFileData(self.full_path),
+                ('Failed to collect file data for Font %s'):format(self.key))
+            local rs = (self.render_scale or 1) * G.TILESIZE
+            self.FONT = assert(love.graphics.newFont(file_data, rs),
+                ('Failed to initialize font data for Font %s'):format(self.key))
+            
+        end,
+        process_loc_text = function() end,
+    }
+
+
+    -------------------------------------------------------------------------------------------------
     ----- API CODE GameObject.Language
     -------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- This PR adds a way to define font using Steamodded API (can be used for defining a language or for use with text formatting)
- This PR also makes descriptions and name able to contain custom fonts 

Usage: "{font:internal font number or font key with prefix}text with font"

## Synopsis
Normally, Balatro does not support multiple fonts in tooltips. Which makes multilingual description less than trivial. With this PR, developers can use the default (and possibly standardized) `G.FONTS` indices or define their own fonts using `SMODS.Font` to further customise an item's name or description. This `SMODS.Font` can also be used to define localizations' font for more advanced parameters if so choose.

## Example
This jumble of text using multiple languages and formatting rules.
![image](https://github.com/user-attachments/assets/6d0686ac-f228-4a5f-a7b4-c8d32d73315b)
can be defined by this
![image](https://github.com/user-attachments/assets/261828d2-c054-4e3a-abdc-50dd99b68180)
![image](https://github.com/user-attachments/assets/e58f4d08-8eca-4e7d-8a9c-2cd504b15c29)
Note that font:5 refers to the game's internal font for different localization. In this case, 5 refers to Noto JP font, the default Japanese localization font for Balatro.

Feel free to edit this PR if something was unintentionally broken.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
