### PR TITLE
fix `restart_game` referencing wrong path

### DIFF
--- a/src/utils.lua
+++ b/src/utils.lua
@@ -428,7 +428,7 @@ function SMODS.restart_game()
     if love.system.getOS() ~= 'OS X' then
         love.thread.newThread("os.execute(...)\n"):start('"' .. arg[-2] .. '" ' .. table.concat(arg, " "))
     else
-        os.execute('sh "/Users/$USER/Library/Application Support/Steam/steamapps/common/Balatro/run_lovely.sh" &')
+        os.execute('sh "/Users/nnmrts/Library/Application Support/Steam/steamapps/common/Balatro/run_lovely_macos.sh" &')
     end
 
     love.event.quit()

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -428,7 +428,7 @@ function SMODS.restart_game()
     if love.system.getOS() ~= 'OS X' then
         love.thread.newThread("os.execute(...)\n"):start('"' .. arg[-2] .. '" ' .. table.concat(arg, " "))
     else
-        os.execute('sh "/Users/nnmrts/Library/Application Support/Steam/steamapps/common/Balatro/run_lovely_macos.sh" &')
+        os.execute('sh "/Users/$USER/Library/Application Support/Steam/steamapps/common/Balatro/run_lovely_macos.sh" &')
     end
 
     love.event.quit()


### PR DESCRIPTION
Ideally this should be determined dynamically, but this works as a quick fix, I guess.