### PR TITLE
fix crash when `floating_sprite` is `nil`

### DIFF
--- a/src/card_draw.lua
+++ b/src/card_draw.lua
@@ -332,13 +332,15 @@ SMODS.DrawStep {
 
             if type(self.config.center.soul_pos.draw) == 'function' then
                 self.config.center.soul_pos.draw(self, scale_mod, rotate_mod)
-            elseif self.ability.name == 'Hologram' then
-                self.hover_tilt = self.hover_tilt*1.5
-                self.children.floating_sprite:draw_shader('hologram', nil, self.ARGS.send_to_shader, nil, self.children.center, 2*scale_mod, 2*rotate_mod)
-                self.hover_tilt = self.hover_tilt/1.5
-            else
-                self.children.floating_sprite:draw_shader('dissolve',0, nil, nil, self.children.center,scale_mod, rotate_mod,nil, 0.1 + 0.03*math.sin(1.8*G.TIMERS.REAL),nil, 0.6)
-                self.children.floating_sprite:draw_shader('dissolve', nil, nil, nil, self.children.center, scale_mod, rotate_mod)
+            elseif self.children.floating_sprite then
+                if self.ability.name == 'Hologram' then
+                    self.hover_tilt = self.hover_tilt*1.5
+                    self.children.floating_sprite:draw_shader('hologram', nil, self.ARGS.send_to_shader, nil, self.children.center, 2*scale_mod, 2*rotate_mod)
+                    self.hover_tilt = self.hover_tilt/1.5
+                else
+                    self.children.floating_sprite:draw_shader('dissolve',0, nil, nil, self.children.center,scale_mod, rotate_mod,nil, 0.1 + 0.03*math.sin(1.8*G.TIMERS.REAL),nil, 0.6)
+                    self.children.floating_sprite:draw_shader('dissolve', nil, nil, nil, self.children.center, scale_mod, rotate_mod)
+                end
             end
             if self.edition then 
                 for k, v in pairs(G.P_CENTER_POOLS.Edition) do


### PR DESCRIPTION
Should fix this crash:

```
INFO - [G] 2025-05-08 03:17:32 :: ERROR :: StackTrace :: Oops! The game crashed
[SMODS _ "src/card_draw.lua"]:353: attempt to index field 'floating_sprite' (a nil value)
Stack Traceback
===============
(1) Lua local 'handler' at file 'main.lua:612'
	Local variables:
	 msg = string: "[SMODS _ \"src/card_draw.lua\"]:353: attempt to index field 'floating_sprite' (a nil value)"
	 (*temporary) = Lua function '?' (defined at line 31 of chunk [SMODS _ "src/logging.lua"])
	 (*temporary) = number: 2.40314e-314
	 (*temporary) = string: "Oops! The game crashed\
"
(2) LÖVE metamethod at file 'boot.lua:352'
	Local variables:
	 errhand = Lua function '?' (defined at line 598 of chunk main.lua)
	 handler = Lua function '?' (defined at line 598 of chunk main.lua)
(3) Lua field 'func' at Steamodded file 'src/card_draw.lua:353'
	Local variables:
	 self = table: 0x03ffde8780  {T:table: 0x03ffdf27b0, layered_parallax:table: 0x0429e9ee08, sprite_facing:front, original_T:table: 0x03fff7f808, velocity:table: 0x03ffe44908 (more...)}
	 scale_mod = number: 0.058424
	 rotate_mod = number: -0.0364779
	 (*temporary) = nil
	 (*temporary) = number: 2.42341e-314
	 (*temporary) = nil
	 (*temporary) = number: 2.42341e-314
	 (*temporary) = number: 230.041
	 (*temporary) = boolean: true
	 (*temporary) = number: 6.62767e-314
	 (*temporary) = table: 0x01247e06e0  {func:function: 0x012469e180, conditions:table: 0x01243bbf08, atlas:Draw Step, prefix_config:table: 0x0124492198, registered:true, order:60, original_key:floating_sprite (more...)}
	 (*temporary) = table: 0x03ffde8780  {T:table: 0x03ffdf27b0, layered_parallax:table: 0x0429e9ee08, sprite_facing:front, original_T:table: 0x03fff7f808, velocity:table: 0x03ffe44908 (more...)}
	 (*temporary) = string: "both"
	 (*temporary) = string: "vortex"
	 (*temporary) = boolean: false
	 (*temporary) = boolean: true
	 (*temporary) = nil
	 (*temporary) = Lua function '?' (defined at line 78 of chunk engine/sprite.lua)
	 (*temporary) = string: "attempt to index field 'floating_sprite' (a nil value)"
(4) Lua upvalue 'raw_Card_draw' at Steamodded file 'src/card_draw.lua:474'
	Local variables:
	 self = table: 0x03ffde8780  {T:table: 0x03ffdf27b0, layered_parallax:table: 0x0429e9ee08, sprite_facing:front, original_T:table: 0x03fff7f808, velocity:table: 0x03ffe44908 (more...)}
	 layer = string: "both"
	 (for generator) = C function: builtin#6
	 (for state) = table: 0x0124248028  {1:shadow, 2:dvrprv_cine_shadow, 3:focused_ui_1, 4:tilt, 5:particles, 6:tags_buttons, 7:vortex, 8:vic_underlayer, 9:center, 10:front, 11:back (more...)}
	 (for control) = number: 30
	 _ = number: 30
	 k = string: "floating_sprite"
(5) Lua upvalue 'draw_ref' at file 'src//util.lua:619' (from mod with id Bakery)
	Local variables:
	 self = table: 0x03ffde8780  {T:table: 0x03ffdf27b0, layered_parallax:table: 0x0429e9ee08, sprite_facing:front, original_T:table: 0x03fff7f808, velocity:table: 0x03ffe44908 (more...)}
	 layer = nil
(6) Lua upvalue 'card_drawref' at file 'utilities/hooks.lua:44' (from mod with id paperback)
	Local variables:
	 self = table: 0x03ffde8780  {T:table: 0x03ffdf27b0, layered_parallax:table: 0x0429e9ee08, sprite_facing:front, original_T:table: 0x03fff7f808, velocity:table: 0x03ffe44908 (more...)}
	 layer = nil
(7) Lua upvalue 'mblockdrawref' at file 'Familiar.lua:514' (from mod with id familiar)
	Local variables:
	 self = table: 0x03ffde8780  {T:table: 0x03ffdf27b0, layered_parallax:table: 0x0429e9ee08, sprite_facing:front, original_T:table: 0x03fff7f808, velocity:table: 0x03ffe44908 (more...)}
	 layer = nil
(8) Lua method 'draw' at file 'lua_files/jokers/uncommon/moveblock.lua:87' (from mod with id CelesteCardCollection)
	Local variables:
	 self = table: 0x03ffde8780  {T:table: 0x03ffdf27b0, layered_parallax:table: 0x0429e9ee08, sprite_facing:front, original_T:table: 0x03fff7f808, velocity:table: 0x03ffe44908 (more...)}
	 layer = nil
(9) Lua upvalue 'game_drawref' at file 'game.lua:3730'
	Local variables:
	 self = table: 0x01128cc6b8  {ROOM:table: 0x031fde4ab8, CARD_W:2.0487804878049, CARD_H:2.7512195121951, F_MUTE:false, PITCH_MOD:1, HIGHLIGHT_H:0.55024390243902, P_CENTERS:table: 0x031f990930 (more...)}
	 (for generator) = C function: next
	 (for state) = table: 0x031f8be100  {1:table: 0x03fff781c0, 2:table: 0x040dba7248, 3:table: 0x032e602248, 4:table: 0x032cf67888, 5:table: 0x040dae15b0, 6:table: 0x040da64318, 7:table: 0x03fff09da0 (more...)}
	 (for control) = userdata: NULL
	 k = number: 24
	 v = table: 0x03ffde8780  {T:table: 0x03ffdf27b0, layered_parallax:table: 0x0429e9ee08, sprite_facing:front, original_T:table: 0x03fff7f808, velocity:table: 0x03ffe44908 (more...)}
(10) Lua upvalue 'olddraw' at file 'MoreFluff.lua:1081' (from mod with id MoreFluff)
	Local variables:
	 self = table: 0x01128cc6b8  {ROOM:table: 0x031fde4ab8, CARD_W:2.0487804878049, CARD_H:2.7512195121951, F_MUTE:false, PITCH_MOD:1, HIGHLIGHT_H:0.55024390243902, P_CENTERS:table: 0x031f990930 (more...)}
(11) Lua method 'draw' at file 'steamodded.lua:80' (from mod with id toomanyjokers)
(12) Lua upvalue 'olddraw' at file 'main.lua:1032'
(13) Lua field 'draw' at file 'TMJ/defineUI.lua:228' (from mod with id toomanyjokers)
(14) Lua function '?' at file 'main.lua:952' (best guess)
(15) global C function 'xpcall'
(16) LÖVE function at file 'boot.lua:377' (best guess)
	Local variables:
	 func = Lua function '?' (defined at line 915 of chunk main.lua)
	 inerror = boolean: true
	 deferErrhand = Lua function '(LÖVE Function)' (defined at line 348 of chunk [love "boot.lua"])
	 earlyinit = Lua function '(LÖVE Function)' (defined at line 355 of chunk [love "boot.lua"])

INFO - [G] file not found: engine/sprite.lua: No such file or directory
INFO - [G] file not found: main.lua: No such file or directory
INFO - [G] file not found: main.lua: No such file or directory
INFO - [G] 2025-05-08 03:17:32 :: INFO  :: StackTrace :: Additional Context:
Balatro Version: 1.0.1o-FULL
Modded Version: 1.0.0~BETA-0506d-STEAMODDED
LÖVE Version: 11.5.0
Lovely Version: 0.7.1
Platform: OS X
Steamodded Mods:
    1: Too Many Jokers by cg [ID: toomanyjokers, Priority: 1000000, Uses Lovely]
    2: DebugPlus by WilsontheWolf [ID: DebugPlus, Version: 1.5.0~dev, Uses Lovely]
    3: Lucky Jimbos: Joker Pack by LuckySix [ID: L6_luckyjimbo, Version: 0.3~alpha-5]
    4: Garbshit by garb [ID: GARBPACK, Version: 2.0.1, Uses Lovely]
    5: Mistigris by astrapboy [ID: mistigris, Priority: 69, Version: 0.5.0-dev_25w14b, Uses Lovely]
    6: Bird Jokers by Justin [ID: BirdJokers, Uses Lovely]
    7: Bakery by BakersDozenBagels [ID: Bakery, Version: 2.7.3, Uses Lovely]
    8: More Fluff by notmario, CHECK CREDITS IN MOD TAB [ID: MoreFluff, Version: 1.5.1, Uses Lovely]
    9: Redux Arcanum by itayfeder, Lyman, Jumbo [ID: ReduxArcanum, Version: 2.0.0~PreRelease5, Uses Lovely]
    10: Handy by SleepyG11 [ID: Handy, Version: 1.4.2a, Uses Lovely]
    11: Plantain by TeamToaster [ID: plantain, Priority: 1, Version: 1.0.0, Uses Lovely]
    12: Betmma Jokers by Betmma [ID: BetmmaJokers]
    13: rcBLib by realicraft [ID: rcblib, Priority: 120, Version: 1.1.0, Uses Lovely]
    14: JankJonklersMod by Lyman [ID: JankJonklersMod]
    15: Seven Deadly Decks by AstroLightz [ID: 7DeadlyDecks, Priority: -5, Version: 1.1.0]
    16: Betmma Voucher Pack by Betmma, nicholassam6425 [ID: BetmmaVoucherPack]
    17: Familiar by RattlingSnow353, humplydinkle [ID: familiar, Priority: 1, Version: 0.2.0, Uses Lovely]
    18: Betmma Vouchers by Betmma [ID: BetmmaVouchers, Priority: -1, Version: 3.0.2.2(20250504)]
    19: TIWMIG by Oinite [ID: tiwmig, Version: 0.1.0, Uses Lovely]
    20: Reverie by DVRP [ID: Reverie, Priority: 1, Version: 1.5.3b, Uses Lovely]
    21: Balatro+ by SomeCoder99 [ID: balatro_plus, Version: 1.0.2-a, Uses Lovely]
    22: sortatro by nnmrts [ID: sortatro, Version: 0.1.0]
    23: Custom Suit Order by DigitalDetective47 [ID: SuitOrder, Priority: 1.79e+308, Version: 1.0.2]
    24: rcBalatro by realicraft [ID: rcbalatro, Priority: 126, Version: 0.2.2]
    25: Better Vouchers This Run UI by Betmma [ID: BetterVouchersThisRunUI]
    26: Lobotomy Corporation by Mysthaps [ID: LobotomyCorp, Version: 1.2.0c, Uses Lovely]
    27: Handsome Devils by Kars, sup3p [ID: HandsomeDevils, Version: 1.0.0, Uses Lovely]
    28: Grim by mathguy [ID: GRM, Version: 1.2.6d, Uses Lovely]
    29: TOGA's Stuff by TheOneGoofAli [ID: TOGAPack, Priority: 2, Version: 1.4.0, Uses Lovely]
    30: Warp Zone! by Freh [ID: Wzone, Uses Lovely]
    31: Severed by frogzsj [ID: svrd, Priority: 13, Version: 0.1, Uses Lovely]
    32: Fusion Jokers by itayfeder, Lyman [ID: FusionJokers, Priority: -10000]
    33: Card Sleeves by Larswijn [ID: CardSleeves, Priority: -10, Version: 1.7.5, Uses Lovely]
    34: 5 legendary challenges by Betmma [ID: legendaryChallenges]
    35: Revo's Vault by CodeRevo [ID: RevosVault, Version: 4.2.0d, Uses Lovely]
    36: Buffoonery by PinkMaggit [ID: Buffoonery, Version: 1.2.1, Uses Lovely]
    37: Celeste Card Collection by AuroraAquir, toneblock, Gappie, bein, sunsetquasar, goose! [ID: CelesteCardCollection, Priority: 10, Version: 0.37.4, Uses Lovely]
    38: KCVanilla by krackocloud [ID: kcvanilla, Version: 2.4.1, Uses Lovely]
    39: Jank Challenges by Lyman [ID: JankChallenges]
    40: Cartomancer by stupxd aka stupid [ID: cartomancer, Priority: 69, Version: 4.13-hotfix, Uses Lovely]
    41: Tsu's Jeopardy by tje.tsu [ID: TsusJeo, Version: 0.25 [TEST RELEASE]]
    42: Galdur by Eremel_ [ID: galdur, Priority: -10000, Version: 1.2, Uses Lovely]
    43: Victin's Collection by Victin [ID: victinscollection, Uses Lovely]
    44: Sarcpot by SarcasticPotato [ID: sarcpot, Version: 0.1.10, Uses Lovely]
    45: Stuffz by Mini [ID: Stuffz, Version: 1.1.1]
    46: JokerDisplay by nh6574 [ID: JokerDisplay, Priority: -100000, Version: 1.8.4.1]
    47: Prism by Blazingulag [ID: Prism, Version: 1.9.0-ALPHA, Uses Lovely]
    48: JokerSellValue by OppositeWolf770 [ID: JokerSellValue, Priority: 100000, Version: 1.2.1]
    49: Unjankify by Blazingulag [ID: Unjank, Version: 1.0.0, Uses Lovely]
    50: Rift-Raft by vitellary [ID: RiftRaft, Priority: 115, Version: 1.0.0, Uses Lovely]
    51: UnStableEX by Kirbio [ID: UnStableEX, Priority: 99999, Version: 0.2.2e]
    52: Snows Mods by RattlingSnow353 [ID: SnowMods, Version: 0.2.0]
    53: UnStable by Kirbio, RamChops Games [ID: UnStable, Priority: 777, Version: 1.2b, Uses Lovely]
    54: Mossed by Larantula, Jetziel [ID: mossed, Priority: -20, Version: 1.0.0]
    55: SoulEverything by OppositeWolf770 [ID: SoulEverything, Version: 1.2.0]
    56: Showdown by Mistyk__ [ID: showdown, Priority: 5, Version: 1.3, Uses Lovely]
    57: 3x Credits by AuroraAquir [ID: 3xCredits, Priority: -33, Version: 1.0.0, Uses Lovely]
    58: All in Jest by Nevernamed, survivalaiden, RattlingSnow353 [ID: allinjest, Priority: 9999, Version: 0.2.2]
    59: SDM_0's Stuff by SDM_0 [ID: sdm0sstuff, Version: 1.6.4o, Uses Lovely]
    60: Joker Evolution by SDM_0 [ID: joker_evolution, Priority: -1000, Version: 1.2.3c, Uses Lovely]
    61: Neato Jokers by Neato [ID: Neato_Jokers, Version: 1.1.6]
    62: ExtraCredit by CampfireCollective [ID: extracredit, Priority: 1, Version: 1.3.0, Uses Lovely]
    63: Balatro Goes Kino by IcyEthics [ID: kino, Version: 0.9.0b, Uses Lovely]
    64: Lucky Rabbit by Fennex, Trif, HarmoniousJoker [ID: LuckyRabbit, Version: 1.1.0, Uses Lovely]
    65: Malverk by Eremel_ [ID: malverk, Priority: -999999, Version: 1.1.3a, Uses Lovely]
    66: Paperback by PaperMoon, OppositeWolf770, srockw, Nether, B [ID: paperback, Version: 0.6.4b, Uses Lovely]
    67: Banner by SylviBlossom [ID: banner, Version: 1.1.1, Uses Lovely]
    68: FickleFox by FoxDeploy [ID: fickleFox, Priority: 1, Version: 0.0.4, Uses Lovely]
    69: Reverse Tarot + Hijinks by SkywawrdTARDIS [ID: reverse_tarot, Version: 1.5.5, Uses Lovely]
    70: Cosmos by Cosmos [ID: Cosmos, Version: 0.0.3, Uses Lovely]
    71: Blueprint by stupxd aka stupid, Jonathan [ID: blueprint, Priority: 69, Version: 3.3, Uses Lovely]
Lovely Mods:
```