### PR TITLE
fix hc art for custom rank + custom suit cards

### DIFF
--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -1818,7 +1818,8 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
                             ranks = {'Ace', 'King', 'Queen', 'Jack', '10', '9', '8', '7', '6', '5', '4', '3', '2'},
                             display_ranks = {'King', 'Queen', 'Jack'},
                             atlas = self.hc_atlas,
-                            pos_style = 'deck'
+                            pos_style = 'deck',
+			    hc_default = true
                         } or nil,
                     }
                 }


### PR DESCRIPTION
If a mod adds art for a custom rank in a custom suit, and that custom suit is set to high-contrast art and the default deck skin, the custom ranks would still load the low-contrast art. This fixes that.



## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
