### PR TITLE
Add text styling to poker hand tips

### DIFF
--- a/lovely/poker_hand_screen.toml
+++ b/lovely/poker_hand_screen.toml
@@ -16,3 +16,16 @@ if v.edition then card:set_edition(v.edition, true, true) end
 if v.seal then card:set_seal(v.seal, true, true) end
 '''
 match_indent = true
+
+# Add text styling to poker hand screen
+# create_popup_UIBox_tooltip
+[[patches]]
+[patches.pattern]
+target = "functions/UI_definitions.lua"
+pattern = '''local r = {n=G.UIT.R, config={align = "cm", padding = 0.03}, nodes={
+                {n=G.UIT.T, config={text = text[i],colour = G.C.UI.TEXT_DARK, scale = 0.4}}}}'''
+position = "at"
+payload = '''
+local r = {n=G.UIT.R, config={align = "cm", padding = 0.03}, nodes=SMODS.localize_box(loc_parse_string(text[i]), {scale = 1.25})}
+'''
+match_indent = true


### PR DESCRIPTION
Adds support for text formatting like in card descriptions to poker hand tips. 

The only detail is that `s` is based on the description scale of `0.32` instead of the poker hand tooltip scale of `0.4` so anything smaller than `{s:1.25}` will be smaller than normal text. And V and B are obviously not supported without `loc_vars`.

![Captura de pantalla 2025-05-24 193639](https://github.com/user-attachments/assets/63f5cdb4-71de-4637-aa96-6f421e25c76b)

![Captura de pantalla 2025-05-24 194036](https://github.com/user-attachments/assets/5125ec8f-68a8-447a-9aef-c08b71e53df1)
![Captura de pantalla 2025-05-24 194052](https://github.com/user-attachments/assets/8fe79a6a-350e-4a18-8cee-384f604c4d18)


As far as I can find the only other place in vanilla that uses the patched function are these tooltips in deck view but they are unaffected.

![Captura de pantalla 2025-05-24 193523](https://github.com/user-attachments/assets/b5d16ff6-925a-4105-847d-5cc3c596321d)

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
