### PR TITLE
Add glass_trigger to Glass Cards destroyed by their own effect

### DIFF
--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -3038,6 +3038,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
     SMODS.Enhancement:take_ownership('glass', {
         calculate = function(self, card, context)
             if context.destroy_card and context.cardarea == G.play and context.destroy_card == card and pseudorandom('glass') < G.GAME.probabilities.normal/card.ability.extra then
+                card.glass_trigger = true
                 return { remove = true }
             end
         end,


### PR DESCRIPTION
Adds glass_trigger to destroyed Glass cards similar to lucky_trigger for Lucky cards. This allows checking if any glass shattered because of its own trigger in context.remove_playing_cards.

I've seen multiple devs asking how to do this on the Balatro server recently being recommended to use take_ownership and I've already seen it cause conflicts because multiple devs wanted to take_ownership for similar reasons but another mod did beforehand. For that, I think this would be a cool addition to SMODS.

I don't believe the flag has to be cleared as the card is removed after, but I could be wrong.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
