### PR TITLE
Fix copy_card back sprite bug

### DIFF
--- a/lovely/center.toml
+++ b/lovely/center.toml
@@ -401,6 +401,20 @@ position = 'at'
 payload = '''
 discover = SMODS.bypass_create_card_discover or area==G.jokers or area==G.consumeables, '''
 
+# Fix vanilla copy_card back bug
+# copy_card()
+[[patches]]
+[patches.pattern]
+target = "functions/common_events.lua"
+pattern = '''
+local new_card = new_card or Card(other.T.x, other.T.y, G.CARD_W*(card_scale or 1), G.CARD_H*(card_scale or 1), G.P_CARDS.empty, G.P_CENTERS.c_base, {playing_card = playing_card})
+'''
+position = "at"
+payload = '''
+local new_card = new_card or Card(other.T.x, other.T.y, G.CARD_W*(card_scale or 1), G.CARD_H*(card_scale or 1), G.P_CARDS.empty, G.P_CENTERS.c_base, {playing_card = playing_card, bypass_back = G.GAME.selected_back.pos})
+'''
+match_indent = true
+
 # Card:add_to_deck()
 [[patches]]
 [patches.regex]


### PR DESCRIPTION
Fixes vanilla bug where a card copied with copy_card has it's atlas position changed to 0, 0. It does the same `create_card` does to assign the current back.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
