### PR TITLE
`SMODS.showman()`

### DIFF
--- a/lovely/center.toml
+++ b/lovely/center.toml
@@ -367,7 +367,7 @@ match_indent = true
 position = 'after'
 payload = '''
     for _, v in ipairs(SMODS.Consumable.legendaries) do
-        if (_type == v.type.key or _type == v.soul_set) and not (G.GAME.used_jokers[v.key] and not next(find_joker("Showman")) and not v.can_repeat_soul) and (not v.in_pool or (type(v.in_pool) ~= "function") or v:in_pool()) then
+        if (_type == v.type.key or _type == v.soul_set) and not (G.GAME.used_jokers[v.key] and not SMODS.showman() and not v.can_repeat_soul) and (not v.in_pool or (type(v.in_pool) ~= "function") or v:in_pool()) then
             if pseudorandom('soul_'..v.key.._type..G.GAME.round_resets.ante) > (1 - v.soul_rate) then
                 forced_key = v.key
             end
@@ -400,6 +400,24 @@ match_indent = true
 position = 'at'
 payload = '''
 discover = SMODS.bypass_create_card_discover or area==G.jokers or area==G.consumeables, '''
+
+[[patches]]
+[patches.pattern]
+target = 'functions/common_events.lua'
+pattern = '''not (G.GAME.used_jokers['c_soul'] and not next(find_joker("Showman")))  then'''
+match_indent = true
+position = 'at'
+payload = '''
+not (G.GAME.used_jokers['c_soul'] and not SMODS.showman()) then'''
+
+[[patches]]
+[patches.pattern]
+target = 'functions/common_events.lua'
+pattern = '''not (G.GAME.used_jokers['c_black_hole'] and not next(find_joker("Showman")))  then'''
+match_indent = true
+position = 'at'
+payload = '''
+not (G.GAME.used_jokers['c_black_hole'] and not SMODS.showman()) then'''
 
 # Fix vanilla copy_card back bug
 # copy_card()

--- a/lovely/center.toml
+++ b/lovely/center.toml
@@ -149,7 +149,6 @@ pattern = 'elseif desc_nodes ~= full_UI_table.main then'
 payload = 'elseif desc_nodes ~= full_UI_table.main and not desc_nodes.name then'
 
 
-
 # check_for_unlock()
 [[patches]]
 [patches.regex]
@@ -367,7 +366,7 @@ match_indent = true
 position = 'after'
 payload = '''
     for _, v in ipairs(SMODS.Consumable.legendaries) do
-        if (_type == v.type.key or _type == v.soul_set) and not (G.GAME.used_jokers[v.key] and not SMODS.showman() and not v.can_repeat_soul) and (not v.in_pool or (type(v.in_pool) ~= "function") or v:in_pool()) then
+        if (_type == v.type.key or _type == v.soul_set) and not (G.GAME.used_jokers[v.key] and not SMODS.showman(v.key) and not v.can_repeat_soul) and (not v.in_pool or (type(v.in_pool) ~= "function") or v:in_pool()) then
             if pseudorandom('soul_'..v.key.._type..G.GAME.round_resets.ante) > (1 - v.soul_rate) then
                 forced_key = v.key
             end
@@ -408,7 +407,7 @@ pattern = '''not (G.GAME.used_jokers['c_soul'] and not next(find_joker("Showman"
 match_indent = true
 position = 'at'
 payload = '''
-not (G.GAME.used_jokers['c_soul'] and not SMODS.showman()) then'''
+not (G.GAME.used_jokers['c_soul'] and not SMODS.showman('c_soul')) then'''
 
 [[patches]]
 [patches.pattern]
@@ -417,7 +416,7 @@ pattern = '''not (G.GAME.used_jokers['c_black_hole'] and not next(find_joker("Sh
 match_indent = true
 position = 'at'
 payload = '''
-not (G.GAME.used_jokers['c_black_hole'] and not SMODS.showman()) then'''
+not (G.GAME.used_jokers['c_black_hole'] and not SMODS.showman('c_black_hole')) then'''
 
 # Fix vanilla copy_card back bug
 # copy_card()
@@ -483,7 +482,7 @@ target = 'functions/button_callbacks.lua'
 match_indent = true
 position = 'before'
 pattern = '''
-if area and area.cards[1] then 
+if area and area.cards[1] then
 '''
 payload = '''
 if nc and not area then G.consumeables:emplace(card) end

--- a/lovely/pool.toml
+++ b/lovely/pool.toml
@@ -122,7 +122,7 @@ target = 'functions/common_events.lua'
 pattern = 'elseif not (G.GAME.used_jokers[v.key] and not next(find_joker("Showman"))) and'
 match_indent = true
 position = 'at'
-payload = '''elseif not (G.GAME.used_jokers[v.key] and not pool_opts.allow_duplicates and not next(find_joker("Showman"))) and'''
+payload = '''elseif not (G.GAME.used_jokers[v.key] and not pool_opts.allow_duplicates and not SMODS.showman()) and'''
 
 [[patches]]
 [patches.pattern]

--- a/lovely/pool.toml
+++ b/lovely/pool.toml
@@ -172,7 +172,7 @@ target = "card.lua"
 pattern = '''
 (?<indent>[\t ]*)for k, v in pairs\(G\.P_CENTERS\) do
 [\t ]*if v\.name == self\.ability\.name then
-[\t ]*if not next\(find_joker\(self\.ability\.name, true\)\) then
+[\t ]*if not next\(find_joker\(self\.ability\.name, true\)\) then 
 [\t ]*G\.GAME\.used_jokers\[k\] = nil
 [\t ]*end
 [\t ]*end

--- a/lovely/pool.toml
+++ b/lovely/pool.toml
@@ -32,13 +32,13 @@ pattern = "keys[#keys+1] = {k = k,v = v}"
 position = "at"
 payload = """
 local keep = true
-local in_pool_func = 
+local in_pool_func =
     args and args.in_pool
     or type(v) == 'table' and type(v.in_pool) == 'function' and v.in_pool
     or _t == G.P_CARDS and function(c)
             --Handles special case for Erratic Deck
             local initial_deck = args and args.starting_deck or false
-            
+
             return not (
                 type(SMODS.Ranks[c.value].in_pool) == 'function' and not SMODS.Ranks[c.value]:in_pool({initial_deck = initial_deck, suit = c.suit})
                 or type(SMODS.Suits[c.suit].in_pool) == 'function' and not SMODS.Suits[c.suit]:in_pool({initial_deck = initial_deck, rank = c.value})
@@ -122,7 +122,7 @@ target = 'functions/common_events.lua'
 pattern = 'elseif not (G.GAME.used_jokers[v.key] and not next(find_joker("Showman"))) and'
 match_indent = true
 position = 'at'
-payload = '''elseif not (G.GAME.used_jokers[v.key] and not pool_opts.allow_duplicates and not SMODS.showman()) and'''
+payload = '''elseif not (G.GAME.used_jokers[v.key] and not pool_opts.allow_duplicates and not SMODS.showman(v.key)) and'''
 
 [[patches]]
 [patches.pattern]
@@ -172,7 +172,7 @@ target = "card.lua"
 pattern = '''
 (?<indent>[\t ]*)for k, v in pairs\(G\.P_CENTERS\) do
 [\t ]*if v\.name == self\.ability\.name then
-[\t ]*if not next\(find_joker\(self\.ability\.name, true\)\) then 
+[\t ]*if not next\(find_joker\(self\.ability\.name, true\)\) then
 [\t ]*G\.GAME\.used_jokers\[k\] = nil
 [\t ]*end
 [\t ]*end

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2419,7 +2419,7 @@ function SMODS.draw_cards(hand_space)
     }))
 end
 
-function SMODS.showman()
+function SMODS.showman(card_key)
     if next(SMODS.find_card('j_ring_master')) then
         return true
     end

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2419,6 +2419,13 @@ function SMODS.draw_cards(hand_space)
     }))
 end
 
+function SMODS.showman()
+    if next(SMODS.find_card('j_ring_master')) then
+        return true
+    end
+    return false
+end
+
 function SMODS.four_fingers()
     if next(SMODS.find_card('j_four_fingers')) then
         return 4


### PR DESCRIPTION
Adds a function for mods to hook when the game checks for Showman to allow Showman-like effects. Additionally, it takes the key of the card to generate in order to be more granular with the effect.

Following #659 I've noticed updating [Vanilla Remade](https://github.com/nh6574/VanillaRemade) that Showman was the only joker to not have a graceful implementation using only SMODS and hooks (though the solution was simply to force the name to be "Showman")

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
