### PR TITLE
`get_current_pool` for editions

### DIFF
--- a/lovely/pool.toml
+++ b/lovely/pool.toml
@@ -119,6 +119,20 @@ pool_opts = pool_opts or {}
 [[patches]]
 [patches.pattern]
 target = 'functions/common_events.lua'
+pattern = '''
+if _type == 'Enhanced' then
+    add = true
+'''
+match_indent = true
+position = 'after'
+payload = '''
+elseif _type == 'Edition' then
+    if v.in_shop then add = true end
+'''
+
+[[patches]]
+[patches.pattern]
+target = 'functions/common_events.lua'
 pattern = 'elseif not (G.GAME.used_jokers[v.key] and not next(find_joker("Showman"))) and'
 match_indent = true
 position = 'at'
@@ -134,6 +148,18 @@ payload = '''
 if v.in_pool and type(v.in_pool) == 'function' then
     add = in_pool and (add or pool_opts.override_base_checks)
 end
+'''
+
+[[patches]]
+[patches.pattern]
+target = 'functions/common_events.lua'
+pattern = '''
+elseif _type == 'Tag' then _pool[#_pool + 1] = "tag_handy"
+'''
+match_indent = true
+position = 'after'
+payload = '''
+elseif _type == 'Edition' then _pool[#_pool + 1] = "e_foil"
 '''
 
 ## G.GAME.used_jokers now checks keys, not names

--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -3238,6 +3238,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
         sound = { sound = "foil1", per = 1.2, vol = 0.4 },
         weight = 20,
         extra_cost = 2,
+        in_shop = true,
         get_weight = function(self)
             return G.GAME.edition_rate * self.weight
         end,
@@ -3269,6 +3270,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
         sound = { sound = "holo1", per = 1.2 * 1.58, vol = 0.4 },
         weight = 14,
         extra_cost = 3,
+        in_shop = true,
         get_weight = function(self)
             return G.GAME.edition_rate * self.weight
         end,
@@ -3300,6 +3302,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
         sound = { sound = "polychrome1", per = 1.2, vol = 0.7 },
         weight = 3,
         extra_cost = 5,
+        in_shop = true,
         get_weight = function(self)
             return (G.GAME.edition_rate - 1) * G.P_CENTERS["e_negative"].weight + G.GAME.edition_rate * self.weight
         end,
@@ -3331,6 +3334,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
         sound = { sound = "negative", per = 1.5, vol = 0.4 },
         weight = 3,
         extra_cost = 5,
+        in_shop = true,
         get_weight = function(self)
             return self.weight
         end,

--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -1958,7 +1958,6 @@ function poll_edition(_key, _mod, _no_neg, _guaranteed, _options)
         	table.insert(available_editions, edition_option)
         end
     end
-	print(available_editions)
 
 	-- Calculate total weight of editions
 	local total_weight = 0

--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -1938,28 +1938,27 @@ function poll_edition(_key, _mod, _no_neg, _guaranteed, _options)
 	local available_editions = {}                                          -- Table containing a list of editions and their weights
 
 	if not _options then
-		_options = { 'e_negative', 'e_polychrome', 'e_holo', 'e_foil' }
 		if _key == "wheel_of_fortune" or _key == "aura" then -- set base game edition polling
+			_options = { 'e_negative', 'e_polychrome', 'e_holo', 'e_foil' }
 		else
-			for _, v in ipairs(G.P_CENTER_POOLS.Edition) do
-				local in_pool = (v.in_pool and type(v.in_pool) == "function") and v:in_pool({source = _key})
-				if in_pool or v.in_shop then
-					table.insert(_options, v.key)
-				end
-			end
+			_options = get_current_pool("Edition", nil, nil, _key or 'edition_generic')
 		end
 	end
-	for _, v in ipairs(_options) do
-		local edition_option = {}
-		if type(v) == 'string' then
-			assert(string.sub(v, 1, 2) == 'e_', ("Edition \"%s\" is missing \"e_\" prefix."):format(v))
-			edition_option = { name = v, weight = G.P_CENTERS[v].weight }
-		elseif type(v) == 'table' then
-			assert(string.sub(v.name, 1, 2) == 'e_', ("Edition \"%s\" is missing \"e_\" prefix."):format(v.name))
-			edition_option = { name = v.name, weight = v.weight }
-		end
-		table.insert(available_editions, edition_option)
-	end
+    for _, v in ipairs(_options) do
+        local edition_option = {}
+        if type(v) == 'string' then
+            if v ~= 'UNAVAILABLE' then
+                assert(string.sub(v, 1, 2) == 'e_', ("Edition \"%s\" is missing \"e_\" prefix."):format(v))
+                edition_option = { name = v, weight = G.P_CENTERS[v].weight }
+        		table.insert(available_editions, edition_option)
+            end
+        elseif type(v) == 'table' then
+            assert(string.sub(v.name, 1, 2) == 'e_', ("Edition \"%s\" is missing \"e_\" prefix."):format(v.name))
+            edition_option = { name = v.name, weight = v.weight }
+        	table.insert(available_editions, edition_option)
+        end
+    end
+	print(available_editions)
 
 	-- Calculate total weight of editions
 	local total_weight = 0


### PR DESCRIPTION
Added the ability to use `get_current_pool("Edition")` and modified `poll_edition` to use it. Also added `in_shop = true` to the vanilla editions for this change.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
