### PR TITLE
(Better) Playing card support for SMODS.create_card

### DIFF
--- a/lovely/center.toml
+++ b/lovely/center.toml
@@ -377,6 +377,15 @@ payload = '''
 [[patches]]
 [patches.pattern]
 target = 'functions/common_events.lua'
+pattern = "local card = Card(area.T.x + area.T.w/2, area.T.y, G.CARD_W, G.CARD_H, front, center,"
+match_indent = true
+position = 'at'
+payload = '''
+local card = Card(area.T.x + area.T.w/2, area.T.y, G.CARD_W, G.CARD_H, SMODS.set_create_card_front or front, center,'''
+
+[[patches]]
+[patches.pattern]
+target = 'functions/common_events.lua'
 pattern = "{bypass_discovery_center = area==G.shop_jokers or area == G.pack_cards or area == G.shop_vouchers or (G.shop_demo and area==G.shop_demo) or area==G.jokers or area==G.consumeables,"
 match_indent = true
 position = 'at'

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -364,13 +364,26 @@ function SMODS.create_card(t)
     if not t.area and not t.key and t.set and SMODS.ConsumableTypes[t.set] then
         t.area = G.consumeables
     end
+    if not t.key and t.set == 'Playing Card' or t.set == 'Base' or t.set == 'Enhanced' or (not t.set and (t.front or t.rank or t.suit)) then
+        t.set = t.set == 'Playing Card' and (pseudorandom('front' .. (t.key_append or '') .. G.GAME.round_resets.ante) > (t.enhancement_poll or 0.6) and 'Enhanced' or 'Base') or t.set or 'Base'
+        t.area = t.area or G.hand
+        if not t.front then
+            t.suit = t.suit and (SMODS.Suits["".. t.suit] or {}).card_key or t.suit or
+            pseudorandom_element(SMODS.Suits, pseudoseed('front' .. (t.key_append or '') .. G.GAME.round_resets.ante)).card_key
+            t.rank = t.rank and (SMODS.Ranks["".. t.rank] or {}).card_key or t.rank or
+            pseudorandom_element(SMODS.Ranks, pseudoseed('front' .. (t.key_append or '') .. G.GAME.round_resets.ante)).card_key
+        end
+        t.front = t.front or (t.suit .. "_" .. t.rank)
+    end
     SMODS.bypass_create_card_edition = t.no_edition or t.edition
     SMODS.bypass_create_card_discover = t.discover
     SMODS.bypass_create_card_discovery_center = t.bypass_discovery_center
+    SMODS.set_create_card_front = G.P_CARDS[t.front]
     local _card = create_card(t.set, t.area, t.legendary, t.rarity, t.skip_materialize, t.soulable, t.key, t.key_append)
     SMODS.bypass_create_card_edition = nil
     SMODS.bypass_create_card_discover = nil
     SMODS.bypass_create_card_discovery_center = nil
+    SMODS.set_create_card_front = nil
 
     -- Should this be restricted to only cards able to handle these
     -- or should that be left to the person calling SMODS.create_card to use it correctly?
@@ -391,6 +404,11 @@ end
 
 function SMODS.add_card(t)
     local card = SMODS.create_card(t)
+    if t.set == "Base" or t.set == "Enhanced" then
+        G.playing_card = (G.playing_card and G.playing_card + 1) or 1
+        card.playing_card = G.playing_card
+        table.insert(G.playing_cards, card)
+    end
     card:add_to_deck()
     local area = t.area or G.jokers
     area:emplace(card)

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -365,7 +365,7 @@ function SMODS.create_card(t)
         t.area = G.consumeables
     end
     if not t.key and t.set == 'Playing Card' or t.set == 'Base' or t.set == 'Enhanced' or (not t.set and (t.front or t.rank or t.suit)) then
-        t.set = t.set == 'Playing Card' and (pseudorandom('front' .. (t.key_append or '') .. G.GAME.round_resets.ante) > (t.enhanced_poll or 0.6) and 'Enhanced' or 'Base') or t.set or 'Base'
+        t.set = t.set == 'Playing Card' and t.enhancement and 'Base' or (pseudorandom('front' .. (t.key_append or '') .. G.GAME.round_resets.ante) > (t.enhanced_poll or 0.6) and 'Enhanced' or 'Base') or t.set or 'Base'
         t.area = t.area or G.hand
         if not t.front then
             t.suit = t.suit and (SMODS.Suits["".. t.suit] or {}).card_key or t.suit or

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -365,7 +365,7 @@ function SMODS.create_card(t)
         t.area = G.consumeables
     end
     if not t.key and t.set == 'Playing Card' or t.set == 'Base' or t.set == 'Enhanced' or (not t.set and (t.front or t.rank or t.suit)) then
-        t.set = t.set == 'Playing Card' and (pseudorandom('front' .. (t.key_append or '') .. G.GAME.round_resets.ante) > (t.enhancement_poll or 0.6) and 'Enhanced' or 'Base') or t.set or 'Base'
+        t.set = t.set == 'Playing Card' and (pseudorandom('front' .. (t.key_append or '') .. G.GAME.round_resets.ante) > (t.enhanced_poll or 0.6) and 'Enhanced' or 'Base') or t.set or 'Base'
         t.area = t.area or G.hand
         if not t.front then
             t.suit = t.suit and (SMODS.Suits["".. t.suit] or {}).card_key or t.suit or


### PR DESCRIPTION
Better handling of playing cards with SMODS.create_card and add_card. 

`set` now takes `Playing Card` for a random choice between `Base` and `Enhanced` and all three sets now default to `G.hand` as the `area` instead of `G.jokers`.

Additionally the following parameters are added:

`front`: Front of the playing card, formatted like `S_R`. Added to maintain a formatting similar to `create_playing_card` for those who need it. Ignores `rank` and `suit`.
`rank`: Takes both the `key` or the `card_key` (allows integers for vanilla ranks).
`suit`: Takes both the `key` or the `card_key`
`enhanced_poll`: To modify the chance of choosing `Base` or `Enhanced` with set `Playing Card`. Default: 0.6

`SMODS.add_card` adds to the `G.playing_card` counter and inserts the card into `G.playing_cards`. I thought it made more sense than `SMODS.create_card` doing it.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
