### PR TITLE
Add dollar_buffer calculation to `dollars` return (Resolves #709)

### DIFF
--- a/src/utils.lua
+++ b/src/utils.lua
@@ -1250,6 +1250,7 @@ SMODS.calculate_individual_effect = function(effect, scored_card, key, amount, f
 
     if (key == 'p_dollars' or key == 'dollars' or key == 'h_dollars') and amount then
         if effect.card and effect.card ~= scored_card then juice_card(effect.card) end
+        G.GAME.dollar_buffer = (G.GAME.dollar_buffer or 0) + amount
         ease_dollars(amount)
         if not effect.remove_default_message then
             if effect.dollar_message then
@@ -1258,6 +1259,12 @@ SMODS.calculate_individual_effect = function(effect, scored_card, key, amount, f
                 card_eval_status_text(effect.message_card or effect.juice_card or scored_card or effect.card or effect.focus, 'dollars', amount, percent)
             end
         end
+        G.E_MANAGER:add_event(Event({
+            func = function()
+                G.GAME.dollar_buffer = 0
+                return true
+            end
+        }))
         return true
     end
 


### PR DESCRIPTION
Adds to the dollar_buffer automatically when returning `dollars` in calculations.

I haven't seen this done in mods often or recommended to people as it's somewhat cumbersome to do, but it's important for cards to work properly with other cards that use the dollar amount during scoring.

It will probably mess with mods that are already doing it manually, however.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
