### PR TITLE
Allow `pseudorandom_element` to take strings for seeds

### DIFF
--- a/lovely/pool.toml
+++ b/lovely/pool.toml
@@ -13,6 +13,7 @@ target = "functions/misc_functions.lua"
 pattern = "function pseudorandom_element(_t, seed)"
 position = "at"
 payload = """function pseudorandom_element(_t, seed, args)
+    if seed and type(seed) == "string" then seed = pseudoseed(seed) end
     -- TODO special cases for now
     -- Preserves reverse nominal order for Suits, nominal+face_nominal order for Ranks
     -- for vanilla RNG


### PR DESCRIPTION
I'm tired of this one :)
Even the LSP says it does when it doesn't lol

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
