### PR TITLE
Fix DeckSkin Card UI (Crediting)

### DIFF
--- a/lovely/deck_skins.toml
+++ b/lovely/deck_skins.toml
@@ -240,3 +240,28 @@ else
 end
 '''
 match_indent = true
+
+#=======================#
+# DeckSkin Crediting UI #
+#=======================#
+[[patches]]
+[patches.pattern]
+target = "functions/UI_definitions.lua"
+pattern = '''
+label = "Production",
+chosen = true,
+'''
+position = "at"
+payload = '''
+label = "Production",
+chosen = not SMODS.init_collab_credits,
+'''
+match_indent = true
+
+[[patches]]
+[patches.pattern]
+target = "functions/UI_definitions.lua"
+pattern = '''label = "Collabs",'''
+position = "after"
+payload = '''chosen = SMODS.init_collab_credits,'''
+match_indent = true

--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -2501,32 +2501,14 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
     }
 
     -- weird hook to artificially initialize G.collab_credits early
+    -- this previously used a local recursive function, which broke modded languages
+    SMODS.init_collab_credits = true
     local ps_ref = Game.prep_stage
     function Game:prep_stage(new_stage, new_state, new_game_obj)
         ps_ref(self, new_stage, new_state, new_game_obj)
         if not G.collab_credits then
-            local visited = {}
-            local function recursive_search(t)
-                if visited[t] then return false end
-                visited[t] = true
-                if type(t) == "table" and t.label == "Collabs" and type(t.tab_definition_function) == "function" then
-                    t.tab_definition_function()
-                    return true
-                end
-                for _, v in ipairs(t) do
-                    if type(v) == "table" and recursive_search(v) then
-                        return true
-                    end
-                end
-                for k, v in pairs(t) do
-                    if type(v) == "table" and recursive_search(v) then
-                        return true
-                    end
-                end
-                return false
-            end
             G.FUNCS.show_credits()
-            local result = recursive_search(G.OVERLAY_MENU)
+            SMODS.init_collab_credits = false
             G.FUNCS:exit_overlay_menu()
         end
     end


### PR DESCRIPTION
This addition would break modded languages on game launch with said language selected because there was nothing to stop the recursion, hence causing the "loop in gettable" error.



## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
