### PR TITLE
Fix `SMODS.Gradient` crashing in `attention_text`

### DIFF
--- a/lovely/gradient.toml
+++ b/lovely/gradient.toml
@@ -11,6 +11,46 @@ pattern = "self.C.EDITION[2] = 0.7+0.2*(1+math.sin(self.TIMERS.REAL*1.5 + 6))"
 position = "after"
 payload = '''
 for _,v in pairs(SMODS.Gradients) do
-   v:update(dt) 
+   v:update(dt)
 end'''
+match_indent = true
+
+# Fix for effect messages
+# attention_text
+[[patches]]
+[patches.pattern]
+target = "functions/UI_definitions.lua"
+pattern = "args.colour = copy_table(args.colour or G.C.WHITE)"
+position = "at"
+payload = '''
+args.colour = SMODS.shallow_copy(args.colour or G.C.WHITE)
+'''
+match_indent = true
+
+# attention_text
+[[patches]]
+[patches.pattern]
+target = "functions/UI_definitions.lua"
+pattern = '''
+args.cover_colour = copy_table(args.cover_colour or G.C.RED)
+args.cover_colour_l = copy_table(lighten(args.cover_colour, 0.2))
+args.cover_colour_d = copy_table(darken(args.cover_colour, 0.2))
+'''
+position = "at"
+payload = '''
+args.cover_colour = SMODS.shallow_copy(args.cover_colour or G.C.RED)
+args.cover_colour_l = SMODS.shallow_copy(lighten(args.cover_colour, 0.2))
+args.cover_colour_d = SMODS.shallow_copy(darken(args.cover_colour, 0.2))
+'''
+match_indent = true
+
+# attention_text
+[[patches]]
+[patches.pattern]
+target = "functions/UI_definitions.lua"
+pattern = "args.backdrop_colour = copy_table(args.backdrop_colour)"
+position = "at"
+payload = '''
+args.backdrop_colour = SMODS.shallow_copy(args.backdrop_colour)
+'''
 match_indent = true


### PR DESCRIPTION
Fixes gradients causing a stack overflow when used for messages and other functions that use `attention_text`.

This fix would probably need to be applied in the future to other places that use `copy_table` to copy colours such as the text inputs.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
