### PR TITLE
SMODS.PokerHand function to control visibility

### DIFF
--- a/lovely/poker_hand.toml
+++ b/lovely/poker_hand.toml
@@ -58,3 +58,48 @@ for _, v in ipairs(G.handlist) do
     end
 end'''
 match_indent = true
+
+## is_visible
+
+# create_UIBox_blind_choice
+[[patches]]
+[patches.pattern]
+target = "functions/UI_definitions.lua"
+pattern = '''if v.visible then _poker_hands[#_poker_hands+1] = k end'''
+position = "at"
+payload = '''
+if SMODS.is_poker_hand_visible(k) then _poker_hands[#_poker_hands+1] = k end
+'''
+match_indent = true
+
+# card:calculate_joker
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''if k ~= context.scoring_name and v.played >= play_more_than and v.visible then'''
+position = "at"
+payload = '''
+if k ~= context.scoring_name and v.played >= play_more_than and SMODS.is_poker_hand_visible(k) then
+'''
+match_indent = true
+
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''if v.visible and k ~= self.ability.to_do_poker_hand then _poker_hands[#_poker_hands+1] = k end'''
+position = "at"
+payload = '''
+if SMODS.is_poker_hand_visible(k) and k ~= self.ability.to_do_poker_hand then _poker_hands[#_poker_hands+1] = k end
+'''
+match_indent = true
+
+# card:set_ability
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''if v.visible then _poker_hands[#_poker_hands+1] = k end'''
+position = "at"
+payload = '''
+if SMODS.is_poker_hand_visible(k) then _poker_hands[#_poker_hands+1] = k end
+'''
+match_indent = true

--- a/lovely/poker_hand_screen.toml
+++ b/lovely/poker_hand_screen.toml
@@ -29,3 +29,13 @@ payload = '''
 local r = {n=G.UIT.R, config={align = "cm", padding = 0.03}, nodes=SMODS.localize_box(loc_parse_string(text[i]), {scale = 1.25})}
 '''
 match_indent = true
+
+[[patches]]
+[patches.pattern]
+target = "functions/UI_definitions.lua"
+pattern = '''return (G.GAME.hands[handname].visible) and'''
+position = "at"
+payload = '''
+return SMODS.is_poker_hand_visible(handname) and
+'''
+match_indent = true

--- a/lsp_def/classes/poker_hand.lua
+++ b/lsp_def/classes/poker_hand.lua
@@ -27,7 +27,8 @@
 ---@field take_ownership? fun(self: SMODS.PokerHand|table, key: string, obj: SMODS.PokerHand|table, silent?: boolean): nil|table|SMODS.PokerHand Takes control of vanilla objects. Child class must have get_obj for this to function
 ---@field get_obj? fun(self: SMODS.PokerHand|table, key: string): SMODS.PokerHand|table? Returns an object if one matches the `key`. 
 ---@field evaluate? fun(parts: table, hand: table): table? Determines if played cards contain this hand, and what cards are a part of it. 
----@field modify_display_text? fun(self: SMODS.PokerHand|table, cards: Card[]|table[], scoring_hand: Card[]|table[]): string? Allows modifying the display text when this poker hand's text is meant to display. 
+---@field modify_display_text? fun(self: SMODS.PokerHand|table, cards: Card[]|table[], scoring_hand: Card[]|table[]): string? Allows modifying the display text when this poker hand's text is meant to display.
+---@field is_visible? fun(self:SMODS.PokerHand|table): boolean? Allows more precise control over hand visibility in the poker hands menu. If this function is defined, `visible` is ignored. 
 ---@overload fun(self: SMODS.PokerHand): SMODS.PokerHand
 SMODS.PokerHand = setmetatable({}, {
     __call = function(self)

--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -584,3 +584,8 @@ function SMODS.draw_cards(hand_space) end
 ---@return table
 ---Flattens given calculation returns into one, utilising `extra` tables. 
 function SMODS.merge_effects(...) end
+
+---@param handname string
+---@return boolean
+---Checks if handname is visible in the poker hands menu.
+function SMODS.is_poker_hand_visible(handname) end

--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -1534,7 +1534,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
             if G.GAME.used_vouchers.v_telescope and i == 1 then
                 local _planet, _hand, _tally = nil, nil, 0
                 for k, v in ipairs(G.handlist) do
-                    if G.GAME.hands[v].visible and G.GAME.hands[v].played > _tally then
+                    if SMODS.is_poker_hand_visible(v) and G.GAME.hands[v].played > _tally then
                         _hand = v
                         _tally = G.GAME.hands[v].played
                     end

--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -1506,7 +1506,7 @@ function create_UIBox_current_hands(simple)
 
 	local visible_hands = {}
 	for _, v in ipairs(G.handlist) do
-		if G.GAME.hands[v].visible then
+		if SMODS.is_poker_hand_visible(v) then
 			table.insert(visible_hands, v)
 		end
 	end
@@ -1565,7 +1565,7 @@ G.FUNCS.your_hands_page = function(args)
 
 	local visible_hands = {}
 	for _, v in ipairs(G.handlist) do
-		if G.GAME.hands[v].visible then
+		if SMODS.is_poker_hand_visible(v) then
 			table.insert(visible_hands, v)
 		end
 	end

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2494,3 +2494,10 @@ function SMODS.merge_effects(...)
     end
     return ret
 end
+
+function SMODS.is_poker_hand_visible(handname)
+    if SMODS.PokerHands[handname].is_visible and type(SMODS.PokerHands[handname].is_visible) == "function" then
+        return not not SMODS.PokerHands[handname]:is_visible()
+    end
+    return G.GAME.hands[handname].visible
+end


### PR DESCRIPTION
Adds `is_visible` field to `SMODS.PokerHand` for greater control over the visibility of poker hands. This function takes precedence over `visible`. 

Also adds a `SMODS.is_poker_hand_visible` util function to check if a hand is visible, allowing mods to hook it to manipulate it further. This modifies To Do List, Obelisk, Telescope and Orbital Tag to use this function. (Note: This can cause crashes when less than 2 hands are visible, but I wasn't sure if a fallback should be added or if it should be left to modder's discretion)

I think `is_visible` and `visible` are perhaps too similar, so I accept any other suggestions

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
