### PR TITLE
Front Hiding Revamp

### DIFF
--- a/lovely/enhancement.toml
+++ b/lovely/enhancement.toml
@@ -291,7 +291,7 @@ position = "after"
 payload = "SMODS.enh_cache:clear()"
 match_indent = true
 
-# Invalidate enhancement cache when card changes / Stone Card Fix Part 1
+# Invalidate enhancement cache when card changes / replace_base_card fix pt1
 [[patches]]
 [patches.pattern]
 target = "card.lua"
@@ -300,32 +300,18 @@ position = "after"
 payload = '''  SMODS.enh_cache:write(self, nil)
   
   if self.ability and not initial then
-    self.front_hidden = self:should_hide()
+    self.front_hidden = self:should_hide_front()
   end'''
 match_indent = true
 
-# Stone Card Fix Part 2
-[[patches]]
-[patches.pattern]
-target = "card.lua"
-pattern = "function Card:set_ability(center, initial, delay_sprites)"
-position = 'before'
-payload = '''function Card:should_hide()
-  if not (self.ability and self.ability.effect) then return false end
-  return self.ability.effect == 'Stone Card'
-end
-
-'''
-match_indent = true
-
-# Stone Card Fix Part 3
+# replace_base_card Fix Part 2
 [[patches]]
 [patches.pattern]
 target = "card.lua"
 pattern = "self:set_sprites(center)"
 position = "after"
 payload = '''if self.ability and not initial then
-  self.front_hidden = self:should_hide()
+  self.front_hidden = self:should_hide_front()
 end'''
 match_indent = true
 

--- a/lovely/enhancement.toml
+++ b/lovely/enhancement.toml
@@ -291,13 +291,42 @@ position = "after"
 payload = "SMODS.enh_cache:clear()"
 match_indent = true
 
-# Invalidate enhancement cache when card changes
+# Invalidate enhancement cache when card changes / Stone Card Fix Part 1
 [[patches]]
 [patches.pattern]
 target = "card.lua"
 pattern = "function Card:set_ability(center, initial, delay_sprites)"
 position = "after"
-payload = "SMODS.enh_cache:write(self, nil)"
+payload = '''  SMODS.enh_cache:write(self, nil)
+  
+  if self.ability and not initial then
+    self.front_hidden = self:should_hide()
+  end'''
+match_indent = true
+
+# Stone Card Fix Part 2
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = "function Card:set_ability(center, initial, delay_sprites)"
+position = 'before'
+payload = '''function Card:should_hide()
+  if not (self.ability and self.ability.effect) then return false end
+  return self.ability.effect == 'Stone Card'
+end
+
+'''
+match_indent = true
+
+# Stone Card Fix Part 3
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = "self:set_sprites(center)"
+position = "after"
+payload = '''if self.ability and not initial then
+  self.front_hidden = self:should_hide()
+end'''
 match_indent = true
 
 [[patches]]

--- a/src/card_draw.lua
+++ b/src/card_draw.lua
@@ -28,6 +28,7 @@ SMODS.DrawStep = SMODS.GameObject:extend {
     check_individual_condition = function(self, card, layer, k, v)
         if k == 'vortex' then return not not card.vortex == v end
         if k == 'facing' then return card.sprite_facing == v end
+        if k == 'front_hidden' then return not not card.front_hidden == v end
         return true
     end,
     check_conditions = function(self, card, layer)
@@ -218,7 +219,7 @@ SMODS.DrawStep {
             end
         end
     end,
-    conditions = { vortex = false, facing = 'front' },
+    conditions = { vortex = false, facing = 'front', front_hidden = false },
 }
 SMODS.DrawStep {
     key = 'card_type_shader',
@@ -457,10 +458,6 @@ function Card:draw(layer)
     self.hover_tilt = 1
     if not self.states.visible then return end
     for _, k in ipairs(SMODS.DrawStep.obj_buffer) do
-      if k == 'front' and self.front_hidden then
-        --sendWarnMessage("Should not draw front of "..self.base.name)
-      else
         if SMODS.DrawSteps[k]:check_conditions(self, layer) then SMODS.DrawSteps[k].func(self, layer) end
-      end
     end
 end

--- a/src/card_draw.lua
+++ b/src/card_draw.lua
@@ -457,6 +457,10 @@ function Card:draw(layer)
     self.hover_tilt = 1
     if not self.states.visible then return end
     for _, k in ipairs(SMODS.DrawStep.obj_buffer) do
+      if k == 'front' and self.front_hidden then
+        --sendWarnMessage("Should not draw front of "..self.base.name)
+      else
         if SMODS.DrawSteps[k]:check_conditions(self, layer) then SMODS.DrawSteps[k].func(self, layer) end
+      end
     end
 end

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2494,3 +2494,7 @@ function SMODS.merge_effects(...)
     end
     return ret
 end
+
+function Card:should_hide_front()
+  return self.ability.effect == 'Stone Card' or self.config.center.overrides_base_rank
+end


### PR DESCRIPTION
Fixed an annoying bug with enhanced playing cards that are supposed to have hidden fronts, like Stone Cards, having those fronts be shown just before the enhancement is changed; for example, when Vampire removes the enhancement. It is also much easier to make card enhancements hide the front of the card by overriding the new Card:should_hide() function.

(Any other changes are because I made this with the beta-0614a build; my sincerest apologies for not really knowing what I'm doing GitHub-wise.)



## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
