### PR TITLE
Integrated card value scaling

### DIFF
--- a/lovely/card_scaling.toml
+++ b/lovely/card_scaling.toml
@@ -1,7 +1,7 @@
 [manifest]
 version = "1.0.0"
 dump_lua = true
-priority = 1
+priority = -5
 
 # Injects for global scalar modifiers
 [[patches]]

--- a/lovely/card_scaling.toml
+++ b/lovely/card_scaling.toml
@@ -1,0 +1,239 @@
+[manifest]
+version = "1.0.0"
+dump_lua = true
+priority = 1
+
+# Injects for global scalar modifiers
+[[patches]]
+[patches.pattern]
+target = "game.lua"
+pattern = '''
+probabilities = {
+    normal = 1,
+},
+'''
+position = "after"
+payload = '''
+scalar_mod = {
+    addative = 0,
+    multiplicative = 1
+},
+'''
+match_indent = true
+times = 1
+
+
+# Patch anything with generic x_mult gain
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+self.ability.x_mult = self.ability.x_mult + self.ability.extra
+'''
+position = "at"
+payload = '''
+self.ability.x_mult = SMODS.scale_value(self.ability.x_mult, self.ability.extra, self)
+'''
+match_indent = true
+
+
+# Patch anything with generic mult gain
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+self.ability.mult = self.ability.mult + self.ability.extra
+'''
+position = "at"
+payload = '''
+self.ability.mult = SMODS.scale_value(self.ability.mult, self.ability.extra, self)
+'''
+match_indent = true
+
+
+# Patch anything with generic chip gain
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+self.ability.extra.chips = self.ability.extra.chips + self.ability.extra.chip_mod
+'''
+position = "at"
+payload = '''
+self.ability.extra.chips = SMODS.scale_value(self.ability.extra.chips, self.ability.extra.chip_mod, self)
+'''
+match_indent = true
+
+
+# Patch anything with extra value scaling
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+self.ability.extra_value = self.ability.extra_value + self.ability.extra
+'''
+position = "at"
+payload = '''
+self.ability.extra_value = SMODS.scale_value(self.ability.extra_value, self.ability.extra, self)
+'''
+match_indent = true
+times = 1
+
+
+# Hologram
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+self.ability.x_mult = self.ability.x_mult + #context.cards*self.ability.extra
+'''
+position = "at"
+payload = '''
+self.ability.x_mult = SMODS.scale_value(self.ability.x_mult, #context.cards*self.ability.extra, self)
+'''
+match_indent = true
+times = 1
+
+
+# Ceremonial Dagger
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+self.ability.mult = self.ability.mult + sliced_card.sell_cost*2
+'''
+position = "at"
+payload = '''
+self.ability.mult = SMODS.scale_value(self.ability.mult, sliced_card.sell_cost*2, self)
+'''
+match_indent = true
+times = 1
+
+
+# Canio
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+self.ability.caino_xmult = self.ability.caino_xmult + faces*self.ability.extra
+'''
+position = "at"
+payload = '''
+self.ability.caino_xmult = SMODS.scale_value(self.ability.caino_xmult, faces*self.ability.extra, self)
+'''
+match_indent = true
+times = 1
+
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+self.ability.caino_xmult = self.ability.caino_xmult + face_cards*self.ability.extra
+'''
+position = "at"
+payload = '''
+self.ability.caino_xmult = SMODS.scale_value(self.ability.caino_xmult, face_cards*self.ability.extra, self)
+'''
+match_indent = true
+times = 1
+
+
+# Glass Joker
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+self.ability.x_mult = self.ability.x_mult + self.ability.extra*glasses
+'''
+position = "at"
+payload = '''
+self.ability.x_mult = SMODS.scale_value(self.ability.x_mult, self.ability.extra*glasses, self)
+'''
+match_indent = true
+times = 1
+
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+self.ability.x_mult = self.ability.x_mult + self.ability.extra*glass_cards
+'''
+position = "at"
+payload = '''
+self.ability.x_mult = SMODS.scale_value(self.ability.x_mult, self.ability.extra*glass_cards, self)
+'''
+match_indent = true
+times = 1
+
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+self.ability.x_mult = self.ability.x_mult + self.ability.extra*shattered_glass
+'''
+position = "at"
+payload = '''
+self.ability.x_mult = SMODS.scale_value(self.ability.x_mult, self.ability.extra*shattered_glass, self)
+'''
+match_indent = true
+times = 1
+
+
+# Yorick
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+self.ability.x_mult = self.ability.x_mult + self.ability.extra.xmult
+'''
+position = "at"
+payload = '''
+self.ability.x_mult = SMODS.scale_value(self.ability.x_mult, self.ability.extra.xmult, self)
+'''
+match_indent = true
+times = 1
+
+
+# Rocket
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+self.ability.extra.dollars = self.ability.extra.dollars + self.ability.extra.increase
+'''
+position = "at"
+payload = '''
+self.ability.extra.dollars = SMODS.scale_value(self.ability.extra.dollars, self.ability.extra.increase, self)
+'''
+match_indent = true
+times = 1
+
+
+# Vampire
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+self.ability.x_mult = self.ability.x_mult + self.ability.extra*#enhanced
+'''
+position = "at"
+payload = '''
+self.ability.x_mult = SMODS.scale_value(self.ability.x_mult, self.ability.extra*#enhances, self)
+'''
+match_indent = true
+times = 1
+
+
+# Green Joker
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+self.ability.mult = self.ability.mult + self.ability.extra.hand_add
+'''
+position = "at"
+payload = '''
+self.ability.mult = SMODS.scale_value(self.ability.mult, self.ability.extra.hand_add, self)
+'''
+match_indent = true
+times = 1

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2494,3 +2494,9 @@ function SMODS.merge_effects(...)
     end
     return ret
 end
+
+function SMODS.scale_value(value, scalar, card)
+    local modified_scalar = (scalar + G.GAME.scalar_mod.addative) * G.GAME.scalar_mod.multiplicative
+    SMODS.calculate_context({scaling_card = true, scalar = modified_scalar, card = card})
+    return value + scalar
+end


### PR DESCRIPTION
This PR aims to establish a dedicated function for scaling card values that allow the scalar to be affected by global values. These global values can be affected by devs who wish to change the way cards are scaling on a global level. This PR also aims to fire off a new context "context.scaling_card" to allow cards to execute functionality whenever another card scales. (I will also preface that this is my first PR to the Steamodded project so I apologize for any potentially bad practices)

Current roadblocks:
- The timing for context.scaling_card happens before the card actually scales
- The lovely patches that change scaling vanilla cards to use this functionality may be inefficient

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
