### PR TITLE
`context.evaluate_poker_hand`

### DIFF
--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -71,6 +71,8 @@
 ---@field modify_hand? true Check if `true` for modifying the chips and mult of the played hand. 
 ---@field drawing_cards? true `true` when cards are being drawn
 ---@field amount? integer Amount of cards about to be drawn from deck to hand. Check for modifying amount of cards drawn.
+---@field evaluate_poker_hand? integer Check if `true` for modifying the name, display name or contained poker hands when evaluating a hand.
+---@field display_name? integer Display name of the scoring poker hand
 
 --- Util Functions
 

--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -1474,18 +1474,23 @@ function G.FUNCS.get_poker_hand_info(_cards)
 	end
 	disp_text = text
 	local _hand = SMODS.PokerHands[text]
-	if text == 'Straight Flush' then
-		local royal = true
-		for j = 1, #scoring_hand do
-			local rank = SMODS.Ranks[scoring_hand[j].base.value]
-			royal = royal and (rank.key == 'Ace' or rank.key == '10' or rank.face)
-		end
-		if royal then
-			disp_text = 'Royal Flush'
-		end
-	elseif _hand and _hand.modify_display_text and type(_hand.modify_display_text) == 'function' then
-		disp_text = _hand:modify_display_text(_cards, scoring_hand) or disp_text
-	end
+    if text == 'Straight Flush' then
+        local royal = true
+        for j = 1, #scoring_hand do
+            local rank = SMODS.Ranks[scoring_hand[j].base.value]
+            royal = royal and (rank.key == 'Ace' or rank.key == '10' or rank.face)
+        end
+        if royal then
+            disp_text = 'Royal Flush'
+        end
+    elseif _hand and _hand.modify_display_text and type(_hand.modify_display_text) == 'function' then
+        disp_text = _hand:modify_display_text(_cards, scoring_hand) or disp_text
+    end
+    local flags = SMODS.calculate_context({ evaluate_poker_hand = true, full_hand = _cards, scoring_hand = scoring_hand, scoring_name =
+    text, poker_hands = poker_hands, display_name = disp_text })
+    text = flags.replace_scoring_name or text
+    disp_text = flags.replace_display_name or flags.replace_scoring_name or disp_text
+	poker_hands = flags.replace_poker_hands or poker_hands
 	loc_disp_text = localize(disp_text, 'poker_hands')
 	return text, loc_disp_text, poker_hands, scoring_hand, disp_text
 end

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -1437,6 +1437,10 @@ SMODS.calculate_individual_effect = function(effect, scored_card, key, amount, f
     if key == 'numerator' or key == 'denominator' then
         return { [key] = amount }
     end
+
+    if key == 'replace_scoring_name' or key == 'replace_display_name' or key == 'replace_poker_hands' then
+        return { [key] = amount }
+    end
 end
 
 -- Used to calculate a table of effects generated in evaluate_play
@@ -1512,7 +1516,8 @@ SMODS.calculation_keys = {
     'cards_to_draw',
     'message',
     'level_up', 'func', 'extra',
-    'numerator', 'denominator'
+    'numerator', 'denominator',
+    'replace_scoring_name', 'replace_display_name', 'replace_poker_hands'
 }
 
 SMODS.insert_repetitions = function(ret, eval, effect_card, _type)


### PR DESCRIPTION
Added a context for modifying a poker hand's name, display name and contained poker hands during evaluation.

You can return `replace_scoring_name = key`,  `replace_display_name = key` (falls back to `replace_scoring_name`) or `replace_poker_hands = poker_hands_table`. 
(Note: `context.poker_hands` can also be modified directly. I don't know if this is something that should be avoided.)

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
