### PR TITLE
Make blind's tag object accessible outside of skipping

### DIFF
--- a/lovely/better_calc.toml
+++ b/lovely/better_calc.toml
@@ -854,7 +854,7 @@ end
 position = 'at'
 match_indent = true
 payload = '''
-SMODS.calculate_context({setting_blind = true, blind = G.GAME.round_resets.blind, tag = G.GAME.round_resets.blind_tag})
+SMODS.calculate_context({setting_blind = true, blind = G.GAME.round_resets.blind})
 
 -- TARGET: setting_blind effects
 '''

--- a/lovely/better_calc.toml
+++ b/lovely/better_calc.toml
@@ -830,20 +830,7 @@ payload = '''for _,v in ipairs(SMODS.get_card_areas('playing_cards', 'end_of_rou
 end
 '''
 
-
 # allow passing tag object to new_round()
-[[patches]]
-[patches.pattern]
-target = 'functions/state_events.lua'
-pattern = '''
-function new_round()
-'''
-position = 'at'
-match_indent = true
-payload = '''
-function new_round(_tag)
-'''
-
 [[patches]]
 [patches.pattern]
 target = "functions/button_callbacks.lua"
@@ -864,6 +851,18 @@ payload = '''
 new_round(_tag)
 '''
 match_indent = true
+
+[[patches]]
+[patches.pattern]
+target = 'functions/state_events.lua'
+pattern = '''
+function new_round()
+'''
+position = 'at'
+match_indent = true
+payload = '''
+function new_round(_tag)
+'''
 
 # context.setting_blind
 [[patches]]

--- a/lovely/better_calc.toml
+++ b/lovely/better_calc.toml
@@ -831,6 +831,40 @@ end
 '''
 
 
+# allow passing tag object to new_round()
+[[patches]]
+[patches.pattern]
+target = 'functions/state_events.lua'
+pattern = '''
+function new_round()
+'''
+position = 'at'
+match_indent = true
+payload = '''
+function new_round(_tag)
+'''
+
+[[patches]]
+[patches.pattern]
+target = "functions/button_callbacks.lua"
+pattern = "G.blind_prompt_box:get_UIE_by_ID('prompt_dynatext1').config.object.pop_delay = 0"
+position = "before"
+payload = '''
+local _tag = e.UIBox:get_UIE_by_ID('tag_container')
+_tag = _tag.config and _tag.config.ref_table or nil
+'''
+match_indent = true
+
+[[patches]]
+[patches.pattern]
+target = "functions/button_callbacks.lua"
+pattern = "new_round()"
+position = "at"
+payload = '''
+new_round(_tag)
+'''
+match_indent = true
+
 # context.setting_blind
 [[patches]]
 [patches.pattern]
@@ -843,7 +877,7 @@ end
 position = 'at'
 match_indent = true
 payload = '''
-SMODS.calculate_context({setting_blind = true, blind = G.GAME.round_resets.blind})
+SMODS.calculate_context({setting_blind = true, blind = G.GAME.round_resets.blind, tag = _tag})
 
 -- TARGET: setting_blind effects
 '''

--- a/lovely/better_calc.toml
+++ b/lovely/better_calc.toml
@@ -830,39 +830,17 @@ payload = '''for _,v in ipairs(SMODS.get_card_areas('playing_cards', 'end_of_rou
 end
 '''
 
-# allow passing tag object to new_round()
+# store associated blind tag as a global object
 [[patches]]
 [patches.pattern]
 target = "functions/button_callbacks.lua"
-pattern = "G.blind_prompt_box:get_UIE_by_ID('prompt_dynatext1').config.object.pop_delay = 0"
+pattern = "G.GAME.round_resets.blind = e.config.ref_table"
 position = "before"
 payload = '''
 local _tag = e.UIBox:get_UIE_by_ID('tag_container')
-_tag = _tag.config and _tag.config.ref_table or nil
+G.GAME.round_resets.blind_tag = _tag.config and _tag.config.ref_table or nil
 '''
 match_indent = true
-
-[[patches]]
-[patches.pattern]
-target = "functions/button_callbacks.lua"
-pattern = "new_round()"
-position = "at"
-payload = '''
-new_round(_tag)
-'''
-match_indent = true
-
-[[patches]]
-[patches.pattern]
-target = 'functions/state_events.lua'
-pattern = '''
-function new_round()
-'''
-position = 'at'
-match_indent = true
-payload = '''
-function new_round(_tag)
-'''
 
 # context.setting_blind
 [[patches]]
@@ -876,7 +854,7 @@ end
 position = 'at'
 match_indent = true
 payload = '''
-SMODS.calculate_context({setting_blind = true, blind = G.GAME.round_resets.blind, tag = _tag})
+SMODS.calculate_context({setting_blind = true, blind = G.GAME.round_resets.blind, tag = G.GAME.round_resets.blind_tag})
 
 -- TARGET: setting_blind effects
 '''


### PR DESCRIPTION
Allows access to a blind's associated tag (if any) via setting_blind context 

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
