### PR TITLE
fix SMODS.destroy_cards(CardArea.cards) crashing

### DIFF
--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2431,7 +2431,7 @@ function SMODS.destroy_cards(cards)
     
     if next(playing_cards) then SMODS.calculate_context({scoring_hand = cards, remove_playing_cards = true, removed = playing_cards}) end
 
-    for i=1, #cards do
+    for i=#cards, 1, -1 do
         G.E_MANAGER:add_event(Event({
             func = function()
                 if cards[i].shattered then


### PR DESCRIPTION
Destruction calls are put inside an event to ensure cards[i] won't go nil early, except for when events are messed up (e.g. by Nopeus' fast forward). Reverting the direction solves the issue.



## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
