### PR TITLE
Changes to `SMODS.destroy_cards`

### DIFF
--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -573,8 +573,11 @@ function SMODS.localize_box(lines, args) end
 function SMODS.get_multi_boxes(multi_box) end
 
 ---@param cards Card|Card[]
+---@param bypass_eternal boolean?
+---@param immediate boolean?
 --- Destroys the cards passed to the function, handling calculation events that need to happen
-function SMODS.destroy_cards(cards) end
+function SMODS.destroy_cards(cards, bypass_eternal, immediate) end
+
 ---@param hand_space number
 --- Used to draw cards to hand outside of the normal card draw
 --- Allows context.drawing_cards to function

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2408,22 +2408,24 @@ function SMODS.get_multi_boxes(multi_box)
     return multi_boxes
 end
 
-function SMODS.destroy_cards(cards)
+function SMODS.destroy_cards(cards, bypass_eternal, immediate)
     if not cards[1] then
         cards = {cards}
     end
     local glass_shattered = {}
     local playing_cards = {}
     for _, card in ipairs(cards) do
-        card.getting_sliced = true
-        if SMODS.shatters(card) then
-            card.shattered = true
-            glass_shattered[#glass_shattered+1] = card
-        else
-            card.destroyed = true
-        end
-        if card.base.name then
-            playing_cards[#playing_cards+1] = card
+        if bypass_eternal or not card.ability.eternal then
+            card.getting_sliced = true
+            if SMODS.shatters(card) then
+                card.shattered = true
+                glass_shattered[#glass_shattered + 1] = card
+            else
+                card.destroyed = true
+            end
+            if card.base.name then
+                playing_cards[#playing_cards + 1] = card
+            end
         end
     end
     
@@ -2431,17 +2433,25 @@ function SMODS.destroy_cards(cards)
     
     if next(playing_cards) then SMODS.calculate_context({scoring_hand = cards, remove_playing_cards = true, removed = playing_cards}) end
 
-    for i=1, #cards do
-        G.E_MANAGER:add_event(Event({
-            func = function()
-                if cards[i].shattered then
-                    cards[i]:shatter()
-                else
-                    cards[i]:start_dissolve()
-                end
-                return true
+    for i = 1, #cards do
+        if immediate then
+            if cards[i].shattered then
+                cards[i]:shatter()
+            elseif cards[i].destroyed then
+                cards[i]:start_dissolve()
             end
-        }))
+        else
+            G.E_MANAGER:add_event(Event({
+                func = function()
+                    if cards[i].shattered then
+                        cards[i]:shatter()
+                    elseif cards[i].destroyed then
+                        cards[i]:start_dissolve()
+                    end
+                    return true
+                end
+            }))
+        end
     end
 end
 


### PR DESCRIPTION
Adds the following parameters to `SMODS.destroy_cards`

1. `bypass_eternal` along with an Eternal sticker check. This could be extended in the future to support Eternal-like effects.
2. `immediate` to remove the event in the destruction call. Personally, I have some effects that I need to be run after the event inside start_dissolve/shatter but the event that wraps them was messing up with the timings.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
