### PR TITLE
Add beat_boss to context.end_of_round

### DIFF
--- a/lovely/better_calc.toml
+++ b/lovely/better_calc.toml
@@ -813,7 +813,7 @@ match_indent = true
 payload = '''
 -- context.end_of_round calculations
 SMODS.saved = false
-SMODS.calculate_context({end_of_round = true, game_over = game_over })
+SMODS.calculate_context({end_of_round = true, game_over = game_over, beat_boss = G.GAME.blind.boss })
 if SMODS.saved then game_over = false end
 -- TARGET: main end_of_round evaluation
 '''
@@ -826,7 +826,7 @@ position = 'at'
 pattern = '''(?<indent>[\t ]*)for i=1, #G\.hand\.cards do\n\s+--Check for hand doubling\n(.*\n)*?\s+delay\(0\.3\)'''
 line_prepend = '$indent'
 payload = '''for _,v in ipairs(SMODS.get_card_areas('playing_cards', 'end_of_round')) do
-    SMODS.calculate_end_of_round_effects({ cardarea = v, end_of_round = true })
+    SMODS.calculate_end_of_round_effects({ cardarea = v, end_of_round = true, beat_boss = G.GAME.blind.boss })
 end
 '''
 


### PR DESCRIPTION
Adds a new value to context.end_of_round to provide a simpler way to check if a boss blind has just been defeated


## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
