### PR TITLE
Type check in `SMODS.merge_effects`

### DIFF
--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2533,7 +2533,9 @@ function SMODS.merge_effects(...)
     local t = {}
     for _, v in ipairs({...}) do
         for _, vv in ipairs(v) do
-            table.insert(t, vv)
+            if vv == true or type(vv) == "table" then 
+                table.insert(t, vv)
+            end
         end
     end
     local ret = table.remove(t, 1)

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2533,7 +2533,7 @@ function SMODS.merge_effects(...)
     local t = {}
     for _, v in ipairs({...}) do
         for _, vv in ipairs(v) do
-            if vv == true or type(vv) == "table" then 
+            if vv == true or (type(vv) == "table" and next(vv)) then 
                 table.insert(t, vv)
             end
         end


### PR DESCRIPTION
To avoid some nil checks when passing the returns of SMODS.blueprint_effect directly

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
