### PR TITLE
Fix smart_level_up_hand() not properly updating hand text for hands with face-down cards

### DIFF
--- a/src/utils.lua
+++ b/src/utils.lua
@@ -1212,12 +1212,12 @@ SMODS.smart_level_up_hand = function(card, hand, instant, amount)
     -- Level ups outside anything -> always update to empty chips/mult
     local vals_after_level
     if SMODS.displaying_scoring and not (SMODS.displayed_hand == hand) then
+        vals_after_level = copy_table(G.GAME.current_round.current_hand)
         local text,disp_text,_,_,_ = G.FUNCS.get_poker_hand_info(G.play.cards)
-        vals_after_level = {}
         vals_after_level.handname = disp_text or ''
         vals_after_level.level = (G.GAME.hands[text] or {}).level or ''
-        vals_after_level.chips = (G.GAME.hands[text] or {}).chips or 0
-        vals_after_level.mult = (G.GAME.hands[text] or {}).mult or 0
+        vals_after_level.chips = number_format(hand_chips) or 0
+        vals_after_level.mult = number_format(mult) or 0
     end
     if not (instant or SMODS.displayed_hand == hand) then
         update_hand_text({sound = 'button', volume = 0.7, pitch = 0.8, delay = 0.3}, {handname=localize(hand, 'poker_hands'),chips = G.GAME.hands[hand].chips, mult = G.GAME.hands[hand].mult, level=G.GAME.hands[hand].level})

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -1212,8 +1212,17 @@ SMODS.smart_level_up_hand = function(card, hand, instant, amount)
     -- Level ups outside anything -> always update to empty chips/mult
     local vals_after_level
     if SMODS.displaying_scoring and not (SMODS.displayed_hand == hand) then
-        vals_after_level = copy_table(G.GAME.current_round.current_hand)
-        vals_after_level.level = (G.GAME.hands[vals_after_level.handname] or {}).level or ''
+        if not G.GAME.current_round.current_hand.handname == '????' then
+            vals_after_level = copy_table(G.GAME.current_round.current_hand)
+            vals_after_level.level = (G.GAME.hands[vals_after_level.handname] or {}).level or ''
+        else
+            local text,disp_text,_,_,_ = G.FUNCS.get_poker_hand_info(G.play.cards)
+            vals_after_level = {}
+            vals_after_level.handname = disp_text or ''
+            vals_after_level.level = (G.GAME.hands[text] or {}).level or ''
+            vals_after_level.chips = (G.GAME.hands[text] or {}).chips or 0
+            vals_after_level.mult = (G.GAME.hands[text] or {}).mult or 0
+        end
     end
     if not (instant or SMODS.displayed_hand == hand) then
         update_hand_text({sound = 'button', volume = 0.7, pitch = 0.8, delay = 0.3}, {handname=localize(hand, 'poker_hands'),chips = G.GAME.hands[hand].chips, mult = G.GAME.hands[hand].mult, level=G.GAME.hands[hand].level})

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -1212,17 +1212,12 @@ SMODS.smart_level_up_hand = function(card, hand, instant, amount)
     -- Level ups outside anything -> always update to empty chips/mult
     local vals_after_level
     if SMODS.displaying_scoring and not (SMODS.displayed_hand == hand) then
-        if not G.GAME.current_round.current_hand.handname == '????' then
-            vals_after_level = copy_table(G.GAME.current_round.current_hand)
-            vals_after_level.level = (G.GAME.hands[vals_after_level.handname] or {}).level or ''
-        else
-            local text,disp_text,_,_,_ = G.FUNCS.get_poker_hand_info(G.play.cards)
-            vals_after_level = {}
-            vals_after_level.handname = disp_text or ''
-            vals_after_level.level = (G.GAME.hands[text] or {}).level or ''
-            vals_after_level.chips = (G.GAME.hands[text] or {}).chips or 0
-            vals_after_level.mult = (G.GAME.hands[text] or {}).mult or 0
-        end
+        local text,disp_text,_,_,_ = G.FUNCS.get_poker_hand_info(G.play.cards)
+        vals_after_level = {}
+        vals_after_level.handname = disp_text or ''
+        vals_after_level.level = (G.GAME.hands[text] or {}).level or ''
+        vals_after_level.chips = (G.GAME.hands[text] or {}).chips or 0
+        vals_after_level.mult = (G.GAME.hands[text] or {}).mult or 0
     end
     if not (instant or SMODS.displayed_hand == hand) then
         update_hand_text({sound = 'button', volume = 0.7, pitch = 0.8, delay = 0.3}, {handname=localize(hand, 'poker_hands'),chips = G.GAME.hands[hand].chips, mult = G.GAME.hands[hand].mult, level=G.GAME.hands[hand].level})


### PR DESCRIPTION
Calling `smart_level_up_hand()` while the hand display text is set to '????' due to cards being played while face-down would cause the function to incorrectly re-set the hand display text values after leveling up the given poker hand. This PR fixes the issue.
Relevant issue: #756 
## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
