### PR TITLE
Avoid crashes in SMODS.is_pokerhand_visible and add assert

### DIFF
--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2591,10 +2591,11 @@ function SMODS.pseudorandom_probability(trigger_obj, seed, base_numerator, base_
 end
 
 function SMODS.is_poker_hand_visible(handname)
-    if SMODS.PokerHands[handname].visible and type(SMODS.PokerHands[handname].visible) == "function" then
+    if SMODS.PokerHands[handname] and SMODS.PokerHands[handname].visible and type(SMODS.PokerHands[handname].visible) == "function" then
         return not not SMODS.PokerHands[handname]:visible()
     end
-    return G.GAME.hands[handname].visible
+	assert(G.GAME.hands[handname], "handname '" .. handname .. "' not found!")
+    return not not SMODS.PokerHands[handname] and G.GAME.hands[handname].visible
 end
 
 G.FUNCS.update_blind_debuff_text = function(e)


### PR DESCRIPTION
Prevents a nil crash.
Adds assertion for more clarity about why it crashes when it does crash.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [X] I didn't modify api's or I've updated lsp definitions.
- [X] I didn't make new lovely files or all new lovely files have appropriate priority.
