### PR TITLE
Add context.money_altered (and G.STATES.SMODS_REDEEM_VOUCHER)

### DIFF
--- a/lovely/better_calc.toml
+++ b/lovely/better_calc.toml
@@ -1808,3 +1808,33 @@ not self.ability.eternal then
 payload = '''
 not SMODS.is_eternal(self, {from_sell = true}) then
 '''
+
+# context.money_altered
+[[patches]]
+[patches.pattern]
+target = 'functions/common_events.lua'
+match_indent = true
+position = 'after'
+pattern = '''
+if instant then
+    _mod(mod)
+else
+    G.E_MANAGER:add_event(Event({
+    trigger = 'immediate',
+    func = function()
+        _mod(mod)
+        return true
+    end
+    }))
+end
+'''
+payload = '''
+if not instant then delay(0.4) end
+SMODS.calculate_context({
+    money_altered = true,
+    amount = mod,
+    from_shop = (G.STATE == G.STATES.SHOP or G.STATE == G.STATES.SMODS_BOOSTER_OPENED or G.STATE == G.STATES.SMODS_REDEEM_VOUCHER) or nil,
+    from_consumeable = (G.STATE == G.STATES.PLAY_TAROT) or nil,
+    from_scoring = (G.STATE == G.STATES.HAND_PLAYED) or nil,
+})
+'''

--- a/lovely/booster.toml
+++ b/lovely/booster.toml
@@ -64,7 +64,8 @@ pattern = '''(?<indent>[\t ]*)self\.STATES = \{'''
 position = "after"
 payload = '''
 
-    SMODS_BOOSTER_OPENED = 999,'''
+    SMODS_BOOSTER_OPENED = 999,
+    SMODS_REDEEM_VOUCHER = 998,'''
 line_prepend = '$indent'
 
 # Game:update
@@ -323,3 +324,13 @@ pattern = "if e.config.ref_table.ability.set ~= 'Joker' or (e.config.ref_table.e
 payload = '''local card = e.config.ref_table
 local card_limit = card.edition and card.edition.card_limit or 0
 if card.ability.set ~= 'Joker' or #G.jokers.cards < G.jokers.config.card_limit + card_limit then'''
+
+# Card:redeem()
+# Specific G.STATE for when a Voucher is redeemed
+[[patches]]
+[patches.pattern]
+target = 'card.lua'
+match_indent = true
+position = 'after'
+pattern = '''if self.shop_voucher then G.GAME.current_round.voucher = nil end'''
+payload = '''G.STATE = G.STATES.SMODS_REDEEM_VOUCHER'''

--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -2311,18 +2311,15 @@ function Blind:modify_hand(cards, poker_hands, text, mult, hand_chips, scoring_h
 	return _G.mult, _G.hand_chips, modded or flags.calculated
 end
 
-local ease_dollars_ref = ease_dollars
-function ease_dollars(mod,instant)
-	local ret = ease_dollars_ref(mod, instant)
-	G.E_MANAGER:add_event(Event({trigger='immediate',func=function()
-		SMODS.calculate_context({
-			money_altered = true,
-			amount = mod,
-			from_shop = (G.STATE == G.STATES.SHOP or G.STATE == G.STATES.SMODS_BOOSTER_OPENED or G.STATE == G.STATES.SMODS_REDEEM_VOUCHER) or nil,
-			from_consumeable = (G.STATE == G.STATES.PLAY_TAROT) or nil,
-			from_scoring = (G.STATE == G.STATES.HAND_PLAYED) or nil,
-		})
-		return true
-	end}))
-	return ret
-end
+-- local ease_dollars_ref = ease_dollars
+-- function ease_dollars(mod,instant)
+-- 	local ret = ease_dollars_ref(mod, instant)
+-- 	SMODS.calculate_context({
+-- 		money_altered = true,
+-- 		amount = mod,
+-- 		from_shop = (G.STATE == G.STATES.SHOP or G.STATE == G.STATES.SMODS_BOOSTER_OPENED or G.STATE == G.STATES.SMODS_REDEEM_VOUCHER) or nil,
+-- 		from_consumeable = (G.STATE == G.STATES.PLAY_TAROT) or nil,
+-- 		from_scoring = (G.STATE == G.STATES.HAND_PLAYED) or nil,
+-- 	})
+-- 	return ret
+-- end

--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -2310,3 +2310,19 @@ function Blind:modify_hand(cards, poker_hands, text, mult, hand_chips, scoring_h
 	local flags = SMODS.calculate_context({ modify_hand = true, poker_hands = poker_hands, scoring_name = text, scoring_hand = scoring_hand, full_hand = cards })
 	return _G.mult, _G.hand_chips, modded or flags.calculated
 end
+
+local ease_dollars_ref = ease_dollars
+function ease_dollars(mod,instant)
+	local ret = ease_dollars_ref(mod, instant)
+	G.E_MANAGER:add_event(Event({trigger='immediate',func=function()
+		SMODS.calculate_context({
+			money_altered = true,
+			amount = mod,
+			from_shop = (G.STATE == G.STATES.SHOP or G.STATE == G.STATES.SMODS_BOOSTER_OPENED or G.STATE == G.STATES.SMODS_REDEEM_VOUCHER) or nil,
+			from_consumeable = (G.STATE == G.STATES.PLAY_TAROT) or nil,
+			from_scoring = (G.STATE == G.STATES.HAND_PLAYED) or nil,
+		})
+		return true
+	end}))
+	return ret
+end

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -1269,7 +1269,6 @@ SMODS.calculate_individual_effect = function(effect, scored_card, key, amount, f
 
     if (key == 'p_dollars' or key == 'dollars' or key == 'h_dollars') and amount then
         if effect.card and effect.card ~= scored_card then juice_card(effect.card) end
-        ease_dollars(amount)
         if not effect.remove_default_message then
             if effect.dollar_message then
                 card_eval_status_text(effect.message_card or effect.juice_card or scored_card or effect.card or effect.focus, 'extra', nil, percent, nil, effect.dollar_message)
@@ -1277,6 +1276,7 @@ SMODS.calculate_individual_effect = function(effect, scored_card, key, amount, f
                 card_eval_status_text(effect.message_card or effect.juice_card or scored_card or effect.card or effect.focus, 'dollars', amount, percent)
             end
         end
+        ease_dollars(amount)
         return true
     end
 


### PR DESCRIPTION
- Calculates `context.money_altered` when money is earned or lost by hooking `ease_dollars()`.
- I've also included `G.STATES.SMODS_REDEEM_VOUCHER = 998` for when a voucher is redeemed (since previously it would be considered `G.STATES.PLAY_TAROT`, which made it very difficult to separate the two)

`context.money_altered` also includes some built-in checks for roughly determining the source of the change in money,
(ex: `context.from_shop` checks for shop transactions)
though these are not strictly necessary.
```
if context.money_altered then
{
	amount = mod,
	from_shop = (G.STATE == G.STATES.SHOP or G.STATE == G.STATES.SMODS_BOOSTER_OPENED or G.STATE == G.STATES.SMODS_REDEEM_VOUCHER) or nil,
	from_consumeable = (G.STATE == G.STATES.PLAY_TAROT) or nil,
	from_scoring = (G.STATE == G.STATES.HAND_PLAYED) or nil,
	money_altered = true,
}
```

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
