### PR TITLE
Remove padding from base node of dynamic tab

### DIFF
--- a/src/ui.lua
+++ b/src/ui.lua
@@ -1527,7 +1527,6 @@ local function generateBaseNode(staticPageDefinition)
             r = 0.1,
             minw = 8,
             align = "cm",
-            padding = 0.2,
             colour = G.C.BLACK
         },
         nodes = {


### PR DESCRIPTION
The function `generateBaseNode` is used to generate a base node for the dynamic content tabs and so affects any mod that uses a dynamic tab by using `SMODS.GUI.DynamicUIManager.initTab`. On the repo, it is used in the mod list tab.


There was a padding in this node that caused a offset in any child node. You can  see it highlighted in orange below.

## Before:
![Captura de tela de 2025-07-07 18-41-10](https://github.com/user-attachments/assets/140aed9e-60e4-411c-a1e1-2a5de5815016)
![Captura de tela de 2025-07-07 18-43-19](https://github.com/user-attachments/assets/46ae79a1-7f25-4add-ae05-5dec1edc8b05)

## After:
![Captura de tela de 2025-07-07 18-42-23](https://github.com/user-attachments/assets/03390040-b14f-4c09-810f-e0e12fc582dd)
![Captura de tela de 2025-07-07 18-42-50](https://github.com/user-attachments/assets/1e690093-b949-4089-ab87-4d6f73100ccc)


The color was changed only for the debug screenshots.



## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ X ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ X ] I didn't modify api's or I've updated lsp definitions.
- [ X ] I didn't make new lovely files or all new lovely files have appropriate priority.
