### PR TITLE
Allow UI dynamic area update to receive config as param

### DIFF
--- a/lsp_def/ui.lua
+++ b/lsp_def/ui.lua
@@ -180,8 +180,10 @@ function SMODS.GUI.createOptionSelector(args) end
 function SMODS.GUI.DynamicUIManager.initTab(args) end
 
 ---@param uiDefinitions table<string, UIBox|table>
---- Updates all provided dynamic UIBoxes. 
-function SMODS.GUI.DynamicUIManager.updateDynamicAreas(uiDefinitions) end
+---@param config? UINode.config
+--- Updates all provided dynamic UIBoxes.
+--- Optionally accepts a config to be used for all dynamic areas.
+function SMODS.GUI.DynamicUIManager.updateDynamicAreas(uiDefinitions, config) end
 
 ---@return UINode
 --- Define the content in the pane that does not need to update

--- a/src/ui.lua
+++ b/src/ui.lua
@@ -1551,14 +1551,22 @@ function SMODS.GUI.DynamicUIManager.initTab(args)
 end
 
 -- Call this to trigger an update for a list of dynamic content areas
-function SMODS.GUI.DynamicUIManager.updateDynamicAreas(uiDefinitions)
+function SMODS.GUI.DynamicUIManager.updateDynamicAreas(uiDefinitions, config)
+    base_conf = config or {
+        offset = {x=0, y=0},
+        align = 'cm',
+    }
+
     for id, uiDefinition in pairs(uiDefinitions) do
         local dynamicArea = G.OVERLAY_MENU:get_UIE_by_ID(id)
         if dynamicArea and dynamicArea.config.object then
+            cfg = SMODS.shallow_copy(base_conf)
+            cfg.parent = dynamicArea
+
             dynamicArea.config.object:remove()
             dynamicArea.config.object = UIBox{
                 definition = uiDefinition,
-                config = {offset = {x=0, y=0}, align = 'cm', parent = dynamicArea}
+                config = cfg
             }
         end
     end


### PR DESCRIPTION
Updates `SMODS.GUI.DynamicUIManager.updateDynamicAreas` to receive an optional `config` table to be used in all dynamic areas.

### Why? 
`updateDynamicAreas` set the alignment of the object to be `cm`. This causes the center of the object to be used as the reference for alignment in the parent node. This may cause clipping when trying to use other alignment in the parent node and is overall harder to design around. This change keeps backwards compatibility by allowing to change the object alignment (and other configs) with an optional param.

## Examples

### Object: `cm` (default),  parent (red): `tm`
![image](https://github.com/user-attachments/assets/f25324bd-9b20-48ce-8510-288d083efb85)

### Object: `cm` (default),  parent (red): `bm`
![image](https://github.com/user-attachments/assets/85d8d920-7e7a-469c-877e-e04f089ed4c7)

### Object: `bm` (custom),  parent (red): `tm`
![image](https://github.com/user-attachments/assets/8e27b4b7-6911-4ec3-b7ed-22414c07f25b)

### Object: `tm` (custom),  parent (red): `bm`
![image](https://github.com/user-attachments/assets/5d62984b-2e8e-4c46-96da-033a5d83016d)

### Code snippet
```lua
-- ...
{
        n = G.UIT.ROOT,
        config = {
            align = "tm",
            colour = G.C.GREEN,
            r = 0.1,
            minw=10,
            minh=8,
            padding=0
        },
        nodes = {
            {
                n = G.UIT.C,
                config = {
                    align = "tm",
                    colour = G.C.BLUE,
                    padding = 0.05,
                },
                nodes = {
                    -- Parent
                    {
                        n = G.UIT.R,
                        config = {
                            minw = 8,
                            minh = 6,
                            colour = G.C.RED,
                            align = "bm", -- Parent node's children alignment
                        },
                        nodes = {
                            {
                                n=G.UIT.O,
                                config={
                                    id = 'qolConfigOptions',
                                    object = Moveable(),
                                }
                            },
                        }
                    },
                    -- Page selector (conditionally rendered)
                    totalPages > 1 and SMODS.GUI.createOptionSelector({
                        label = "",
                        scale = 0.8,
                        options = pageOptions,
                        opt_callback = 'qol_bundle_update_config_page',
                        no_pips = true,
                        current_option = currentPage,
                        config = { align = "cm", padding = 0.15 }
                    }) or nil
                }
            }
        }
}
    
 -- ...
 
SMODS.GUI.DynamicUIManager.updateDynamicAreas({
    ["qolConfigOptions"] = QOL_BUNDLE.UI.dynamicConfigTabContent(e.cycle_config.current_option)
}, {
    offset = {x = 0.0, y = 0.0},
    align = "tm", -- Object aligment
})
```

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ X ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ X ] I didn't modify api's or I've updated lsp definitions.
- [ X ] I didn't make new lovely files or all new lovely files have appropriate priority.
