### PR TITLE
Better handling of `true` in `SMODS.merge_effects`

### DIFF
--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2569,14 +2569,14 @@ function SMODS.merge_effects(...)
         end
     end
     local ret = table.remove(t, 1)
-    local current = ret
+    local current = ret == true and { remove = true } or ret
     for _, eff in ipairs(t) do
-        assert(type(eff) == 'table', ("\"%s\" is not a table."):format(tostring(eff)))
+        assert(eff == true or type(eff) == 'table', ("\"%s\" is not a valid calculate return."):format(tostring(eff)))
         while current.extra ~= nil do
             if current.extra == true then
                 current.extra = { remove = true }
             end
-            assert(type(current.extra) == 'table', ("\"%s\" is not a table."):format(tostring(current.extra)))
+            assert(type(current.extra) == 'table', ("\"%s\" is not a valid calculate return."):format(tostring(current.extra)))
             current = current.extra
         end
         current.extra = eff


### PR DESCRIPTION
Right now it crashes if one of the effects is `true` unless it's in an extra table.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
