### PR TITLE
Support animated Mod Icons

### DIFF
--- a/src/ui.lua
+++ b/src/ui.lua
@@ -889,7 +889,13 @@ function buildModtag(mod)
 
     local tag_sprite_tab = nil
     local units = SMODS.pixels_to_unit(34) * 2
-    local tag_sprite = Sprite(0, 0, units, units, G.ASSET_ATLAS[tag_atlas] or G.ASSET_ATLAS['tags'], tag_pos)
+    local animated = G.ANIMATION_ATLAS[tag_atlas] or nil
+    local tag_sprite
+    if animated then
+      tag_sprite = AnimatedSprite(0, 0, 0.8*1, 0.8*1, animated or G.ASSET_ATLAS[tag_atlas] or G.ASSET_ATLAS['tags'], tag_pos)
+    else
+      tag_sprite = Sprite(0, 0, 0.8*1, 0.8*1, G.ASSET_ATLAS[tag_atlas] or G.ASSET_ATLAS['tags'], tag_pos)
+    end
     tag_sprite.T.scale = 1
     tag_sprite_tab = {n= G.UIT.C, config={align = "cm", padding = 0}, nodes={
         {n=G.UIT.O, config={w=units, h=units, colour = G.C.BLUE, object = tag_sprite, focus_with_object = true}},


### PR DESCRIPTION
Allow the user to register their modicon with a number of frames and the 'ANIMATION_ATLAS' atlas_table to allow it to be animated in the mod menu

## Additional Info:
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
