### PR TITLE
probability functions: Added Enhancement/Individual scoring compatibility

### DIFF
--- a/lovely/listed_probabilities.toml
+++ b/lovely/listed_probabilities.toml
@@ -9,7 +9,17 @@ priority = -5
 target = 'card.lua'
 pattern = '''pseudorandom\((.*?)\) ?< ?G\.GAME\.probabilities\.normal ?\/ ?(.*?)( |\)|$)'''
 position = 'at'
-payload = "SMODS.pseudorandom_probability(self, $1, 1, $2)$3"
+payload = "SMODS.pseudorandom_probability(self, $1, 1, $2, 'no_identifier', context)$3"
+
+# Hacky Lucky card mult for this ^
+[[patches]]
+[patches.pattern]
+target = 'card.lua'
+pattern = '''if SMODS.pseudorandom_probability(self, 'lucky_mult', 1, 5) then'''
+position = 'at'
+payload = "SMODS.pseudorandom_probability(self,'lucky_mult', 1, 5, 'lucky_mult', context) then"
+match_indent = true
+
 
 # The Wheel
 # Don't have to modify loc_debuff_text since that's already done via override

--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -596,25 +596,27 @@ function SMODS.merge_effects(...) end
 ---@param base_denominator number
 ---@param key string|nil optional seed key for associating results in loc_vars with in-game probability rolls
 ---@param from_roll boolean|nil
+---@param source_context table|nil optional context during which function was called
 ---@return number numerator
 ---@return number denominator
 --- Returns a *`numerator` in `denominator`* listed probability opportunely modified by in-game effects
 --- starting from a *`base_numerator` in `base_denominator`* probability. 
 --- 
 --- Can be hooked for more complex probability behaviour. `trigger_obj` is optionally the object that queues the probability.
-function SMODS.get_probability_vars(trigger_obj, base_numerator, base_denominator, key, from_roll) end
+function SMODS.get_probability_vars(trigger_obj, base_numerator, base_denominator, key, from_roll, source_context) end
 
 ---@param trigger_obj Card|table
 ---@param seed string|number
 ---@param base_numerator number
 ---@param base_denominator number
 ---@param key string
+---@param source_context table|nil optional context during which function was called
 ---@return boolean
 --- Sets the seed to `seed` and runs a *`base_numerator` in `base_denominator`* listed probability check. 
 --- Returns `true` if the probability succeeds. You do not need to multiply `base_numerator` by `G.GAME.probabilities.normal`. 
 --- 
 --- Can be hooked to run code when a listed probability succeeds and/or fails. `trigger_obj` is optionally the object that queues the probability.
-function SMODS.pseudorandom_probability(trigger_obj, seed, base_numerator, base_denominator, key) end
+function SMODS.pseudorandom_probability(trigger_obj, seed, base_numerator, base_denominator, key, source_context) end
 
 ---@param handname string
 ---@return boolean

--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -627,11 +627,11 @@ function SMODS.merge_effects(...) end
 ---@param base_numerator number
 ---@param base_denominator number
 ---@param identifier? string optional seed key for associating results in loc_vars with in-game probability rolls
----@param from_roll boolean|nil
----@param source_context table|nil optional context during which function was called
+---@param from_roll? boolean
+---@param source_context? table optional context during which function was called
+---@param no_mod? boolean optional boolean to bypass other probability modifying effects
 ---@return number numerator
 ---@return number denominator
----@param no_mod boolean|nil optional boolean to bypass other probability modifying effects
 --- Returns a *`numerator` in `denominator`* listed probability opportunely modified by in-game effects
 --- starting from a *`base_numerator` in `base_denominator`* probability. 
 --- 
@@ -643,8 +643,8 @@ function SMODS.get_probability_vars(trigger_obj, base_numerator, base_denominato
 ---@param base_numerator number
 ---@param base_denominator number
 ---@param identifier? string
----@param source_context table|nil optional context during which function was called
----@param no_mod boolean|nil optional boolean to bypass other probability modifying effects
+---@param source_context? table optional context during which function was called
+---@param no_mod? boolean optional boolean to bypass other probability modifying effects
 ---@return boolean
 --- Sets the seed to `seed` and runs a *`base_numerator` in `base_denominator`* listed probability check. 
 --- Returns `true` if the probability succeeds. You do not need to multiply `base_numerator` by `G.GAME.probabilities.normal`. 

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -1768,7 +1768,21 @@ function SMODS.calculate_card_areas(_type, context, return_table, args)
             for _,v in ipairs(context.scoring_hand) do scoring_map[v] = true end
         end
         for _, area in ipairs(SMODS.get_card_areas('playing_cards')) do
-            if area == G.play and not context.scoring_hand then goto continue end
+            if area == G.play and not context.scoring_hand then
+                -- If context is for probability, eval_card() anyway
+                -- This allows Seals, etc. to affect Joker probabilities during individual scoring:
+                -- For example; A seal can double the probability of Blood Stone hitting for the playing card it is applied to.
+                if context.mod_probability or context.fix_probability then
+                    for _, card in ipairs(area.cards) do
+                        local effects = {eval_card(card, context)}
+                        local f = SMODS.trigger_effects(effects, card)
+                        for k,v in pairs(f) do flags[k] = v end
+                        if flags.numerator then flags.numerator = flags.numerator end
+                        if flags.denominator then flags.denominator = flags.denominator end
+                    end
+                end
+                goto continue
+            end
             if not args or not args.has_area then context.cardarea = area end
             for _, card in ipairs(area.cards) do
                 if not args or not args.has_area then
@@ -1789,6 +1803,8 @@ function SMODS.calculate_card_areas(_type, context, return_table, args)
                     SMODS.calculate_quantum_enhancements(card, effects, context)
                     local f = SMODS.trigger_effects(effects, card)
                     for k,v in pairs(f) do flags[k] = v end
+                    if flags.numerator then context.numerator = flags.numerator end
+                    if flags.denominator then context.denominator = flags.denominator end
                 end
             end
             ::continue::
@@ -1820,6 +1836,8 @@ function SMODS.calculate_card_areas(_type, context, return_table, args)
             else
                 local f = SMODS.trigger_effects(effects, area.scored_card)
                 for k,v in pairs(f) do flags[k] = v end
+                if flags.numerator then context.numerator = flags.numerator end
+                if flags.denominator then context.denominator = flags.denominator end
             end
         end
     end
@@ -2586,16 +2604,15 @@ function SMODS.merge_effects(...)
     return ret
 end
 
-function SMODS.get_probability_vars(trigger_obj, base_numerator, base_denominator, identifier, from_roll)
-    if not G.jokers then return base_numerator, base_denominator end
-    local additive = SMODS.calculate_context({mod_probability = true, from_roll = from_roll, trigger_obj = trigger_obj, identifier = identifier, numerator = base_numerator, denominator = base_denominator}, nil, not from_roll)
+function SMODS.get_probability_vars(trigger_obj, base_numerator, base_denominator, identifier, from_roll, source_context)
+    local additive = SMODS.calculate_context({mod_probability = true, from_roll = from_roll, trigger_obj = trigger_obj, identifier = identifier, numerator = base_numerator, denominator = base_denominator, source_context = source_context or {}}, nil, not from_roll)
     additive.numerator = (additive.numerator or base_numerator) * ((G.GAME and G.GAME.probabilities.normal or 1) / (2 ^ #SMODS.find_card('j_oops')))
-    local fixed = SMODS.calculate_context({fix_probability = true, from_roll = from_roll, trigger_obj = trigger_obj, identifier = identifier, numerator = additive.numerator or base_numerator, denominator = additive.denominator or base_denominator}, nil, not from_roll)
+    local fixed = SMODS.calculate_context({fix_probability = true, from_roll = from_roll, trigger_obj = trigger_obj, identifier = identifier, numerator = additive.numerator or base_numerator, denominator = additive.denominator or base_denominator, source_context = source_context or {}}, nil, not from_roll)
     return fixed.numerator or additive.numerator or base_numerator, fixed.denominator or additive.denominator or base_denominator
 end
 
-function SMODS.pseudorandom_probability(trigger_obj, seed, base_numerator, base_denominator, identifier)
-    local numerator, denominator = SMODS.get_probability_vars(trigger_obj, base_numerator, base_denominator, identifier or seed, true)
+function SMODS.pseudorandom_probability(trigger_obj, seed, base_numerator, base_denominator, identifier, source_context)
+    local numerator, denominator = SMODS.get_probability_vars(trigger_obj, base_numerator, base_denominator, identifier or seed, true, source_context)
     local result = pseudorandom(seed) < numerator / denominator
     SMODS.post_prob = SMODS.post_prob or {}
     SMODS.post_prob[#SMODS.post_prob+1] = {pseudorandom_result = true, result = result, trigger_obj = trigger_obj, numerator = numerator, denominator = denominator, identifier = identifier or seed}

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2067,7 +2067,7 @@ function SMODS.get_card_areas(_type, _context)
     end
     if _type == 'individual' then
         local t = {
-            { object = G.GAME.selected_back, scored_card = G.deck.cards[1] or G.deck },
+            { object = G.GAME.selected_back, scored_card = G.deck and G.deck.cards[1] or G.deck },
         }
         if G.GAME.blind then t[#t+1] = { object = G.GAME.blind, scored_card = G.GAME.blind.children.animatedSprite } end
         -- TARGET: add your own individual scoring targets


### PR DESCRIPTION
*/+**SMODS.pseudorandom_probability()** and **.get_probability_vars()** now take a new parameter "**source_context**". 
-> This allows referencing context.source_context.other_card to get individual playing cards during probability modifications
-> This in turn allows playing card Enhancements to affect a card's Luck, as in; 
Enhancements can change the probability of Joker effects triggering for a playing card their applied to.

 For example; **A seal can double the probability of Blood Stone hitting for the playing card it is applied to.**

*utils.lua: SMODS.calculate_card_areas():
eval_card() in "playing_cards" areas is no longer skipped if context.mod_probability or context.fix_probability is true. 
-> This is necessary for above behaviour to function properly.

This might be a bit messy, took me long enough to get working :'). Any feedback is appreciated!
Anyway good night.


## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
