### PR TITLE
Add basic safety checks to `e.config.page` access and `LAST_SELECTED_MOD_TAB` assignment

### DIFF
--- a/src/loader.lua
+++ b/src/loader.lua
@@ -630,7 +630,9 @@ local function initializeModUIFunctions()
     for id, modInfo in pairs(SMODS.mod_list) do
         G.FUNCS["openModUI_" .. modInfo.id] = function(e)
             G.ACTIVE_MOD_UI = modInfo
-            SMODS.LAST_SELECTED_MOD_TAB = e.config.page or "mod_desc"
+            if e and e.config and e.config.page then
+                SMODS.LAST_SELECTED_MOD_TAB = e.config.page
+            end
             G.FUNCS.overlay_menu({
                 definition = create_UIBox_mods(e)
             })


### PR DESCRIPTION
Just a simple fix for a regression introduced in [`16165a3 (new mod menu)`](https://github.com/Steamodded/smods/commit/16165a3553e37489a3de4d8d433a4d8a5f8a2463#diff-aedf8f5b9a90b1617b8c21a8135ba671ca8149e0ae8ad8876db689dc6e6a3297) which causes `G.FUNCS.openModUI_<MOD-NAME>` functions to crash when called without argument.

Tested with all new mod menu buttons and a variety of other config mods without issue.

Motivated by https://github.com/Breezebuilder/SystemClock/issues/4