### PR TITLE
Fix authors marquee max width

### DIFF
--- a/src/ui.lua
+++ b/src/ui.lua
@@ -1021,7 +1021,7 @@ local function createClickableModBox(modInfo, scale)
             scale = scale * 0.7,
             colours = {the_colour},
             shadow = true,
-            maxw = 2.7,
+            maxw = 2.4,
             marquee = true,
         }
         table.insert(label_nodes,


### PR DESCRIPTION
Prevents long marquees from offsetting the mod boxes widths

## Additional Info:
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
