### PR TITLE
ConsumableType: change primary/secondary color to text/bg color

### DIFF
--- a/lovely/ui.toml
+++ b/lovely/ui.toml
@@ -275,3 +275,33 @@ payload = """if args.hide_label then
     t.nodes = t2
 end"""
 match_indent = true
+
+# UIBox_button():
+# the counters on collection buttons use text_colour instead of being hardcoded to white
+[[patches]]
+[patches.pattern]
+target = 'functions/UI_definitions.lua'
+pattern = "{n=G.UIT.T, config={scale = 0.35,text = args.count.tally..' / '..args.count.of, colour = {1,1,1,0.9}}}"
+position = "at"
+match_indent = true
+payload = "{n=G.UIT.T, config={scale = 0.35,text = args.count.tally..' / '..args.count.of, colour = args.text_colour}}"
+
+# G.UIDEF.card_h_popup():
+# add a "card_type_text_colour" variable
+[[patches]]
+[patches.pattern]
+target = 'functions/UI_definitions.lua'
+pattern = 'local card_type_colour = get_type_colour(card.config.center or card.config, card)'
+position = 'after'
+match_indent = true
+payload = 'local card_type_text_colour = (AUT.card_type and SMODS.ConsumableTypes[AUT.card_type] and SMODS.ConsumableTypes[AUT.card_type].text_colour) or G.C.UI.TEXT_LIGHT'
+
+# G.UIDEF.card_h_popup():
+# pass "card_type_text_colour" variable to create_badge() when creating the badge for a card type
+[[patches]]
+[patches.pattern]
+target = 'functions/UI_definitions.lua'
+pattern = "badges[#badges + 1] = create_badge(((card.ability.name == 'Pluto' or card.ability.name == 'Ceres' or card.ability.name == 'Eris') and localize('k_dwarf_planet')) or (card.ability.name == 'Planet X' and localize('k_planet_q') or card_type),card_type_colour, nil, 1.2)"
+position = 'at'
+match_indent = true
+payload = "badges[#badges + 1] = create_badge(((card.ability.name == 'Pluto' or card.ability.name == 'Ceres' or card.ability.name == 'Eris') and localize('k_dwarf_planet')) or (card.ability.name == 'Planet X' and localize('k_planet_q') or card_type), card_type_colour, card_type_text_colour, 1.2)"

--- a/lsp_def/classes/consumable_type.lua
+++ b/lsp_def/classes/consumable_type.lua
@@ -4,8 +4,8 @@
 ---@field obj_table? table<string, SMODS.ConsumableType|table> Table of objects registered to this class. 
 ---@field loc_txt? table|{name: string, collection: string, undiscovered: table|{name: string, text: string[]} } Contains strings used for displaying text related to this object. 
 ---@field super? SMODS.ObjectType|table Parent class. 
----@field primary_colour? table HEX color used as the primary color. Set as `G.C.SET[self.key]`. 
----@field secondary_colour? table HEX color used as the seconary color. Set as `G.C.SECONDARY_COLOUR[self.key]`. 
+---@field text_colour? table HEX color used as the text color. Set as `G.C.SET[self.key]`. 
+---@field bg_colour? table HEX color used as the background color. Set as `G.C.SECONDARY_COLOUR[self.key]`. 
 ---@field collection_rows? number[] Array of numbers indicating how many rows and how many cards per row this ConsumableType's collection has. 
 ---@field shop_rate? nil|number Defining this value allows cards part of this ConsumableType to appear in the shop. Defined as `G.GAME[key:lower()..'_rate']`.  
 ---@field ctype_buffer? string[] Array of keys to all objects registered to the ConsumableType class. 

--- a/lsp_def/classes/consumable_type.lua
+++ b/lsp_def/classes/consumable_type.lua
@@ -4,8 +4,9 @@
 ---@field obj_table? table<string, SMODS.ConsumableType|table> Table of objects registered to this class. 
 ---@field loc_txt? table|{name: string, collection: string, undiscovered: table|{name: string, text: string[]} } Contains strings used for displaying text related to this object. 
 ---@field super? SMODS.ObjectType|table Parent class. 
----@field text_colour? table HEX color used as the text color. Set as `G.C.SET[self.key]`. 
----@field bg_colour? table HEX color used as the background color. Set as `G.C.SECONDARY_COLOUR[self.key]`. 
+---@field primary_colour? table HEX color used as the primary color. Set as `G.C.SET[self.key]`. 
+---@field secondary_colour? table HEX color used as the seconary color. Set as `G.C.SECONDARY_COLOUR[self.key]`. 
+---@field text_colour? table HEX color used as the text color. Set as `G.C.UI[self.key]`. 
 ---@field collection_rows? number[] Array of numbers indicating how many rows and how many cards per row this ConsumableType's collection has. 
 ---@field shop_rate? nil|number Defining this value allows cards part of this ConsumableType to appear in the shop. Defined as `G.GAME[key:lower()..'_rate']`.  
 ---@field ctype_buffer? string[] Array of keys to all objects registered to the ConsumableType class. 

--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -972,8 +972,8 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
         set = 'ConsumableType',
         required_params = {
             'key',
-            'primary_colour',
-            'secondary_colour',
+            'text_colour',
+            'bg_colour',
         },
         prefix_config = { key = false },
         collection_rows = { 6, 6 },
@@ -995,8 +995,8 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
             SMODS.ObjectType.inject(self)
             SMODS.ConsumableTypes[self.key] = self
             G.localization.descriptions[self.key] = G.localization.descriptions[self.key] or {}
-            G.C.SET[self.key] = self.primary_colour
-            G.C.SECONDARY_SET[self.key] = self.secondary_colour
+            G.C.SET[self.key] = self.text_colour
+            G.C.SECONDARY_SET[self.key] = self.bg_colour
             G.FUNCS['your_collection_' .. string.lower(self.key) .. 's'] = function(e)
                 G.SETTINGS.paused = true
                 G.FUNCS.overlay_menu {
@@ -1016,8 +1016,8 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
     SMODS.ConsumableType {
         key = 'Tarot',
         collection_rows = { 5, 6 },
-        primary_colour = G.C.SET.Tarot,
-        secondary_colour = G.C.SECONDARY_SET.Tarot,
+        text_colour = G.C.UI.TEXT_LIGHT,
+        bg_colour = G.C.SECONDARY_SET.Tarot,
         inject_card = function(self, center)
             SMODS.ObjectType.inject_card(self, center)
             SMODS.insert_pool(G.P_CENTER_POOLS['Tarot_Planet'], center)
@@ -1031,8 +1031,8 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
     SMODS.ConsumableType {
         key = 'Planet',
         collection_rows = { 6, 6 },
-        primary_colour = G.C.SET.Planet,
-        secondary_colour = G.C.SECONDARY_SET.Planet,
+        text_colour = G.C.UI.TEXT_LIGHT,
+        bg_colour = G.C.SECONDARY_SET.Planet,
         inject_card = function(self, center)
             SMODS.ObjectType.inject_card(self, center)
             SMODS.insert_pool(G.P_CENTER_POOLS['Tarot_Planet'], center)
@@ -1046,8 +1046,8 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
     SMODS.ConsumableType {
         key = 'Spectral',
         collection_rows = { 4, 5 },
-        primary_colour = G.C.SET.Spectral,
-        secondary_colour = G.C.SECONDARY_SET.Spectral,
+        text_colour = G.C.UI.TEXT_LIGHT,
+        bg_colour = G.C.SECONDARY_SET.Spectral,
         loc_txt = {},
     }
 

--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -972,8 +972,8 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
         set = 'ConsumableType',
         required_params = {
             'key',
-            'text_colour',
-            'bg_colour',
+            'primary_colour',
+            'secondary_colour',
         },
         prefix_config = { key = false },
         collection_rows = { 6, 6 },
@@ -995,8 +995,9 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
             SMODS.ObjectType.inject(self)
             SMODS.ConsumableTypes[self.key] = self
             G.localization.descriptions[self.key] = G.localization.descriptions[self.key] or {}
-            G.C.SET[self.key] = self.text_colour
-            G.C.SECONDARY_SET[self.key] = self.bg_colour
+            G.C.SET[self.key] = self.primary_colour
+            G.C.SECONDARY_SET[self.key] = self.secondary_colour
+            G.C.UI[self.key] = self.text_colour or G.C.UI.TEXT_LIGHT
             G.FUNCS['your_collection_' .. string.lower(self.key) .. 's'] = function(e)
                 G.SETTINGS.paused = true
                 G.FUNCS.overlay_menu {
@@ -1016,8 +1017,8 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
     SMODS.ConsumableType {
         key = 'Tarot',
         collection_rows = { 5, 6 },
-        text_colour = G.C.UI.TEXT_LIGHT,
-        bg_colour = G.C.SECONDARY_SET.Tarot,
+        primary_colour = G.C.SET.Tarot,
+        secondary_colour = G.C.SECONDARY_SET.Tarot,
         inject_card = function(self, center)
             SMODS.ObjectType.inject_card(self, center)
             SMODS.insert_pool(G.P_CENTER_POOLS['Tarot_Planet'], center)
@@ -1031,8 +1032,8 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
     SMODS.ConsumableType {
         key = 'Planet',
         collection_rows = { 6, 6 },
-        text_colour = G.C.UI.TEXT_LIGHT,
-        bg_colour = G.C.SECONDARY_SET.Planet,
+        primary_colour = G.C.SET.Planet,
+        secondary_colour = G.C.SECONDARY_SET.Planet,
         inject_card = function(self, center)
             SMODS.ObjectType.inject_card(self, center)
             SMODS.insert_pool(G.P_CENTER_POOLS['Tarot_Planet'], center)
@@ -1046,8 +1047,8 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
     SMODS.ConsumableType {
         key = 'Spectral',
         collection_rows = { 4, 5 },
-        text_colour = G.C.UI.TEXT_LIGHT,
-        bg_colour = G.C.SECONDARY_SET.Spectral,
+        primary_colour = G.C.SET.Spectral,
+        secondary_colour = G.C.SECONDARY_SET.Spectral,
         loc_txt = {},
     }
 

--- a/src/ui.lua
+++ b/src/ui.lua
@@ -378,7 +378,7 @@ function buildAdditionsTab(mod)
         local id = 'your_collection_'..key:lower()..'s'
         local tally = modsCollectionTally(G.P_CENTER_POOLS[key])
         if tally.of > 0 then
-            consumable_nodes[#consumable_nodes+1] = UIBox_button({button = id, label = {localize('b_'..key:lower()..'_cards')}, count = tally, minw = 4, id = id, colour = G.C.SECONDARY_SET[key], text_colour = G.C.SET[key]})
+            consumable_nodes[#consumable_nodes+1] = UIBox_button({button = id, label = {localize('b_'..key:lower()..'_cards')}, count = tally, minw = 4, id = id, colour = G.C.SECONDARY_SET[key], text_colour = G.C.UI[key]})
         end
     end
     if #consumable_nodes > 3 then
@@ -623,7 +623,7 @@ G.UIDEF.consumable_collection_page = function(page)
                 t[#t+1] = { n = G.UIT.R, config = { align ='cm', minh = 0.81 }, nodes = {}}
             else 
                 local id = 'your_collection_'..key:lower()..'s'
-                t[#t+1] = UIBox_button({button = id, label = {localize('b_'..key:lower()..'_cards')}, count = G.ACTIVE_MOD_UI and modsCollectionTally(G.P_CENTER_POOLS[key]) or G.DISCOVER_TALLIES[key:lower()..'s'], minw = 4, id = id, colour = G.C.SECONDARY_SET[key], text_colour = G.C.SET[key]})
+                t[#t+1] = UIBox_button({button = id, label = {localize('b_'..key:lower()..'_cards')}, count = G.ACTIVE_MOD_UI and modsCollectionTally(G.P_CENTER_POOLS[key]) or G.DISCOVER_TALLIES[key:lower()..'s'], minw = 4, id = id, colour = G.C.SECONDARY_SET[key], text_colour = G.C.UI[key]})
             end
         end
         return t

--- a/src/ui.lua
+++ b/src/ui.lua
@@ -378,7 +378,7 @@ function buildAdditionsTab(mod)
         local id = 'your_collection_'..key:lower()..'s'
         local tally = modsCollectionTally(G.P_CENTER_POOLS[key])
         if tally.of > 0 then
-            consumable_nodes[#consumable_nodes+1] = UIBox_button({button = id, label = {localize('b_'..key:lower()..'_cards')}, count = tally, minw = 4, id = id, colour = G.C.SECONDARY_SET[key]})
+            consumable_nodes[#consumable_nodes+1] = UIBox_button({button = id, label = {localize('b_'..key:lower()..'_cards')}, count = tally, minw = 4, id = id, colour = G.C.SECONDARY_SET[key], text_colour = G.C.SET[key]})
         end
     end
     if #consumable_nodes > 3 then
@@ -623,7 +623,7 @@ G.UIDEF.consumable_collection_page = function(page)
                 t[#t+1] = { n = G.UIT.R, config = { align ='cm', minh = 0.81 }, nodes = {}}
             else 
                 local id = 'your_collection_'..key:lower()..'s'
-                t[#t+1] = UIBox_button({button = id, label = {localize('b_'..key:lower()..'_cards')}, count = G.ACTIVE_MOD_UI and modsCollectionTally(G.P_CENTER_POOLS[key]) or G.DISCOVER_TALLIES[key:lower()..'s'], minw = 4, id = id, colour = G.C.SECONDARY_SET[key]})
+                t[#t+1] = UIBox_button({button = id, label = {localize('b_'..key:lower()..'_cards')}, count = G.ACTIVE_MOD_UI and modsCollectionTally(G.P_CENTER_POOLS[key]) or G.DISCOVER_TALLIES[key:lower()..'s'], minw = 4, id = id, colour = G.C.SECONDARY_SET[key], text_colour = G.C.SET[key]})
             end
         end
         return t


### PR DESCRIPTION
It was brought to my attention earlier today that ConsumableTypes don't actually do anything with their primary_colour definitions; I dug around in the code for a little while, but couldn't find much of anything that uses it directly or via the `G.C.SET[type_key]` definition. (there is one place where I saw it used, but I don't see any visual differences from my changes) As such, I decided that it might be useful to actually make it do something. This coincides with my work on a new consumable set of my own, which I wanted to use a white background and black text for.

ConsumableType objects now take a `text_colour` and a `bg_colour` parameter, instead of `primary_colour` and `secondary_colour`. `bg_colour` is used for the color of the consumable type's badge and its UI button in the collection/in a mod's Additions list, and behaves identically to how `secondary_colour` did before this PR. `text_colour` is now used for the text on top of the aforementioned badge and UI buttons.

This also comes with edits to the Tarot/Planet/Spectral ConsumableTypes that come packed in with SMODS; all that's changed is that it uses the new parameter names and assigns `G.C.UI.TEXT_LIGHT` to `text_colour` (`primary_colour` was set to something different before this change, but as I mentioned, nothing looks noticeably different in-game to me). Due to the parameter name change, it will also require custom ConsumableTypes in other mods to be updated, but that should help remind people to change `primary_colour`'s definition to an appropriate `text_colour` anyway.

Images of text_colour performing its job (the new Dice consumable type had its text_colour set to `G.C.UI.TEXT_DARK` and its bg_colour set to pure white):
<img width="300" alt="text_colour at work in the collection" src="https://github.com/user-attachments/assets/addba7e4-eb71-4ed3-b890-dc6b301b0968" />
<img width="300" alt="text_colour at work in the Additions tab" src="https://github.com/user-attachments/assets/4fcff181-4e7b-4334-8693-89105061dacf" />
(pardon my placeholder graphics and missing localizations)
<img width="150" alt="text_colour at work in a badge" src="https://github.com/user-attachments/assets/e97cbf2b-ea56-4c38-af5d-c389876d879e" />

(if this is well-received, I'll get around to making a PR to the wiki repo as well!)

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [X] I didn't modify api's or I've updated lsp definitions.
- [X] I didn't make new lovely files or all new lovely files have appropriate priority.
