### PR TITLE
Better Save Actions

### DIFF
--- a/lovely/fixes.toml
+++ b/lovely/fixes.toml
@@ -737,6 +737,7 @@ pattern = 'if G.playing_cards then'
 position = 'before'
 payload = '::skip_game_actions_during_remove::'
 match_indent = true
+
 # CardArea:remove_card()
 [[patches]]
 [patches.pattern]
@@ -748,4 +749,57 @@ position = 'at'
 payload = '''
 self:set_ranks()
 if not G.in_delete_run and self == G.deck then check_for_unlock({type = 'modify_deck', deck = self}) end'''
+match_indent = true
+
+
+# Game:start_run()
+[[patches]]
+[patches.pattern]
+target = "game.lua"
+pattern = '''for k, v in pairs(G.I.CARD) do
+    if v.sort_id == saveTable.ACTION.card then
+        G.FUNCS.use_card({config = {ref_table = v}}, nil, true)
+    end
+end'''
+position = 'at'
+payload = '''local action_card = nil
+for _, card in pairs(G.I.CARD) do 
+    if card.sort_id == saveTable.ACTION.card then
+        action_card = card
+    end
+
+    if saveTable.ACTION.highlights then
+        for k, v in pairs(saveTable.ACTION.highlights) do
+            if card.area and G[k] == card.area and v[card.sort_id] then 
+                card.area:add_to_highlighted(card, true)
+            end
+        end
+    end
+end
+
+if action_card then
+    SMODS.action_nosave = true
+    G.FUNCS[saveTable.ACTION.type]({config = {ref_table = action_card}}, saveTable.ACTION.args and unpack(saveTable.ACTION.args))
+    SMODS.action_nosave = nil
+end'''
+match_indent = true
+
+# Game:start_run()
+[[patches]]
+[patches.pattern]
+target = "functions/button_callbacks.lua"
+pattern = '''if card.ability.set == 'Booster' and not nosave and G.STATE == G.STATES.SHOP then
+  save_with_action({
+      type = 'use_card',
+      card = card.sort_id,
+    })
+  end'''
+position = 'at'
+payload = '''if card.ability.set == 'Booster' and not SMODS.action_nosave and G.STATE == G.STATES.SHOP then
+    save_with_action({
+        type = 'use_card',
+        args = {mute},
+        card = card.sort_id,
+    })
+end'''
 match_indent = true

--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -627,3 +627,9 @@ function SMODS.is_poker_hand_visible(handname) end
 --- Checks whether the card is eternal.
 --- `trigger` is the card or effect that runs the check
 function SMODS.is_eternal(card, trigger) end
+
+---@param cardareas table | nil a map of cardarea keys to access them from the global G table. Passing nil saves all global cardarea highights
+---@return table
+--- Saves highlighted cards for saved actions that require them
+--- Returns a table of sort_id maps, indexed by the keys of their cardareas
+function SMODS.save_action_highights(cardareas) end

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2652,3 +2652,17 @@ function Tag:apply_to_run(_context)
     end
     return res
 end
+
+-- saving highights for any card actions you might want saved between runs, similar to boosters
+function SMODS.save_action_highights(cardareas)
+    local highlights = {}
+    for k, v in pairs(G) do
+        if (type(v) == "table") and v.is and v:is(CardArea) and (not cardareas or cardareas[k]) and #v.highlighted > 0 then
+            highlights[k] = {}
+            for _, highlight in ipairs(v.highlighted) do
+                highlights[k][highlight.sort_id] = true
+            end
+        end
+    end
+    return next(highlights) and highlights or nil
+end


### PR DESCRIPTION
Expands the `save_with_action()` function that has limited use in vanilla. Originally, it's only used to save opening Booster Packs, and is hardcoded to call `G.FUNCS.use_card`. Now, it can be generally applied to any card action/function, which can be helpful for more advanced modded card types.

- Handling for `save_with_action()` on reload correctly uses `type` property passed in to call the keyed function
- New `save_with_action()` arguments
  - `args` table argument: saved and then unpacked to call the type function on reload (NOTE: this applies the second argument onwards. The first argument remains a dummy table `{config = {ref_table = action_card}}` to represent the action card)
  - `highlights` table argument: a table of sort_id maps to rehighlight cards in relevant cardareas on reload (since many consumables require them)
- Added `SMODS.save_action_highights(cardareas)` utility function to help create the `highlights` argument above
  - If `cardareas` is nil, it will save all highlighted cards in global table cardareas. Otherwise, `cardareas` is a map of string keys
- Added `SMODS.action_nosave` value so you don't have to redeclare vanilla functions with similar `nosave` arguments to `G.FUNCS.use_card` when hooking or patching


## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
