### PR TITLE
Custom hidden achievement names

### DIFF
--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -3426,6 +3426,8 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
         process_loc_text = function(self)
             SMODS.process_loc_text(G.localization.misc.achievement_names, self.key, self.loc_txt, "name")
             SMODS.process_loc_text(G.localization.misc.achievement_descriptions, self.key, self.loc_txt, "description")
+            SMODS.process_loc_text(G.localization.misc.achievement_names, self.key.."_hidden", self.loc_txt, "hidden_name")
+            SMODS.process_loc_text(G.localization.misc.achievement_descriptions, self.key.."_hidden", self.loc_txt, "hidden_description")
         end,
     }
 

--- a/src/ui.lua
+++ b/src/ui.lua
@@ -724,9 +724,15 @@ function buildAchievementsTab(mod, current_page)
             return wrappedText
         end
     
-        local loc_target = (v.hidden_text and not v.earned) and {localize("hidden_achievement", 'achievement_descriptions')} or localize(v.key, 'achievement_descriptions')
+        local loc_target
+        if (v.hidden_text and not v.earned) then
+            loc_target = (localize(v.key.."_hidden", 'achievement_descriptions') ~= 'ERROR') and localize(v.key.."_hidden", 'achievement_descriptions') or {localize("hidden_achievement", 'achievement_descriptions')}
+        else loc_target = localize(v.key, 'achievement_descriptions') end
         if type(loc_target) == 'string' then loc_target = wrapText(loc_target, maxCharsPerLine) end
-        local loc_name = (v.hidden_name and not v.earned) and localize("hidden_achievement", 'achievement_names') or localize(v.key, 'achievement_names')
+        local loc_name
+        if (v.hidden_name and not v.earned) then
+            loc_name = (localize(v.key.."_hidden", 'achievement_names') ~= 'ERROR') and localize(v.key.."_hidden", 'achievement_names') or localize("hidden_achievement", 'achievement_names')
+        else loc_name = localize(v.key, 'achievement_names') end
 
         local ability_text = {}
         if loc_target then 


### PR DESCRIPTION
Adds the ability to define a custom name or description for an achievement if it's hidden
#### A custom name or description can be defined in:
- A localization file with the achievement's key with `_hidden` appended to the end, or
- A loc_txt table with the keys `hidden_name` and `hidden_description`

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
