### PR TITLE
`allow_duplicates` in `SMODS.create_card`

### DIFF
--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -403,8 +403,8 @@ function SMODS.find_card(key, count_debuffed) end
 ---@field seal? Seals|string Apply this seal.
 ---@field stickers? Stickers[]|string[] Apply all stickers in this array.
 ---@field allow_duplicates? boolean Allows duplicated cards to be created, even without Showman.
----@field rank? string|integer Rank of the playing card.
----@field suit? string Suit of the playing card.
+---@field rank? Ranks|string|integer Rank of the playing card.
+---@field suit? Suits|string Suit of the playing card.
 ---@field front? string Front of the playing card. Ignores rank and suit.
 ---@field enhanced_poll? number Chance to pick 'Base' over 'Enhanced' with set 'Playing Card'.
 

--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -375,9 +375,9 @@ function SMODS.find_card(key, count_debuffed) end
 ---| 'Joker'
 ---| 'Tarot'
 ---| 'Planet'
----| 'Tarot_Planet'
+---| 'Tarot_Planet' # Random pick between Tarot and Planet.
 ---| 'Spectral'
----| 'Consumeables'
+---| 'Consumeables' # Random pick between any consumable type.
 ---| 'Booster'
 ---| 'Voucher'
 

--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -368,8 +368,21 @@ function SMODS.modify_rank(card, amount) end
 --- Returns all cards matching provided `key`. 
 function SMODS.find_card(key, count_debuffed) end
 
+---@alias CreateCardSets
+---| 'Base' # Playing Cards without enhancements.
+---| 'Enhanced' # Playing Cards with enhancements.
+---| 'Playing Card' # Playing Cards with a random chance for enhancements.
+---| 'Joker'
+---| 'Tarot'
+---| 'Planet'
+---| 'Tarot_Planet'
+---| 'Spectral'
+---| 'Consumeables'
+---| 'Booster'
+---| 'Voucher'
+
 ---@class CreateCard
----@field set? string Set of the card. 
+---@field set? CreateCardSets|string Set of the card. 
 ---@field area? CardArea|table CardArea to emplace this card to. 
 ---@field legendary? boolean Pools legendary cards, if applicable. 
 ---@field rarity? number|string Only spawns cards with provided rarity, if applicable. 
@@ -383,7 +396,12 @@ function SMODS.find_card(key, count_debuffed) end
 ---@field edition? string Apply this edition. 
 ---@field enhancement? string Apply this enhancement. 
 ---@field seal? string Apply this seal. 
----@field stickers? string[] Apply all stickers in this array. 
+---@field stickers? string[] Apply all stickers in this array.
+---@field allow_duplicates? boolean Allows duplicated cards to be created, even without Showman.
+---@field rank? string|integer Rank of the playing card.
+---@field suit? string Suit of the playing card.
+---@field front? string Front of the playing card. Ignores rank and suit.
+---@field enhanced_poll? number Chance to pick 'Base' over 'Enhanced' with set 'Playing Card'.
 
 ---@param t CreateCard|table
 ---@return Card|table

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -379,11 +379,13 @@ function SMODS.create_card(t)
     SMODS.bypass_create_card_discover = t.discover
     SMODS.bypass_create_card_discovery_center = t.bypass_discovery_center
     SMODS.set_create_card_front = G.P_CARDS[t.front]
+    SMODS.create_card_allow_duplicates = t.allow_duplicates
     local _card = create_card(t.set, t.area, t.legendary, t.rarity, t.skip_materialize, t.soulable, t.key, t.key_append)
     SMODS.bypass_create_card_edition = nil
     SMODS.bypass_create_card_discover = nil
     SMODS.bypass_create_card_discovery_center = nil
     SMODS.set_create_card_front = nil
+    SMODS.create_card_allow_duplicates = nil
 
     -- Should this be restricted to only cards able to handle these
     -- or should that be left to the person calling SMODS.create_card to use it correctly?
@@ -2534,7 +2536,7 @@ function SMODS.draw_cards(hand_space)
 end
 
 function SMODS.showman(card_key)
-    if next(SMODS.find_card('j_ring_master')) then
+    if SMODS.create_card_allow_duplicates or next(SMODS.find_card('j_ring_master')) then
         return true
     end
     return false


### PR DESCRIPTION
Added parameter to create_card/add_card to allow duplicates when using a set that doesn't allow them without needing Showman.

Plus some other updates to the SMODS.create_card LSP definition.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
