### PR TITLE
Miscellaneous LSP updates

### DIFF
--- a/lsp_def/classes/blind.lua
+++ b/lsp_def/classes/blind.lua
@@ -34,9 +34,9 @@
 ---@field drawn_to_hand? fun(self: SMODS.Blind|table) Handles effects when cards are drawn to hand. 
 ---@field press_play? fun(self: SMODS.Blind|table) Handles effects when a hand is played. 
 ---@field recalc_debuff? fun(self: SMODS.Blind|table, card: Card|table, from_blind: boolean): boolean? Determines if a card should be debuffed by this blind. 
----@field debuff_hand? fun(self: SMODS.Blind|table, cards: table, hand: table, handname: string, check: nil|boolean): boolean? Determines if the hand is debuffed. 
+---@field debuff_hand? fun(self: SMODS.Blind|table, cards: table, hand: table, handname: PokerHands|string, check: nil|boolean): boolean? Determines if the hand is debuffed. 
 ---@field stay_flipped? fun(self: SMODS.Blind|table, area: CardArea|table, card: Card|table): boolean? Determines if a card is drawn face down. 
----@field modify_hand? fun(self: SMODS.Blind|table, cards: table, poker_hands: table, text: string, mult: number, hand_chips: number): number?, number?, boolean? Handles modifications of the base score for played poker hand. 
+---@field modify_hand? fun(self: SMODS.Blind|table, cards: table, poker_hands: table, text: PokerHands|string, mult: number, hand_chips: number): number?, number?, boolean? Handles modifications of the base score for played poker hand. 
 ---@field get_loc_debuff_text? fun(self: SMODS.Blind|table): string? Handles text displayed for debuff warnings or invalid hands. 
 ---@field loc_vars? fun(self: SMODS.Blind|table): table? Provides control over displaying the Blind descriptions. See [SMODS.Blind `loc_vars` implementation](https://github.com/Steamodded/smods/wiki/SMODS.Blind#api-methods) documentation for return value details. 
 ---@field collection_loc_vars? fun(self: SMODS.Blind|table): table? Provides control over displaying the Blind description in the collections menu. 

--- a/lsp_def/classes/booster.lua
+++ b/lsp_def/classes/booster.lua
@@ -2,7 +2,7 @@
 
 ---@class SMODS.Booster: SMODS.Center
 ---@field super? SMODS.Center|table Parent class. 
----@field loc_txt? table|{name: string, text: string[], group_name: string} Contains strings used to display text relating to this object. 
+---@field loc_txt? table|{name: string|string[], text: string[]|string[][], group_name: string} Contains strings used to display text relating to this object. 
 ---@field group_key? string Key to the group name. Grabs from `G.localization.misc.dictionary[group_key]`. 
 ---@field draw_hand? boolean Sets if playing cards are drawn when booster pack is opened. 
 ---@field kind? string Groups pack types together. For example, this can be used in `get_pack()` to generate a booster pack of a specific type. 

--- a/lsp_def/classes/center.lua
+++ b/lsp_def/classes/center.lua
@@ -9,7 +9,7 @@
 ---@field unlocked? boolean Sets the unlock state of the center. 
 ---@field discovered? boolean Sets the discovery state of the center. 
 ---@field no_collection? boolean Sets whether the card shows up in the collections menu. 
----@field loc_txt? table|{name: string, text: string[]} Contains strings used for displaying text related to this object. 
+---@field loc_txt? table|{name: string|string[], text: string[]|string[][]} Contains strings used for displaying text related to this object. 
 ---@field pools? string[] Array of keys to ObjectTypes this center will be added to.
 ---@field cost? number Sell cost of this center. 
 ---@field no_pool_flag? string Key to a pool flag defined in `G.GAME.pool_flags`. This center is removed from pools as long as this flag is `true`. 

--- a/lsp_def/classes/edition.lua
+++ b/lsp_def/classes/edition.lua
@@ -1,7 +1,7 @@
 ---@meta
 
 ---@class SMODS.Edition: SMODS.Center
----@field loc_txt? table|{name: string, text: string[], label: string} Contains strings used for displaying text related to this object. 
+---@field loc_txt? table|{name: string|string[], text: string[]|string[][], label: string} Contains strings used for displaying text related to this object. 
 ---@field shader? string|false Key to the shader drawn on cards with this Edition. If set to `false`, a shader will not be drawn. 
 ---@field atlas? string Defines the atlas for the card this Edition is drawn on in the collection. 
 ---@field pos? table|{x: integer, y: integer} Defined the position of the card's sprite this Edition is drawn on in the collection.
@@ -49,7 +49,7 @@ SMODS.Edition = setmetatable({}, {
 function Card:calculate_edition(context) end
 
 ---@param self Card|table
----@param edition? string|{[string]: true} Both `string` values are the key of the edition to apply. 
+---@param edition? Editions|string|{[string]: true} Both `string` values are the key of the edition to apply. 
 ---@param immediate? boolean
 ---@param silent? boolean 
 ---@param delay? boolean
@@ -61,6 +61,6 @@ function Card:set_edition(edition, immediate, silent, delay) end
 ---@param _no_neg? boolean Exclude negative from edition polling. 
 ---@param _guaranteed? boolean Function will always return an Edition. 
 ---@param _options? string[]|{name: string, weight: number}[] Allows defining options for what editions should be polled. 
----@return string?
+---@return Editions|string?
 --- Polls editions. Returns the key of the edition if successful. 
 function poll_edition(_key, _mod, _no_neg, _guaranteed, _options) end

--- a/lsp_def/classes/edition.lua
+++ b/lsp_def/classes/edition.lua
@@ -1,6 +1,8 @@
 ---@meta
 
 ---@class SMODS.Edition: SMODS.Center
+---@field obj_buffer? Editions|string[] Array of keys to all objects registered to this class. 
+---@field obj_table? table<Editions|string, SMODS.Edition|table> Table of objects registered to this class. 
 ---@field loc_txt? table|{name: string|string[], text: string[]|string[][], label: string} Contains strings used for displaying text related to this object. 
 ---@field shader? string|false Key to the shader drawn on cards with this Edition. If set to `false`, a shader will not be drawn. 
 ---@field atlas? string Defines the atlas for the card this Edition is drawn on in the collection. 

--- a/lsp_def/classes/enhancement.lua
+++ b/lsp_def/classes/enhancement.lua
@@ -1,7 +1,9 @@
 ---@meta
 
 ---@class SMODS.Enhancement: SMODS.Center
----@field super? SMODS.Center|table Parent class. 
+---@field super? SMODS.Center|table Parent class.
+---@field obj_buffer? Enhancements|string[] Array of keys to all objects registered to this class. 
+---@field obj_table? table<Enhancements|string, SMODS.Enhancement|table> Table of objects registered to this class. 
 ---@field replace_base_card? boolean Don't draw base card sprite or give base chips. 
 ---@field no_rank? boolean Enhanced cards have no rank
 ---@field no_suit? boolean Enhanced cards have no suit. 

--- a/lsp_def/classes/enhancement.lua
+++ b/lsp_def/classes/enhancement.lua
@@ -38,6 +38,6 @@ SMODS.Enhancement = setmetatable({}, {
 function Card:calculate_enhancement(context) end
 
 ---@param args table|{key?: string, type_key?: string, mod?: number, guaranteed?: true, options?: table}
----@return string?
+---@return Enhancements|string?
 --- Polls all Enhancements with `args` for additional settings, and returns the key to a selected enhancement. 
 function SMODS.poll_enhancement(args) end

--- a/lsp_def/classes/poker_hand.lua
+++ b/lsp_def/classes/poker_hand.lua
@@ -1,7 +1,8 @@
 ---@meta
 
 ---@class SMODS.PokerHand: SMODS.GameObject
----@field obj_table? table<string, SMODS.PokerHand|table> Table of objects registered to this class. 
+---@field obj_buffer? PokerHands|string[] Array of keys to all objects registered to this class. 
+---@field obj_table? table<PokerHands|string, SMODS.PokerHand|table> Table of objects registered to this class. 
 ---@field loc_txt? table|{name: string, description: string[]} Contains strings used for displaying text related to this object. 
 ---@field super? SMODS.GameObject|table Parent class. 
 ---@field mult? number Base mult for poker hand. 
@@ -35,7 +36,7 @@ SMODS.PokerHand = setmetatable({}, {
     end
 })
 
----@type table<string, SMODS.PokerHand|table>
+---@type table<PokerHands|string, SMODS.PokerHand|table>
 SMODS.PokerHands = {}
 
 ---@class SMODS.PokerHandPart: SMODS.GameObject

--- a/lsp_def/classes/poker_hand.lua
+++ b/lsp_def/classes/poker_hand.lua
@@ -10,7 +10,7 @@
 ---@field l_chips? number Chips gained per hand level. 
 ---@field example? table Table of cards used to represent the hand example in the "Run Info" tab. 
 ---@field visible? boolean|fun(self:SMODS.PokerHand|table): boolean? Sets hand visibility in the poker hands menu. If `false`, poker hand is shown only after being played once.  A function allows more precise control over hand visibility in the poker hands menu.  
----@field above_hand? string Key to a poker hand. Used to order this poker hand above specified poker hand. 
+---@field above_hand? PokerHands|string Key to a poker hand. Used to order this poker hand above specified poker hand. 
 ---@field order_offset? number Adds this value to poker hand's mult and chips to offset ordering. 
 ---@field __call? fun(self: SMODS.PokerHand|table, o: SMODS.PokerHand|table): nil|table|SMODS.PokerHand
 ---@field extend? fun(self: SMODS.PokerHand|table, o: SMODS.PokerHand|table): table Primary method of creating a class. 

--- a/lsp_def/classes/rank.lua
+++ b/lsp_def/classes/rank.lua
@@ -13,8 +13,8 @@
 ---@field shorthand? string Short description of this rank in deck preview. 
 ---@field face_nominal? number Determines the displayed order of ranks with the same nominal value. 
 ---@field face? boolean Sets if this rank counts as a "face" card. 
----@field next? string[] List of keys to other ranks that come after this card. 
----@field prev? string[] List of keys to other ranks that come before this card. Used when evaluating straights. 
+---@field next? Ranks|string[] List of keys to other ranks that come after this card. 
+---@field prev? Ranks|string[] List of keys to other ranks that come before this card. Used when evaluating straights. 
 ---@field strength_effect? table|{fixed?: number, random?: boolean, ignore?: boolean} Determines how cards with this rank behave when Strength is used. 
 ---@field straight_edge? boolean Sets if this rank behaves like an Ace for straights. 
 ---@field suit_map? table<string, number> For any suit keys in this table, use this rank's atlas over the suit's atlas. Provided number is the `y` position of the suit on the rank's atlas. 

--- a/lsp_def/classes/rank.lua
+++ b/lsp_def/classes/rank.lua
@@ -1,7 +1,8 @@
 ---@meta
 
 ---@class SMODS.Rank: SMODS.GameObject
----@field obj_table? table<string, SMODS.Rank|table> Table of objects registered to this class. 
+---@field obj_buffer? Ranks|string[] Array of keys to all objects registered to this class. 
+---@field obj_table? table<Ranks|string, SMODS.Rank|table> Table of objects registered to this class. 
 ---@field loc_txt? table|{name: string} Contains strings used for displaying text related to this object. 
 ---@field super? SMODS.GameObject|table Parent class. 
 ---@field atlas? string Key to the rank's atlas. 
@@ -43,5 +44,5 @@ SMODS.Rank = setmetatable({}, {
     end
 })
 
----@type table<string, SMODS.Rank|table>
+---@type table<Ranks|string, SMODS.Rank|table>
 SMODS.Ranks = {}

--- a/lsp_def/classes/rarity.lua
+++ b/lsp_def/classes/rarity.lua
@@ -36,7 +36,7 @@ SMODS.Rarities = {}
 
 ---@param _pool_key string Key to ObjectType
 ---@param _rand_key? string Used as polling seed
----@return string|number rarity_key
+---@return Rarities|string|number rarity_key
 ---Polls all rarities tied to provided ObjectType. 
 function SMODS.poll_rarity(_pool_key, _rand_key) end
 

--- a/lsp_def/classes/rarity.lua
+++ b/lsp_def/classes/rarity.lua
@@ -1,7 +1,8 @@
 ---@meta
 
 ---@class SMODS.Rarity: SMODS.GameObject
----@field obj_table? table<string, SMODS.Rarity|table> Table of objects registered to this class. 
+---@field obj_buffer? Rarities|string[] Array of keys to all objects registered to this class. 
+---@field obj_table? table<Rarities|string, SMODS.Rarity|table> Table of objects registered to this class. 
 ---@field loc_txt? table|{name: string} Contains strings used for displaying text related to this object. 
 ---@field super? SMODS.GameObject|table Parent class. 
 ---@field pools? table Table with a list of ObjectTypes keys this rarity should be added to.
@@ -31,7 +32,7 @@ SMODS.Rarity = setmetatable({}, {
     end
 })
 
----@type table<string, SMODS.Rarity|table>
+---@type table<Rarities|string, SMODS.Rarity|table>
 SMODS.Rarities = {}
 
 ---@param _pool_key string Key to ObjectType

--- a/lsp_def/classes/seal.lua
+++ b/lsp_def/classes/seal.lua
@@ -1,7 +1,8 @@
 ---@meta
 
 ---@class SMODS.Seal: SMODS.GameObject
----@field obj_table? table<string, SMODS.Seal|table> Table of objects registered to this class. 
+---@field obj_buffer? Seals|string[] Array of keys to all objects registered to this class. 
+---@field obj_table? table<Seals|string, SMODS.Seal|table> Table of objects registered to this class. 
 ---@field loc_txt? table|{name: string|string[], text: string[]|string[][], label: string} Contains strings used for displaying text related to this object. 
 ---@field super? SMODS.GameObject|table Parent class. 
 ---@field atlas? string Key to the seal's atlas. 
@@ -39,7 +40,7 @@ SMODS.Seal = setmetatable({}, {
     end
 })
 
----@type table<string, SMODS.Seal|table>
+---@type table<Seals|string, SMODS.Seal|table>
 SMODS.Seals = {}
 
 ---@param args table|{key?: string, mod?: number, guaranteed?: boolean, options?: table, type_key?: string}

--- a/lsp_def/classes/seal.lua
+++ b/lsp_def/classes/seal.lua
@@ -2,7 +2,7 @@
 
 ---@class SMODS.Seal: SMODS.GameObject
 ---@field obj_table? table<string, SMODS.Seal|table> Table of objects registered to this class. 
----@field loc_txt? table|{name: string, text: string[], label: string} Contains strings used for displaying text related to this object. 
+---@field loc_txt? table|{name: string|string[], text: string[]|string[][], label: string} Contains strings used for displaying text related to this object. 
 ---@field super? SMODS.GameObject|table Parent class. 
 ---@field atlas? string Key to the seal's atlas. 
 ---@field pos? table|{x: integer, y: integer} Position of the seal's sprite. 
@@ -43,6 +43,6 @@ SMODS.Seal = setmetatable({}, {
 SMODS.Seals = {}
 
 ---@param args table|{key?: string, mod?: number, guaranteed?: boolean, options?: table, type_key?: string}
----@return string?
+---@return Seals|string?
 --- Polls seals. 
 function SMODS.poll_seal(args) end

--- a/lsp_def/classes/sticker.lua
+++ b/lsp_def/classes/sticker.lua
@@ -44,13 +44,13 @@ SMODS.Sticker = setmetatable({}, {
 SMODS.Stickers = {}
 
 ---@param self Card|table
----@param sticker string Key to the sticker to apply. 
+---@param sticker Stickers|string Key to the sticker to apply. 
 ---@param bypass_check? boolean Whether the sticker's `should_apply` function is called. 
 --- Adds the sticker onto the card. 
 function Card:add_sticker(sticker, bypass_check) end
 
 ---@param self Card|table
----@param sticker string Key to the sticker to remove. 
+---@param sticker Stickers|string Key to the sticker to remove. 
 --- Removes the sticker from the card, if it has the sticker. 
 function Card:remove_sticker(sticker) end
 

--- a/lsp_def/classes/sticker.lua
+++ b/lsp_def/classes/sticker.lua
@@ -1,7 +1,8 @@
 ---@meta
 
 ---@class SMODS.Sticker: SMODS.GameObject
----@field obj_table? table<string, SMODS.Sticker|table> Table of objects registered to this class. 
+---@field obj_buffer? Stickers|string[] Array of keys to all objects registered to this class. 
+---@field obj_table? table<Stickers|string, SMODS.Sticker|table> Table of objects registered to this class. 
 ---@field super? SMODS.GameObject|table Parent class. 
 ---@field atlas? string Key to the center's atlas. 
 ---@field pos? table|{x: integer, y: integer} Position of the center's sprite. 
@@ -40,7 +41,7 @@ SMODS.Sticker = setmetatable({}, {
     end
 })
 
----@type table<string, SMODS.Sticker|table>
+---@type table<Stickers|string, SMODS.Sticker|table>
 SMODS.Stickers = {}
 
 ---@param self Card|table

--- a/lsp_def/classes/suit.lua
+++ b/lsp_def/classes/suit.lua
@@ -1,7 +1,8 @@
 ---@meta
 
 ---@class SMODS.Suit: SMODS.GameObject
----@field obj_table? table<string, SMODS.Suit|table> Table of objects registered to this class. 
+---@field obj_buffer? Suits|string[] Array of keys to all objects registered to this class.
+---@field obj_table? table<Suits|string, SMODS.Suit|table> Table of objects registered to this class. 
 ---@field loc_txt? table|{singular: string, plural: string} Contains strings used for displaying text related to this object. 
 ---@field super? SMODS.GameObject|table Parent class. 
 ---@field atlas? string Key to the suit's atlas. 
@@ -39,5 +40,5 @@ SMODS.Suit = setmetatable({}, {
     end
 })
 
----@type table<string, SMODS.Suit|table>
+---@type table<Suits|string, SMODS.Suit|table>
 SMODS.Suits = {}

--- a/lsp_def/smods_core.lua
+++ b/lsp_def/smods_core.lua
@@ -35,7 +35,7 @@ SMODS.path = ""
 ---@field custom_collection_tabs? fun(): table[] Creates additional buttons displayed inside the "Other" tab in collections.
 ---@field description_loc_vars? fun(self: Mod|table): table Allows dynamic display of this mod's description.
 ---@field custom_ui? fun(mod_nodes: table) Allows manipulating this mod's description tab.
----@field ui_config? fun(mod_nodes: table) Allows specifying custom values for this mod's menu UI elements.
+---@field ui_config? table Allows specifying custom values for this mod's menu UI elements.
 ---@field set_ability_reset_keys? fun(): string[] When a card's `ability` table is changed, values with a key matching a string inside the returned table .
 ---@field reset_game_globals? fun(run_start: boolean) Allows resetting global values every new run or round.
 ---@field set_debuff? fun(card: Card|table): boolean|string? Allows controlling when a card is debuffed or not. Return `"prevent_debuff"` to force a card to be undebuffable.

--- a/lsp_def/vanilla.lua
+++ b/lsp_def/vanilla.lua
@@ -251,3 +251,74 @@ function tally_sprite(pos, value, tooltip, suit) end
 ---@return string key
 --- Sets the seed to `seed` and randomly selects a table within `_t`. 
 function pseudorandom_element(_t, seed, args) end
+
+--- Vanilla Pools
+
+---@alias Enhancements
+---| 'm_bonus'
+---| 'm_mult'
+---| 'm_wild'
+---| 'm_glass'
+---| 'm_steel'
+---| 'm_stone'
+---| 'm_gold'
+---| 'm_lucky'
+
+---@alias Editions
+---| 'e_foil'
+---| 'e_holo'
+---| 'e_polychrome'
+---| 'e_negative'
+
+---@alias Seals
+---| 'Red'
+---| 'Blue'
+---| 'Gold'
+---| 'Purple'
+
+---@alias Stickers
+---| 'perishable'
+---| 'eternal'
+---| 'rental'
+---| 'pinned'
+
+---@alias PokerHands
+---| 'Flush Five'
+---| 'Flush House'
+---| 'Five of a Kind'
+---| 'Straight Flush'
+---| 'Four of a Kind'
+---| 'Full House'
+---| 'Flush'
+---| 'Straight'
+---| 'Three of a Kind'
+---| 'Two Pair'
+---| 'Pair'
+---| 'High Card'
+
+---@alias Ranks
+---| '2'
+---| '3'
+---| '4'
+---| '5'
+---| '6'
+---| '7'
+---| '8'
+---| '9'
+---| '10'
+---| 'Jack'
+---| 'Queen'
+---| 'King'
+---| 'Ace'
+
+---@alias Suits
+---| 'Hearts'
+---| 'Diamonds'
+---| 'Clubs'
+---| 'Spades'
+
+---@alias Rarities
+---| 'Legendary'
+---| 'Rare'
+---| 'Uncommon'
+---| 'Common'


### PR DESCRIPTION
* Added vanilla Enhancements, Editions, Seals, Stickers, Rarities, Ranks, Suits and PokerHands definitions and added it to the relevant type hints in functions
* Added internal card area types (jokers, playing card, individual) definitions
* Fix Mod.ui_config type
* Added 'prevent_debuff' to SMODS.debuff_card
* Update get_probability_vars/pseudorandom_probability definitions
* Updated loc_txt for multiline names and multibox descriptions

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
