### PR TITLE
Add scale_card functionality for scaling detection and modification.

### DIFF
--- a/lovely/scaling.toml
+++ b/lovely/scaling.toml
@@ -19,27 +19,21 @@ SMODS.scale_card(self, {
 })
 '''
 
-# Ride The Bus
+# Ride The Bus/Red Card/Flash Card/Spare Trousers
 [[patches]]
 [patches.pattern]
 target = "card.lua"
 pattern = '''
-if self.ability.name == 'Ride the Bus' and not context.blueprint then
-    local faces = false
-    for i = 1, #context.scoring_hand do
-        if context.scoring_hand[i]:is_face() then faces = true end
-    end
+self.ability.mult = self.ability.mult + self.ability.extra
 '''
 position = 'after'
 match_indent = true
 payload = '''
-    if not faces then 
-        SMODS.scale_card(self, {
-            ref_table = self.ability,
-            ref_value = "mult",
-            scalar_value = "extra"
-        })
-    end
+SMODS.scale_card(self, {
+    ref_table = self.ability,
+    ref_value = "mult",
+    scalar_value = "extra"
+})
 '''
 
 # Egg
@@ -48,7 +42,6 @@ payload = '''
 target = "card.lua"
 pattern = '''
 self.ability.extra_value = self.ability.extra_value + self.ability.extra
-self:set_cost()
 '''
 position = 'after'
 match_indent = true
@@ -60,22 +53,21 @@ SMODS.scale_card(self, {
 })
 '''
 
-# Runner
+# Runner/Square Joker/Wee Joker/Castle
 [[patches]]
 [patches.pattern]
 target = "card.lua"
 pattern = '''
-if self.ability.name == 'Runner' and next(context.poker_hands['Straight']) and not context.blueprint then
-    self.ability.extra.chips = self.ability.extra.chips + self.ability.extra.chip_mod
+self.ability.extra.chips = self.ability.extra.chips + self.ability.extra.chip_mod
 '''
 position = 'after'
 match_indent = true
 payload = '''
-    SMODS.scale_card(self, {
-        ref_table = self.ability.extra,
-        ref_value = "chips",
-        scalar_value = "chip_mod"
-    })
+SMODS.scale_card(self, {
+    ref_table = self.ability.extra,
+    ref_value = "chips",
+    scalar_value = "chip_mod"
+})
 '''
 
 # Ice Cream
@@ -83,58 +75,34 @@ payload = '''
 [patches.pattern]
 target = "card.lua"
 pattern = '''
-if self.ability.name == 'Ice Cream' and not context.blueprint then
-    if self.ability.extra.chips - self.ability.extra.chip_mod <= 0 then 
-        G.E_MANAGER:add_event(Event({
-            func = function()
-                play_sound('tarot1')
-                self.T.r = -0.2
-                self:juice_up(0.3, 0.4)
-                self.states.drag.is = true
-                self.children.center.pinch.x = true
-                G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.3, blockable = false,
-                    func = function()
-                            G.jokers:remove_card(self)
-                            self:remove()
-                            self = nil
-                        return true; end})) 
-                return true
-            end
-        })) 
-        return {
-            message = localize('k_melted_ex'),
-            colour = G.C.CHIPS
-        }
-    else
-        self.ability.extra.chips = self.ability.extra.chips - self.ability.extra.chip_mod
+self.ability.extra.chips = self.ability.extra.chips - self.ability.extra.chip_mod
 '''
 position = 'after'
 match_indent = true
 payload = '''
-        SMODS.scale_card(self, {
-            ref_table = self.ability.extra,
-            ref_value = "chips",
-            scalar_value = "chip_mod",
-            operation = "-"
-        })
+SMODS.scale_card(self, {
+    ref_table = self.ability.extra,
+    ref_value = "chips",
+    scalar_value = "chip_mod",
+    operation = "-"
+})
 '''
 
-# Constellation
+# Constellation/Campfire/Madness/Hit the Road/Lucky Cat/Obelisk
 [[patches]]
 [patches.pattern]
 target = "card.lua"
 pattern = '''
-if self.ability.name == 'Constellation' and not context.blueprint and context.consumeable.ability.set == 'Planet' then
-    self.ability.x_mult = self.ability.x_mult + self.ability.extra
+self.ability.x_mult = self.ability.x_mult + self.ability.extra
 '''
 position = 'after'
 match_indent = true
 payload = '''
-    SMODS.scale_card(self, {
-        ref_table = self.ability,
-        ref_value = "x_mult",
-        scalar_value = "extra"
-    })
+SMODS.scale_card(self, {
+    ref_table = self.ability,
+    ref_value = "x_mult",
+    scalar_value = "extra"
+})
 '''
 
 # Green Joker: Subtraction
@@ -142,9 +110,7 @@ payload = '''
 [patches.pattern]
 target = "card.lua"
 pattern = '''
-if self.ability.name == 'Green Joker' and not context.blueprint and context.other_card == context.full_hand[#context.full_hand] then
-    local prev_mult = self.ability.mult
-    self.ability.mult = math.max(0, self.ability.mult - self.ability.extra.discard_sub)
+if self.ability.mult ~= prev_mult then 
 '''
 position = 'after'
 match_indent = true
@@ -163,72 +129,17 @@ payload = '''
 [patches.pattern]
 target = "card.lua"
 pattern = '''
-if self.ability.name == 'Green Joker' and not context.blueprint then
-    self.ability.mult = self.ability.mult + self.ability.extra.hand_add
+self.ability.mult = self.ability.mult + self.ability.extra.hand_add
 '''
 position = 'after'
 match_indent = true
 payload = '''
-    SMODS.scale_card(self, {
-        ref_table = self.ability,
-        ref_value = "mult",
-        scalar_table = "extra",
-        scalar_value = "hand_add",
-    })
-'''
-
-# Red Card
-[[patches]]
-[patches.pattern]
-target = "card.lua"
-pattern = '''
-if self.ability.name == 'Red Card' and not context.blueprint then
-    self.ability.mult = self.ability.mult + self.ability.extra
-'''
-position = 'after'
-match_indent = true
-payload = '''
-    SMODS.scale_card(self, {
-        ref_table = self.ability,
-        ref_value = "mult",
-        scalar_value = "extra",
-    })
-'''
-
-# Madness
-[[patches]]
-[patches.pattern]
-target = "card.lua"
-pattern = '''
-if self.ability.name == 'Madness' and not context.blueprint and not context.blind.boss then
-    self.ability.x_mult = self.ability.x_mult + self.ability.extra
-'''
-position = 'after'
-match_indent = true
-payload = '''
-    SMODS.scale_card(self, {
-        ref_table = self.ability,
-        ref_value = "x_mult",
-        scalar_value = "extra",
-    })
-'''
-
-# Square Joker
-[[patches]]
-[patches.pattern]
-target = "card.lua"
-pattern = '''
-if self.ability.name == 'Square Joker' and #context.full_hand == 4 and not context.blueprint then
-    self.ability.extra.chips = self.ability.extra.chips + self.ability.extra.chip_mod
-'''
-position = 'after'
-match_indent = true
-payload = '''
-    SMODS.scale_card(self, {
-        ref_table = self.ability.extra,
-        ref_value = "chips",
-        scalar_value = "chip_mod",
-    })
+SMODS.scale_card(self, {
+    ref_table = self.ability,
+    ref_value = "mult",
+    scalar_table = "extra",
+    scalar_value = "hand_add",
+})
 '''
 
 # Vampire
@@ -236,17 +147,16 @@ payload = '''
 [patches.pattern]
 target = "card.lua"
 pattern = '''
-if #enhanced > 0 then 
-    self.ability.x_mult = self.ability.x_mult + self.ability.extra*#enhanced
+self.ability.x_mult = self.ability.x_mult + self.ability.extra*#enhanced
 '''
 position = 'after'
 match_indent = true
 payload = '''
-    SMODS.scale_card(self, {
-        ref_table = self.ability,
-        ref_value = "x_mult",
-        scalar_value = "extra",
-    })
+SMODS.scale_card(self, {
+    ref_table = self.ability,
+    ref_value = "x_mult",
+    scalar_value = "extra",
+})
 '''
 
 # Hologram
@@ -254,18 +164,16 @@ payload = '''
 [patches.pattern]
 target = "card.lua"
 pattern = '''
-if self.ability.name == 'Hologram' and (not context.blueprint)
-and context.cards and context.cards[1] then
-    self.ability.x_mult = self.ability.x_mult + #context.cards*self.ability.extra
+self.ability.x_mult = self.ability.x_mult + #context.cards*self.ability.extra
 '''
 position = 'after'
 match_indent = true
 payload = '''
-    SMODS.scale_card(self, {
-        ref_table = self.ability,
-        ref_value = "x_mult",
-        scalar_value = "extra",
-    })
+SMODS.scale_card(self, {
+    ref_table = self.ability,
+    ref_value = "x_mult",
+    scalar_value = "extra",
+})
 '''
 
 # Rocket
@@ -273,43 +181,16 @@ payload = '''
 [patches.pattern]
 target = "card.lua"
 pattern = '''
-if self.ability.name == 'Rocket' and G.GAME.blind.boss then
-    self.ability.extra.dollars = self.ability.extra.dollars + self.ability.extra.increase
+self.ability.extra.dollars = self.ability.extra.dollars + self.ability.extra.increase
 '''
 position = 'after'
 match_indent = true
 payload = '''
-    SMODS.scale_card(self, {
-        ref_table = self.ability.extra,
-        ref_value = "dollars",
-        scalar_value = "increase",
-    })
-'''
-
-# Obelisk
-[[patches]]
-[patches.pattern]
-target = "card.lua"
-pattern = '''
-if reset then
-    if self.ability.x_mult > 1 then
-        self.ability.x_mult = 1
-        return {
-            card = self,
-            message = localize('k_reset')
-        }
-    end
-else
-    self.ability.x_mult = self.ability.x_mult + self.ability.extra
-'''
-position = 'after'
-match_indent = true
-payload = '''
-    SMODS.scale_card(self, {
-        ref_table = self.ability,
-        ref_value = "x_mult",
-        scalar_value = "extra",
-    })
+SMODS.scale_card(self, {
+    ref_table = self.ability.extra,
+    ref_value = "dollars",
+    scalar_value = "increase",
+})
 '''
 
 # Turtle Bean
@@ -318,7 +199,6 @@ payload = '''
 target = "card.lua"
 pattern = '''
 self.ability.extra.h_size = self.ability.extra.h_size - self.ability.extra.h_mod
-G.hand:change_size(- self.ability.extra.h_mod)
 '''
 position = 'after'
 match_indent = true
@@ -331,98 +211,21 @@ SMODS.scale_card(self, {
 })
 '''
 
-# Lucky Cat
-[[patches]]
-[patches.pattern]
-target = "card.lua"
-pattern = '''
-if self.ability.name == 'Lucky Cat' and context.other_card.lucky_trigger and not context.blueprint then
-    self.ability.x_mult = self.ability.x_mult + self.ability.extra
-'''
-position = 'after'
-match_indent = true
-payload = '''
-    SMODS.scale_card(self, {
-        ref_table = self.ability,
-        ref_value = "x_mult",
-        scalar_value = "extra",
-    })
-'''
-
-# Flash Card
-[[patches]]
-[patches.pattern]
-target = "card.lua"
-pattern = '''
-if self.ability.name == 'Flash Card' and not context.blueprint then
-    self.ability.mult = self.ability.mult + self.ability.extra
-'''
-position = 'after'
-match_indent = true
-payload = '''
-    SMODS.scale_card(self, {
-        ref_table = self.ability,
-        ref_value = "mult",
-        scalar_value = "extra",
-    })
-'''
-
 # Popcorn
 [[patches]]
 [patches.pattern]
 target = "card.lua"
 pattern = '''
-if self.ability.name == 'Popcorn' and not context.blueprint then
-    if self.ability.mult - self.ability.extra <= 0 then 
-        G.E_MANAGER:add_event(Event({
-            func = function()
-                play_sound('tarot1')
-                self.T.r = -0.2
-                self:juice_up(0.3, 0.4)
-                self.states.drag.is = true
-                self.children.center.pinch.x = true
-                G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.3, blockable = false,
-                    func = function()
-                            G.jokers:remove_card(self)
-                            self:remove()
-                            self = nil
-                        return true; end})) 
-                return true
-            end
-        })) 
-        return {
-            message = localize('k_eaten_ex'),
-            colour = G.C.RED
-        }
-    else
-        self.ability.mult = self.ability.mult - self.ability.extra
+self.ability.mult = self.ability.mult - self.ability.extra
 '''
 position = 'after'
 match_indent = true
 payload = '''
-        SMODS.scale_card(self, {
-            ref_table = self.ability,
-            ref_value = "mult",
-            scalar_value = "extra",
-        })
-'''
-
-# Spare Trousers
-[[patches]]
-[patches.pattern]
-target = "card.lua"
-pattern = '''
-if self.ability.name == 'Spare Trousers' and (next(context.poker_hands['Two Pair']) or next(context.poker_hands['Full House'])) and not context.blueprint then
-    self.ability.mult = self.ability.mult + self.ability.extra
-'''
-position = 'after'
-match_indent = true
-payload = '''
-    SMODS.scale_card(self, {
-        ref_table = self.ability,
-        ref_value = "mult",
-        scalar_value = "extra",
-    })
+SMODS.scale_card(self, {
+    ref_table = self.ability,
+    ref_value = "mult",
+    scalar_value = "extra",
+})
 '''
 
 # Ramen
@@ -430,96 +233,17 @@ payload = '''
 [patches.pattern]
 target = "card.lua"
 pattern = '''
-if self.ability.name == 'Ramen' and not context.blueprint then
+self.ability.x_mult = self.ability.x_mult - self.ability.extra
 '''
 position = 'after'
 match_indent = true
 payload = '''
-    if self.ability.x_mult - self.ability.extra >= 1 then 
-        SMODS.scale_card(self, {
-            ref_table = self.ability,
-            ref_value = "x_mult",
-            scalar_value = "extra",
-            operation = "-"
-        })
-    end
-'''
-
-# Castle
-[[patches]]
-[patches.pattern]
-target = "card.lua"
-pattern = '''
-if self.ability.name == 'Castle' and
-not context.other_card.debuff and
-context.other_card:is_suit(G.GAME.current_round.castle_card.suit) and not context.blueprint then
-    self.ability.extra.chips = self.ability.extra.chips + self.ability.extra.chip_mod
-'''
-position = 'after'
-match_indent = true
-payload = '''
-    SMODS.scale_card(self, {
-        ref_table = self.ability.extra,
-        ref_value = "chips",
-        scalar_value = "chip_mod",
-    })
-'''
-
-# Campfire
-[[patches]]
-[patches.pattern]
-target = "card.lua"
-pattern = '''
-if self.ability.name == 'Campfire' and not context.blueprint then
-    self.ability.x_mult = self.ability.x_mult + self.ability.extra
-'''
-position = 'after'
-match_indent = true
-payload = '''
-    SMODS.scale_card(self, {
-        ref_table = self.ability,
-        ref_value = "x_mult",
-        scalar_value = "extra",
-    })
-'''
-
-# Wee Joker
-[[patches]]
-[patches.pattern]
-target = "card.lua"
-pattern = '''
-if self.ability.name == 'Wee Joker' and
-    context.other_card:get_id() == 2 and not context.blueprint then
-        self.ability.extra.chips = self.ability.extra.chips + self.ability.extra.chip_mod
-'''
-position = 'after'
-match_indent = true
-payload = '''
-        SMODS.scale_card(self, {
-            ref_table = self.ability.extra,
-            ref_value = "chips",
-            scalar_value = "chip_mod",
-        })
-'''
-
-# Hit The Road
-[[patches]]
-[patches.pattern]
-target = "card.lua"
-pattern = '''
-if self.ability.name == 'Hit the Road' and
-not context.other_card.debuff and
-context.other_card:get_id() == 11 and not context.blueprint then
-    self.ability.x_mult = self.ability.x_mult + self.ability.extra
-'''
-position = 'after'
-match_indent = true
-payload = '''
-    SMODS.scale_card(self, {
-        ref_table = self.ability,
-        ref_value = "x_mult",
-        scalar_value = "extra",
-    })
+SMODS.scale_card(self, {
+    ref_table = self.ability,
+    ref_value = "x_mult",
+    scalar_value = "extra",
+    operation = "-"
+})
 '''
 
 # Yorick
@@ -527,18 +251,15 @@ payload = '''
 [patches.pattern]
 target = "card.lua"
 pattern = '''
-if self.ability.name == 'Yorick' and not context.blueprint then
-    if self.ability.yorick_discards <= 1 then
-        self.ability.yorick_discards = self.ability.extra.discards
-        self.ability.x_mult = self.ability.x_mult + self.ability.extra.xmult
+self.ability.x_mult = self.ability.x_mult + self.ability.extra.xmult
 '''
 position = 'after'
 match_indent = true
 payload = '''
-        SMODS.scale_card(self, {
-            ref_table = self.ability,
-            ref_value = "x_mult",
-            scalar_table = self.ability.extra,
-            scalar_value = "xmult",
-        })
+SMODS.scale_card(self, {
+    ref_table = self.ability,
+    ref_value = "x_mult",
+    scalar_table = self.ability.extra,
+    scalar_value = "xmult",
+})
 '''

--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -660,6 +660,5 @@ function SMODS.is_eternal(card, trigger) end
 ---@return table? results
 --- Tells Jokers that this card is scaling allowing for scaling detection
 --- Can return scaling_value and scalar_value in results to change the scaling cards values
---- Args must contain ref_table, ref_value, and scalar_value and may optionally contain scalar_table used in place of ref_table for the scalar_value
---- and operation to designate the scaling operation, which defaults to "+"
+--- Args must contain `ref_table`, `ref_value`, and `scalar_value`. It may optionally contain `scalar_table`, used in place of `ref_table` for the `scalar_value`, and `operation` to designate the scaling operation, which defaults to `"+"`
 function SMODS.scale_card(card, args) end

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2658,14 +2658,13 @@ function SMODS.scale_card(card, args)
     if not args.operation then args.operation = "+" end
     for _, area in ipairs(SMODS.get_card_areas('jokers')) do
         for _, _card in ipairs(area.cards) do
-            if _card.config and _card.config.center and _card.config.center.calc_scaling and type(_card.config.center.calc_scaling) == "function" then
-                local ret = _card.config.center:calc_scaling(_card, card, args.ref_table[args.ref_value], (args.scalar_table or args.ref_table)[args.scalar_value], args)
+            local obj = _card.config.center
+            if obj.calc_scaling and type(obj.calc_scaling) == "function" then
+                local ret = obj:calc_scaling(_card, card, args.ref_table[args.ref_value], (args.scalar_table or args.ref_table)[args.scalar_value], args)
                 if ret then
                     if ret.scaling_value then args.ref_table[args.ref_value] = ret.scaling_value end
                     if ret.scalar_value then (args.scalar_table or args.ref_table)[args.scalar_value] = ret.scalar_value end
-                    for i2, v2 in pairs(ret) do
-                        SMODS.calculate_individual_effect(ret, _card, i2, result, false)
-                    end
+                    SMODS.calculate_effect(ret, _card)
                 end
             end
         end


### PR DESCRIPTION
adds SMODS.scale_card for scaling Jokers to optionally call to allow for scaling detection as well as calling this for all vanilla Jokers, Jokers may have a calc_scaling function similar to calc_dollar_bonus to respond to scaling which may return values similarly to calculate. SMODS.scale_card takes in card and a table of arguments: 
ref_table: table where scaling value and scalar value are stored
ref_value: index of the scaling value in ref_table
scalar_table : used in place of ref_table for the scalar value if present
scalar_value: index of the scalar value
operation: optional defaults to "+", allows jokers to respond to more complex scaling events

This feature is not an optional feature under SMODS.optional_features currently due to the hopefully negligent performance impact without any scaling Jokers however scaling Jokers will work fine without SMODS.scale_card scaling detection will just not work for them

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [X] I didn't modify api's or I've updated lsp definitions.
- [X] I didn't make new lovely files or all new lovely files have appropriate priority.
