### PR TITLE
Fix vanilla JimboQuip registering

### DIFF
--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -2630,7 +2630,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
         end
     }
 
-    for i=1,9 do
+    for i=1,10 do
         SMODS.JimboQuip{
             key = "lq_"..tostring(i),
             type = 'loss',


### PR DESCRIPTION
Seems to be missing one vanilla loss quip.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
