### PR TITLE
scale_card message related changes

### DIFF
--- a/lovely/scaling.toml
+++ b/lovely/scaling.toml
@@ -19,27 +19,21 @@ SMODS.scale_card(self, {
 })
 '''
 
-# Ride The Bus
+# Ride The Bus/Red Card/Flash Card/Spare Trousers
 [[patches]]
 [patches.pattern]
 target = "card.lua"
 pattern = '''
-if self.ability.name == 'Ride the Bus' and not context.blueprint then
-    local faces = false
-    for i = 1, #context.scoring_hand do
-        if context.scoring_hand[i]:is_face() then faces = true end
-    end
+self.ability.mult = self.ability.mult + self.ability.extra
 '''
 position = 'after'
 match_indent = true
 payload = '''
-    if not faces then 
-        SMODS.scale_card(self, {
-            ref_table = self.ability,
-            ref_value = "mult",
-            scalar_value = "extra"
-        })
-    end
+SMODS.scale_card(self, {
+    ref_table = self.ability,
+    ref_value = "mult",
+    scalar_value = "extra"
+})
 '''
 
 # Egg
@@ -48,7 +42,6 @@ payload = '''
 target = "card.lua"
 pattern = '''
 self.ability.extra_value = self.ability.extra_value + self.ability.extra
-self:set_cost()
 '''
 position = 'after'
 match_indent = true
@@ -60,22 +53,21 @@ SMODS.scale_card(self, {
 })
 '''
 
-# Runner
+# Runner/Square Joker/Wee Joker/Castle
 [[patches]]
 [patches.pattern]
 target = "card.lua"
 pattern = '''
-if self.ability.name == 'Runner' and next(context.poker_hands['Straight']) and not context.blueprint then
-    self.ability.extra.chips = self.ability.extra.chips + self.ability.extra.chip_mod
+self.ability.extra.chips = self.ability.extra.chips + self.ability.extra.chip_mod
 '''
 position = 'after'
 match_indent = true
 payload = '''
-    SMODS.scale_card(self, {
-        ref_table = self.ability.extra,
-        ref_value = "chips",
-        scalar_value = "chip_mod"
-    })
+SMODS.scale_card(self, {
+    ref_table = self.ability.extra,
+    ref_value = "chips",
+    scalar_value = "chip_mod"
+})
 '''
 
 # Ice Cream
@@ -83,58 +75,34 @@ payload = '''
 [patches.pattern]
 target = "card.lua"
 pattern = '''
-if self.ability.name == 'Ice Cream' and not context.blueprint then
-    if self.ability.extra.chips - self.ability.extra.chip_mod <= 0 then 
-        G.E_MANAGER:add_event(Event({
-            func = function()
-                play_sound('tarot1')
-                self.T.r = -0.2
-                self:juice_up(0.3, 0.4)
-                self.states.drag.is = true
-                self.children.center.pinch.x = true
-                G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.3, blockable = false,
-                    func = function()
-                            G.jokers:remove_card(self)
-                            self:remove()
-                            self = nil
-                        return true; end})) 
-                return true
-            end
-        })) 
-        return {
-            message = localize('k_melted_ex'),
-            colour = G.C.CHIPS
-        }
-    else
-        self.ability.extra.chips = self.ability.extra.chips - self.ability.extra.chip_mod
+self.ability.extra.chips = self.ability.extra.chips - self.ability.extra.chip_mod
 '''
 position = 'after'
 match_indent = true
 payload = '''
-        SMODS.scale_card(self, {
-            ref_table = self.ability.extra,
-            ref_value = "chips",
-            scalar_value = "chip_mod",
-            operation = "-"
-        })
+SMODS.scale_card(self, {
+    ref_table = self.ability.extra,
+    ref_value = "chips",
+    scalar_value = "chip_mod",
+    operation = "-"
+})
 '''
 
-# Constellation
+# Constellation/Campfire/Madness/Hit the Road/Lucky Cat/Obelisk
 [[patches]]
 [patches.pattern]
 target = "card.lua"
 pattern = '''
-if self.ability.name == 'Constellation' and not context.blueprint and context.consumeable.ability.set == 'Planet' then
-    self.ability.x_mult = self.ability.x_mult + self.ability.extra
+self.ability.x_mult = self.ability.x_mult + self.ability.extra
 '''
 position = 'after'
 match_indent = true
 payload = '''
-    SMODS.scale_card(self, {
-        ref_table = self.ability,
-        ref_value = "x_mult",
-        scalar_value = "extra"
-    })
+SMODS.scale_card(self, {
+    ref_table = self.ability,
+    ref_value = "x_mult",
+    scalar_value = "extra"
+})
 '''
 
 # Green Joker: Subtraction
@@ -142,9 +110,7 @@ payload = '''
 [patches.pattern]
 target = "card.lua"
 pattern = '''
-if self.ability.name == 'Green Joker' and not context.blueprint and context.other_card == context.full_hand[#context.full_hand] then
-    local prev_mult = self.ability.mult
-    self.ability.mult = math.max(0, self.ability.mult - self.ability.extra.discard_sub)
+if self.ability.mult ~= prev_mult then 
 '''
 position = 'after'
 match_indent = true
@@ -163,72 +129,17 @@ payload = '''
 [patches.pattern]
 target = "card.lua"
 pattern = '''
-if self.ability.name == 'Green Joker' and not context.blueprint then
-    self.ability.mult = self.ability.mult + self.ability.extra.hand_add
+self.ability.mult = self.ability.mult + self.ability.extra.hand_add
 '''
 position = 'after'
 match_indent = true
 payload = '''
-    SMODS.scale_card(self, {
-        ref_table = self.ability,
-        ref_value = "mult",
-        scalar_table = "extra",
-        scalar_value = "hand_add",
-    })
-'''
-
-# Red Card
-[[patches]]
-[patches.pattern]
-target = "card.lua"
-pattern = '''
-if self.ability.name == 'Red Card' and not context.blueprint then
-    self.ability.mult = self.ability.mult + self.ability.extra
-'''
-position = 'after'
-match_indent = true
-payload = '''
-    SMODS.scale_card(self, {
-        ref_table = self.ability,
-        ref_value = "mult",
-        scalar_value = "extra",
-    })
-'''
-
-# Madness
-[[patches]]
-[patches.pattern]
-target = "card.lua"
-pattern = '''
-if self.ability.name == 'Madness' and not context.blueprint and not context.blind.boss then
-    self.ability.x_mult = self.ability.x_mult + self.ability.extra
-'''
-position = 'after'
-match_indent = true
-payload = '''
-    SMODS.scale_card(self, {
-        ref_table = self.ability,
-        ref_value = "x_mult",
-        scalar_value = "extra",
-    })
-'''
-
-# Square Joker
-[[patches]]
-[patches.pattern]
-target = "card.lua"
-pattern = '''
-if self.ability.name == 'Square Joker' and #context.full_hand == 4 and not context.blueprint then
-    self.ability.extra.chips = self.ability.extra.chips + self.ability.extra.chip_mod
-'''
-position = 'after'
-match_indent = true
-payload = '''
-    SMODS.scale_card(self, {
-        ref_table = self.ability.extra,
-        ref_value = "chips",
-        scalar_value = "chip_mod",
-    })
+SMODS.scale_card(self, {
+    ref_table = self.ability,
+    ref_value = "mult",
+    scalar_table = "extra",
+    scalar_value = "hand_add",
+})
 '''
 
 # Vampire
@@ -236,17 +147,16 @@ payload = '''
 [patches.pattern]
 target = "card.lua"
 pattern = '''
-if #enhanced > 0 then 
-    self.ability.x_mult = self.ability.x_mult + self.ability.extra*#enhanced
+self.ability.x_mult = self.ability.x_mult + self.ability.extra*#enhanced
 '''
 position = 'after'
 match_indent = true
 payload = '''
-    SMODS.scale_card(self, {
-        ref_table = self.ability,
-        ref_value = "x_mult",
-        scalar_value = "extra",
-    })
+SMODS.scale_card(self, {
+    ref_table = self.ability,
+    ref_value = "x_mult",
+    scalar_value = "extra",
+})
 '''
 
 # Hologram
@@ -254,18 +164,16 @@ payload = '''
 [patches.pattern]
 target = "card.lua"
 pattern = '''
-if self.ability.name == 'Hologram' and (not context.blueprint)
-and context.cards and context.cards[1] then
-    self.ability.x_mult = self.ability.x_mult + #context.cards*self.ability.extra
+self.ability.x_mult = self.ability.x_mult + #context.cards*self.ability.extra
 '''
 position = 'after'
 match_indent = true
 payload = '''
-    SMODS.scale_card(self, {
-        ref_table = self.ability,
-        ref_value = "x_mult",
-        scalar_value = "extra",
-    })
+SMODS.scale_card(self, {
+    ref_table = self.ability,
+    ref_value = "x_mult",
+    scalar_value = "extra",
+})
 '''
 
 # Rocket
@@ -273,43 +181,16 @@ payload = '''
 [patches.pattern]
 target = "card.lua"
 pattern = '''
-if self.ability.name == 'Rocket' and G.GAME.blind.boss then
-    self.ability.extra.dollars = self.ability.extra.dollars + self.ability.extra.increase
+self.ability.extra.dollars = self.ability.extra.dollars + self.ability.extra.increase
 '''
 position = 'after'
 match_indent = true
 payload = '''
-    SMODS.scale_card(self, {
-        ref_table = self.ability.extra,
-        ref_value = "dollars",
-        scalar_value = "increase",
-    })
-'''
-
-# Obelisk
-[[patches]]
-[patches.pattern]
-target = "card.lua"
-pattern = '''
-if reset then
-    if self.ability.x_mult > 1 then
-        self.ability.x_mult = 1
-        return {
-            card = self,
-            message = localize('k_reset')
-        }
-    end
-else
-    self.ability.x_mult = self.ability.x_mult + self.ability.extra
-'''
-position = 'after'
-match_indent = true
-payload = '''
-    SMODS.scale_card(self, {
-        ref_table = self.ability,
-        ref_value = "x_mult",
-        scalar_value = "extra",
-    })
+SMODS.scale_card(self, {
+    ref_table = self.ability.extra,
+    ref_value = "dollars",
+    scalar_value = "increase",
+})
 '''
 
 # Turtle Bean
@@ -318,7 +199,6 @@ payload = '''
 target = "card.lua"
 pattern = '''
 self.ability.extra.h_size = self.ability.extra.h_size - self.ability.extra.h_mod
-G.hand:change_size(- self.ability.extra.h_mod)
 '''
 position = 'after'
 match_indent = true
@@ -331,98 +211,21 @@ SMODS.scale_card(self, {
 })
 '''
 
-# Lucky Cat
-[[patches]]
-[patches.pattern]
-target = "card.lua"
-pattern = '''
-if self.ability.name == 'Lucky Cat' and context.other_card.lucky_trigger and not context.blueprint then
-    self.ability.x_mult = self.ability.x_mult + self.ability.extra
-'''
-position = 'after'
-match_indent = true
-payload = '''
-    SMODS.scale_card(self, {
-        ref_table = self.ability,
-        ref_value = "x_mult",
-        scalar_value = "extra",
-    })
-'''
-
-# Flash Card
-[[patches]]
-[patches.pattern]
-target = "card.lua"
-pattern = '''
-if self.ability.name == 'Flash Card' and not context.blueprint then
-    self.ability.mult = self.ability.mult + self.ability.extra
-'''
-position = 'after'
-match_indent = true
-payload = '''
-    SMODS.scale_card(self, {
-        ref_table = self.ability,
-        ref_value = "mult",
-        scalar_value = "extra",
-    })
-'''
-
 # Popcorn
 [[patches]]
 [patches.pattern]
 target = "card.lua"
 pattern = '''
-if self.ability.name == 'Popcorn' and not context.blueprint then
-    if self.ability.mult - self.ability.extra <= 0 then 
-        G.E_MANAGER:add_event(Event({
-            func = function()
-                play_sound('tarot1')
-                self.T.r = -0.2
-                self:juice_up(0.3, 0.4)
-                self.states.drag.is = true
-                self.children.center.pinch.x = true
-                G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.3, blockable = false,
-                    func = function()
-                            G.jokers:remove_card(self)
-                            self:remove()
-                            self = nil
-                        return true; end})) 
-                return true
-            end
-        })) 
-        return {
-            message = localize('k_eaten_ex'),
-            colour = G.C.RED
-        }
-    else
-        self.ability.mult = self.ability.mult - self.ability.extra
+self.ability.mult = self.ability.mult - self.ability.extra
 '''
 position = 'after'
 match_indent = true
 payload = '''
-        SMODS.scale_card(self, {
-            ref_table = self.ability,
-            ref_value = "mult",
-            scalar_value = "extra",
-        })
-'''
-
-# Spare Trousers
-[[patches]]
-[patches.pattern]
-target = "card.lua"
-pattern = '''
-if self.ability.name == 'Spare Trousers' and (next(context.poker_hands['Two Pair']) or next(context.poker_hands['Full House'])) and not context.blueprint then
-    self.ability.mult = self.ability.mult + self.ability.extra
-'''
-position = 'after'
-match_indent = true
-payload = '''
-    SMODS.scale_card(self, {
-        ref_table = self.ability,
-        ref_value = "mult",
-        scalar_value = "extra",
-    })
+SMODS.scale_card(self, {
+    ref_table = self.ability,
+    ref_value = "mult",
+    scalar_value = "extra",
+})
 '''
 
 # Ramen
@@ -430,96 +233,17 @@ payload = '''
 [patches.pattern]
 target = "card.lua"
 pattern = '''
-if self.ability.name == 'Ramen' and not context.blueprint then
+self.ability.x_mult = self.ability.x_mult - self.ability.extra
 '''
 position = 'after'
 match_indent = true
 payload = '''
-    if self.ability.x_mult - self.ability.extra >= 1 then 
-        SMODS.scale_card(self, {
-            ref_table = self.ability,
-            ref_value = "x_mult",
-            scalar_value = "extra",
-            operation = "-"
-        })
-    end
-'''
-
-# Castle
-[[patches]]
-[patches.pattern]
-target = "card.lua"
-pattern = '''
-if self.ability.name == 'Castle' and
-not context.other_card.debuff and
-context.other_card:is_suit(G.GAME.current_round.castle_card.suit) and not context.blueprint then
-    self.ability.extra.chips = self.ability.extra.chips + self.ability.extra.chip_mod
-'''
-position = 'after'
-match_indent = true
-payload = '''
-    SMODS.scale_card(self, {
-        ref_table = self.ability.extra,
-        ref_value = "chips",
-        scalar_value = "chip_mod",
-    })
-'''
-
-# Campfire
-[[patches]]
-[patches.pattern]
-target = "card.lua"
-pattern = '''
-if self.ability.name == 'Campfire' and not context.blueprint then
-    self.ability.x_mult = self.ability.x_mult + self.ability.extra
-'''
-position = 'after'
-match_indent = true
-payload = '''
-    SMODS.scale_card(self, {
-        ref_table = self.ability,
-        ref_value = "x_mult",
-        scalar_value = "extra",
-    })
-'''
-
-# Wee Joker
-[[patches]]
-[patches.pattern]
-target = "card.lua"
-pattern = '''
-if self.ability.name == 'Wee Joker' and
-    context.other_card:get_id() == 2 and not context.blueprint then
-        self.ability.extra.chips = self.ability.extra.chips + self.ability.extra.chip_mod
-'''
-position = 'after'
-match_indent = true
-payload = '''
-        SMODS.scale_card(self, {
-            ref_table = self.ability.extra,
-            ref_value = "chips",
-            scalar_value = "chip_mod",
-        })
-'''
-
-# Hit The Road
-[[patches]]
-[patches.pattern]
-target = "card.lua"
-pattern = '''
-if self.ability.name == 'Hit the Road' and
-not context.other_card.debuff and
-context.other_card:get_id() == 11 and not context.blueprint then
-    self.ability.x_mult = self.ability.x_mult + self.ability.extra
-'''
-position = 'after'
-match_indent = true
-payload = '''
-    SMODS.scale_card(self, {
-        ref_table = self.ability,
-        ref_value = "x_mult",
-        scalar_value = "extra",
-    })
+SMODS.scale_card(self, {
+    ref_table = self.ability,
+    ref_value = "x_mult",
+    scalar_value = "extra",
+    operation = "-"
+})
 '''
 
 # Yorick
@@ -527,18 +251,15 @@ payload = '''
 [patches.pattern]
 target = "card.lua"
 pattern = '''
-if self.ability.name == 'Yorick' and not context.blueprint then
-    if self.ability.yorick_discards <= 1 then
-        self.ability.yorick_discards = self.ability.extra.discards
-        self.ability.x_mult = self.ability.x_mult + self.ability.extra.xmult
+self.ability.x_mult = self.ability.x_mult + self.ability.extra.xmult
 '''
 position = 'after'
 match_indent = true
 payload = '''
-        SMODS.scale_card(self, {
-            ref_table = self.ability,
-            ref_value = "x_mult",
-            scalar_table = self.ability.extra,
-            scalar_value = "xmult",
-        })
+SMODS.scale_card(self, {
+    ref_table = self.ability,
+    ref_value = "x_mult",
+    scalar_table = self.ability.extra,
+    scalar_value = "xmult",
+})
 '''

--- a/lovely/scaling.toml
+++ b/lovely/scaling.toml
@@ -8,18 +8,120 @@ priority = -10
 [patches.pattern]
 target = "card.lua"
 pattern = '''card_eval_status_text(self, 'extra', nil, nil, nil, {message = localize{type = 'variable', key = 'a_mult', vars = {self.ability.mult+2*sliced_card.sell_cost}}, colour = G.C.RED, no_juice = true})'''
-position = 'before'
+position = 'at'
 match_indent = true
 payload = '''
-SMODS.scale_card(self, {
+local msg = SMODS.scale_card(self, {
     ref_table = self.ability,
     ref_value = "mult",
     scalar_table = sliced_card,
     scalar_value = "sell_cost"
 })
+if not msg or type(msg) == "string" then
+    card_eval_status_text(self, 'extra', nil, nil, nil, {message = msg or localize{type = 'variable', key = 'a_mult', vars = {self.ability.mult+2*sliced_card.sell_cost}}, colour = G.C.RED, no_juice = true})
+end
 '''
 
-# Ride The Bus/Red Card/Flash Card/Spare Trousers
+# Red Card
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+self.ability.mult = self.ability.mult + self.ability.extra
+                G.E_MANAGER:add_event(Event({
+            func = function() 
+                card_eval_status_text(self, 'extra', nil, nil, nil, {
+                    message = localize{type = 'variable', key = 'a_mult', vars = {self.ability.extra}},
+                    colour = G.C.RED,
+                    delay = 0.45, 
+                    card = self
+                }) 
+}))
+'''
+position = 'at'
+match_indent = true
+payload = '''
+self.ability.mult = self.ability.mult + self.ability.extra
+local msg = SMODS.scale_card(self, {
+    ref_table = self.ability,
+    ref_value = "mult",
+    scalar_value = "extra"
+})
+if not msg or type(msg) == "string" then
+    G.E_MANAGER:add_event(Event({
+                func = function()
+                card_eval_status_text(self, 'extra', nil, nil, nil, {
+                message = msg or localize{type = 'variable', key = 'a_mult', vars = {self.ability.extra}},
+                colour = G.C.RED,
+                delay = 0.45,
+                card = self
+            })
+        return true
+    end}))
+end
+'''
+
+# Flash Card
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+self.ability.mult = self.ability.mult + self.ability.extra
+G.E_MANAGER:add_event(Event({
+    func = (function()
+    card_eval_status_text(self, 'extra', nil, nil, nil, {message = localize{type = 'variable', key = 'a_mult', vars = {self.ability.mult}}, colour =            G.C.MULT})
+    return true
+end)}))
+'''
+position = 'at'
+match_indent = true
+payload = '''
+self.ability.mult = self.ability.mult + self.ability.extra
+local msg = SMODS.scale_card(self, {
+    ref_table = self.ability,
+    ref_value = "mult",
+    scalar_value = "extra"
+})
+if not msg or type(msg) == "string" then
+    G.E_MANAGER:add_event(Event({
+        func = (function()
+        card_eval_status_text(self, 'extra', nil, nil, nil, {message = msg or localize{type = 'variable', key = 'a_mult', vars = {self.ability.mult}}, colour =            G.C.MULT})
+        return true
+    end)}))
+end
+'''
+
+# Spare Trousers
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+self.ability.mult = self.ability.mult + self.ability.extra
+return {
+    message = localize('k_upgrade_ex'),
+    colour = G.C.RED,
+    card = self
+}
+'''
+position = 'at'
+match_indent = true
+payload = '''
+self.ability.mult = self.ability.mult + self.ability.extra
+local msg = SMODS.scale_card(self, {
+    ref_table = self.ability,
+    ref_value = "mult",
+    scalar_value = "extra"
+})
+if not msg or type(msg) == "string" then
+    return {
+        message = msg or localize('k_upgrade_ex'),
+        colour = G.C.RED,
+        card = self
+    }
+end
+'''
+
+# Ride The Bus
 [[patches]]
 [patches.pattern]
 target = "card.lua"
@@ -42,15 +144,33 @@ SMODS.scale_card(self, {
 target = "card.lua"
 pattern = '''
 self.ability.extra_value = self.ability.extra_value + self.ability.extra
-'''
-position = 'after'
-match_indent = true
-payload = '''
 SMODS.scale_card(self, {
     ref_table = self.ability,
     ref_value = "extra_value",
     scalar_value = "extra"
 })
+self:set_cost()
+return {
+    message = localize('k_val_up'),
+    colour = G.C.MONEY
+}
+'''
+position = 'at'
+match_indent = true
+payload = '''
+self.ability.extra_value = self.ability.extra_value + self.ability.extra
+local msg = SMODS.scale_card(self, {
+    ref_table = self.ability,
+    ref_value = "extra_value",
+    scalar_value = "extra"
+})
+self:set_cost()
+if not msg or type(msg) == "string"
+    return {
+        message = msg or localize('k_val_up'),
+        colour = G.C.MONEY
+    }
+end
 '''
 
 # Runner/Square Joker/Wee Joker/Castle
@@ -59,15 +179,28 @@ SMODS.scale_card(self, {
 target = "card.lua"
 pattern = '''
 self.ability.extra.chips = self.ability.extra.chips + self.ability.extra.chip_mod
+return {
+    message = localize('k_upgrade_ex'),
+    colour = G.C.CHIPS,
+    card = self
+}
 '''
-position = 'after'
+position = 'at'
 match_indent = true
 payload = '''
-SMODS.scale_card(self, {
+self.ability.extra.chips = self.ability.extra.chips + self.ability.extra.chip_mod
+local msg = SMODS.scale_card(self, {
     ref_table = self.ability.extra,
     ref_value = "chips",
     scalar_value = "chip_mod"
 })
+if not msg or type(msg) == "string" then
+    return {
+        message = msg or localize('k_upgrade_ex'),
+        colour = G.C.CHIPS,
+        card = self
+    }
+end
 '''
 
 # Ice Cream
@@ -76,19 +209,56 @@ SMODS.scale_card(self, {
 target = "card.lua"
 pattern = '''
 self.ability.extra.chips = self.ability.extra.chips - self.ability.extra.chip_mod
+return {
+    message = localize{type='variable',key='a_chips_minus',vars={self.ability.extra.chip_mod}},
+    colour = G.C.CHIPS
+}
 '''
-position = 'after'
+position = 'at'
 match_indent = true
 payload = '''
-SMODS.scale_card(self, {
+self.ability.extra.chips = self.ability.extra.chips - self.ability.extra.chip_mod
+local msg = SMODS.scale_card(self, {
     ref_table = self.ability.extra,
     ref_value = "chips",
     scalar_value = "chip_mod",
     operation = "-"
 })
+if not msg or type(msg) == "string" then
+    return {
+        message = msg or localize{type='variable',key='a_chips_minus',vars={self.ability.extra.chip_mod}},
+        colour = G.C.CHIPS
+    }
+end
 '''
 
-# Constellation/Campfire/Madness/Hit the Road/Lucky Cat/Obelisk
+# Constellation/Campfire/Obelisk
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+self.ability.x_mult = self.ability.x_mult + self.ability.extra
+G.E_MANAGER:add_event(Event({
+    func = function() card_eval_status_text(self, 'extra', nil, nil, nil, {message = localize{type='variable',key='a_xmult',vars={self.ability.x_mult}}}); return true
+    end}))
+'''
+position = 'at'
+match_indent = true
+payload = '''
+self.ability.x_mult = self.ability.x_mult + self.ability.extra
+local msg = SMODS.scale_card(self, {
+    ref_table = self.ability,
+    ref_value = "x_mult",
+    scalar_value = "extra"
+})
+if not msg or type(msg) == "string" then
+    G.E_MANAGER:add_event(Event({
+        func = function() card_eval_status_text(self, 'extra', nil, nil, nil, {message = msg or localize{type='variable',key='a_xmult',vars={self.ability.x_mult}}}); return true
+    end}))
+end
+'''
+
+# Madness
 [[patches]]
 [patches.pattern]
 target = "card.lua"
@@ -98,11 +268,88 @@ self.ability.x_mult = self.ability.x_mult + self.ability.extra
 position = 'after'
 match_indent = true
 payload = '''
-SMODS.scale_card(self, {
+local msg = SMODS.scale_card(self, {
     ref_table = self.ability,
     ref_value = "x_mult",
     scalar_value = "extra"
 })
+'''
+
+# Madness
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+self.ability.x_mult = self.ability.x_mult + self.ability.extra
+'''
+position = 'at'
+match_indent = true
+payload = '''
+if not (context.blueprint_card or self).getting_sliced then
+    if not msg or type(msg) == "string" then
+        card_eval_status_text((context.blueprint_card or self), 'extra', nil, nil, nil, {message = msg or localize{type = 'variable', key = 'a_xmult', vars = {self.ability.x_mult}}})
+    end
+end
+'''
+
+# Hit The Road
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+self.ability.x_mult = self.ability.x_mult + self.ability.extra
+return {
+    message = localize{type='variable',key='a_xmult',vars={self.ability.x_mult}},
+        colour = G.C.RED,
+        delay = 0.45, 
+    card = self
+}
+'''
+position = 'at'
+match_indent = true
+payload = '''
+self.ability.x_mult = self.ability.x_mult + self.ability.extra
+local msg = SMODS.scale_card(self, {
+    ref_table = self.ability,
+    ref_value = "x_mult",
+    scalar_value = "extra"
+})
+if not msg or type(msg) == "string" then
+    return {
+        message = msg or localize{type='variable',key='a_xmult',vars={self.ability.x_mult}},
+            colour = G.C.RED,
+            delay = 0.45, 
+        card = self
+    }
+end
+'''
+
+# Lucky Cat
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+self.ability.x_mult = self.ability.x_mult + self.ability.extra
+return {
+    extra = {focus = self, message = localize('k_upgrade_ex'), colour = G.C.MULT},
+    card = self
+}
+'''
+position = 'at'
+match_indent = true
+payload = '''
+self.ability.x_mult = self.ability.x_mult + self.ability.extra
+local msg = SMODS.scale_card(self, {
+    ref_table = self.ability,
+    ref_value = "x_mult",
+    scalar_value = "extra"
+})
+if not msg or type(msg) == "string" then
+    return {
+        extra = {focus = self, message = msg or localize('k_upgrade_ex'), colour = G.C.MULT},
+        card = self
+    }
+end
 '''
 
 # Green Joker: Subtraction
@@ -110,18 +357,36 @@ SMODS.scale_card(self, {
 [patches.pattern]
 target = "card.lua"
 pattern = '''
+local prev_mult = self.ability.mult
 if self.ability.mult ~= prev_mult then 
+    return {
+        message = localize{type='variable',key='a_mult_minus',vars={self.ability.extra.discard_sub}},
+        colour = G.C.RED,
+        card = self
+    }
+end
 '''
-position = 'after'
+position = 'at'
 match_indent = true
 payload = '''
-    SMODS.scale_card(self, {
+local prev_mult = self.ability.mult
+self.ability.mult = math.max(0, self.ability.mult - self.ability.extra.discard_sub)
+if self.ability.mult ~= prev_mult then 
+    local msg = SMODS.scale_card(self, {
         ref_table = self.ability,
         ref_value = "mult",
         scalar_table = self.ability.extra,
         scalar_value = "discard_sub",
         operation = "-"
     })
+    if not msg or type(msg) == "string" then
+        return {
+            message = msg or localize{type='variable',key='a_mult_minus',vars={self.ability.extra.discard_sub}},
+            colour = G.C.RED,
+            card = self
+        }
+    end
+end
 '''
 
 # Green Joker: Addition
@@ -130,16 +395,27 @@ payload = '''
 target = "card.lua"
 pattern = '''
 self.ability.mult = self.ability.mult + self.ability.extra.hand_add
+return {
+    card = self,
+    message = localize{type='variable',key='a_mult',vars={self.ability.extra.hand_add}}
+}
 '''
-position = 'after'
+position = 'at'
 match_indent = true
 payload = '''
-SMODS.scale_card(self, {
+self.ability.mult = self.ability.mult + self.ability.extra.hand_add
+local msg = SMODS.scale_card(self, {
     ref_table = self.ability,
     ref_value = "mult",
     scalar_table = self.ability.extra,
     scalar_value = "hand_add",
 })
+if not msg or type(msg) == "string" then
+    return {
+        card = self,
+        message = localize{type='variable',key='a_mult',vars={self.ability.extra.hand_add}}
+    }
+end
 '''
 
 # Vampire
@@ -148,15 +424,28 @@ SMODS.scale_card(self, {
 target = "card.lua"
 pattern = '''
 self.ability.x_mult = self.ability.x_mult + self.ability.extra*#enhanced
+return {
+    message = localize{type='variable',key='a_xmult',vars={self.ability.x_mult}},
+    colour = G.C.MULT,
+    card = self
+}
 '''
-position = 'after'
+position = 'at'
 match_indent = true
 payload = '''
-SMODS.scale_card(self, {
+self.ability.x_mult = self.ability.x_mult + self.ability.extra*#enhanced
+local msg = SMODS.scale_card(self, {
     ref_table = self.ability,
     ref_value = "x_mult",
     scalar_value = "extra",
 })
+if not msg or type(msg) == "string" then
+    return {
+        message = msg or localize{type='variable',key='a_xmult',vars={self.ability.x_mult}},
+        colour = G.C.MULT,
+        card = self
+    }
+end
 '''
 
 # Hologram
@@ -165,15 +454,25 @@ SMODS.scale_card(self, {
 target = "card.lua"
 pattern = '''
 self.ability.x_mult = self.ability.x_mult + #context.cards*self.ability.extra
-'''
-position = 'after'
-match_indent = true
-payload = '''
 SMODS.scale_card(self, {
     ref_table = self.ability,
     ref_value = "x_mult",
     scalar_value = "extra",
 })
+card_eval_status_text(self, 'extra', nil, nil, nil, {message = localize{type = 'variable', key = 'a_xmult', vars = {self.ability.x_mult}}})
+'''
+position = 'at'
+match_indent = true
+payload = '''
+self.ability.x_mult = self.ability.x_mult + #context.cards*self.ability.extra
+local msg = SMODS.scale_card(self, {
+    ref_table = self.ability,
+    ref_value = "x_mult",
+    scalar_value = "extra",
+})
+if not msg or type(msg) == "string" then
+    card_eval_status_text(self, 'extra', nil, nil, nil, {message = localize{type = 'variable', key = 'a_xmult', vars = {self.ability.x_mult}}})
+end
 '''
 
 # Rocket
@@ -182,15 +481,26 @@ SMODS.scale_card(self, {
 target = "card.lua"
 pattern = '''
 self.ability.extra.dollars = self.ability.extra.dollars + self.ability.extra.increase
+return {
+    message = localize('k_upgrade_ex'),
+    colour = G.C.MONEY
+}
 '''
-position = 'after'
+position = 'at'
 match_indent = true
 payload = '''
-SMODS.scale_card(self, {
+self.ability.extra.dollars = self.ability.extra.dollars + self.ability.extra.increase
+local msg = SMODS.scale_card(self, {
     ref_table = self.ability.extra,
     ref_value = "dollars",
     scalar_value = "increase",
 })
+if not msg or type(msg) == "string" then
+    return {
+        message = msg or localize('k_upgrade_ex'),
+        colour = G.C.MONEY
+    }
+end
 '''
 
 # Turtle Bean
@@ -198,17 +508,28 @@ SMODS.scale_card(self, {
 [patches.pattern]
 target = "card.lua"
 pattern = '''
-self.ability.extra.h_size = self.ability.extra.h_size - self.ability.extra.h_mod
+G.hand:change_size(- self.ability.extra.h_mod)
+return {
+    message = localize{type='variable',key='a_handsize_minus',vars={self.ability.extra.h_mod}},
+    colour = G.C.FILTER
+}
 '''
-position = 'after'
+position = 'at'
 match_indent = true
 payload = '''
-SMODS.scale_card(self, {
+local msg = SMODS.scale_card(self, {
     ref_table = self.ability.extra,
     ref_value = "h_size",
     scalar_value = "h_mod",
     operation = "-"
 })
+G.hand:change_size(- self.ability.extra.h_mod)
+if not msg or type(msg) == "string" then
+    return {
+        message = msg or localize{type='variable',key='a_handsize_minus',vars={self.ability.extra.h_mod}},
+        colour = G.C.FILTER
+    }
+end
 '''
 
 # Popcorn
@@ -217,15 +538,26 @@ SMODS.scale_card(self, {
 target = "card.lua"
 pattern = '''
 self.ability.mult = self.ability.mult - self.ability.extra
+return {
+    message = localize{type='variable',key='a_mult_minus',vars={self.ability.extra}},
+    colour = G.C.MULT
+}
 '''
-position = 'after'
+position = 'at'
 match_indent = true
 payload = '''
-SMODS.scale_card(self, {
+self.ability.mult = self.ability.mult - self.ability.extra
+local msg = SMODS.scale_card(self, {
     ref_table = self.ability,
     ref_value = "mult",
     scalar_value = "extra",
 })
+if not msg or type(msg) == "string" then
+    return {
+        message = msg or localize{type='variable',key='a_mult_minus',vars={self.ability.extra}},
+        colour = G.C.MULT
+    }
+end
 '''
 
 # Ramen
@@ -234,16 +566,31 @@ SMODS.scale_card(self, {
 target = "card.lua"
 pattern = '''
 self.ability.x_mult = self.ability.x_mult - self.ability.extra
+return {
+    delay = 0.2,
+    card = self,
+    message = localize{type='variable',key='a_xmult_minus',vars={self.ability.extra}},
+    colour = G.C.RED
+}
 '''
-position = 'after'
+position = 'at'
 match_indent = true
 payload = '''
-SMODS.scale_card(self, {
+self.ability.x_mult = self.ability.x_mult - self.ability.extra
+local msg = SMODS.scale_card(self, {
     ref_table = self.ability,
     ref_value = "x_mult",
     scalar_value = "extra",
     operation = "-"
 })
+if not msg or type(msg) == "string" then
+    return {
+        delay = 0.2,
+        card = self,
+        message = msg or localize{type='variable',key='a_xmult_minus',vars={self.ability.extra}},
+        colour = G.C.RED
+    }
+end
 '''
 
 # Yorick
@@ -252,14 +599,29 @@ SMODS.scale_card(self, {
 target = "card.lua"
 pattern = '''
 self.ability.x_mult = self.ability.x_mult + self.ability.extra.xmult
+return {
+    card = self,
+    delay = 0.2,
+    message = localize{type='variable',key='a_xmult',vars={self.ability.x_mult}},
+    colour = G.C.RED
+}
 '''
-position = 'after'
+position = 'at'
 match_indent = true
 payload = '''
-SMODS.scale_card(self, {
+self.ability.x_mult = self.ability.x_mult + self.ability.extra.xmult
+local msg = SMODS.scale_card(self, {
     ref_table = self.ability,
     ref_value = "x_mult",
     scalar_table = self.ability.extra,
     scalar_value = "xmult",
 })
+if not msg or type(msg) == "string" then
+    return {
+        card = self,
+        delay = 0.2,
+        message = localize{type='variable',key='a_xmult',vars={self.ability.x_mult}},
+        colour = G.C.RED
+    }
+end
 '''

--- a/lovely/scaling.toml
+++ b/lovely/scaling.toml
@@ -8,7 +8,7 @@ priority = -10
 [patches.pattern]
 target = "card.lua"
 pattern = '''card_eval_status_text(self, 'extra', nil, nil, nil, {message = localize{type = 'variable', key = 'a_mult', vars = {self.ability.mult+2*sliced_card.sell_cost}}, colour = G.C.RED, no_juice = true})'''
-position = 'after'
+position = 'before'
 match_indent = true
 payload = '''
 SMODS.scale_card(self, {
@@ -292,7 +292,7 @@ payload = '''
 target = "card.lua"
 pattern = '''
 if reset then
-    if to_big(self.ability.x_mult) > to_big(1) then
+    if self.ability.x_mult > 1 then
         self.ability.x_mult = 1
         return {
             card = self,

--- a/lovely/scaling.toml
+++ b/lovely/scaling.toml
@@ -1,0 +1,544 @@
+[manifest]
+version = "1.0.0"
+dump_lua = true
+priority = -10
+
+# Ceremonial Dagger
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''card_eval_status_text(self, 'extra', nil, nil, nil, {message = localize{type = 'variable', key = 'a_mult', vars = {self.ability.mult+2*sliced_card.sell_cost}}, colour = G.C.RED, no_juice = true})'''
+position = 'after'
+match_indent = true
+payload = '''
+SMODS.scale_card(self, {
+    ref_table = self.ability,
+    ref_value = "mult",
+    scalar_table = sliced_card,
+    scalar_value = "sell_cost"
+})
+'''
+
+# Ride The Bus
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+if self.ability.name == 'Ride the Bus' and not context.blueprint then
+    local faces = false
+    for i = 1, #context.scoring_hand do
+        if context.scoring_hand[i]:is_face() then faces = true end
+    end
+'''
+position = 'after'
+match_indent = true
+payload = '''
+    if not faces then 
+        SMODS.scale_card(self, {
+            ref_table = self.ability,
+            ref_value = "mult",
+            scalar_value = "extra"
+        })
+    end
+'''
+
+# Egg
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+self.ability.extra_value = self.ability.extra_value + self.ability.extra
+self:set_cost()
+'''
+position = 'after'
+match_indent = true
+payload = '''
+SMODS.scale_card(self, {
+    ref_table = self.ability,
+    ref_value = "extra_value",
+    scalar_value = "extra"
+})
+'''
+
+# Runner
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+if self.ability.name == 'Runner' and next(context.poker_hands['Straight']) and not context.blueprint then
+    self.ability.extra.chips = self.ability.extra.chips + self.ability.extra.chip_mod
+'''
+position = 'after'
+match_indent = true
+payload = '''
+    SMODS.scale_card(self, {
+        ref_table = self.ability.extra,
+        ref_value = "chips",
+        scalar_value = "chip_mod"
+    })
+'''
+
+# Ice Cream
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+if self.ability.name == 'Ice Cream' and not context.blueprint then
+    if self.ability.extra.chips - self.ability.extra.chip_mod <= 0 then 
+        G.E_MANAGER:add_event(Event({
+            func = function()
+                play_sound('tarot1')
+                self.T.r = -0.2
+                self:juice_up(0.3, 0.4)
+                self.states.drag.is = true
+                self.children.center.pinch.x = true
+                G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.3, blockable = false,
+                    func = function()
+                            G.jokers:remove_card(self)
+                            self:remove()
+                            self = nil
+                        return true; end})) 
+                return true
+            end
+        })) 
+        return {
+            message = localize('k_melted_ex'),
+            colour = G.C.CHIPS
+        }
+    else
+        self.ability.extra.chips = self.ability.extra.chips - self.ability.extra.chip_mod
+'''
+position = 'after'
+match_indent = true
+payload = '''
+        SMODS.scale_card(self, {
+            ref_table = self.ability.extra,
+            ref_value = "chips",
+            scalar_value = "chip_mod",
+            operation = "-"
+        })
+'''
+
+# Constellation
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+if self.ability.name == 'Constellation' and not context.blueprint and context.consumeable.ability.set == 'Planet' then
+    self.ability.x_mult = self.ability.x_mult + self.ability.extra
+'''
+position = 'after'
+match_indent = true
+payload = '''
+    SMODS.scale_card(self, {
+        ref_table = self.ability,
+        ref_value = "x_mult",
+        scalar_value = "extra"
+    })
+'''
+
+# Green Joker: Subtraction
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+if self.ability.name == 'Green Joker' and not context.blueprint and context.other_card == context.full_hand[#context.full_hand] then
+    local prev_mult = self.ability.mult
+    self.ability.mult = math.max(0, self.ability.mult - self.ability.extra.discard_sub)
+'''
+position = 'after'
+match_indent = true
+payload = '''
+    SMODS.scale_card(self, {
+        ref_table = self.ability,
+        ref_value = "mult",
+        scalar_table = "extra",
+        scalar_value = "discard_sub",
+        operation = "-"
+    })
+'''
+
+# Green Joker: Addition
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+if self.ability.name == 'Green Joker' and not context.blueprint then
+    self.ability.mult = self.ability.mult + self.ability.extra.hand_add
+'''
+position = 'after'
+match_indent = true
+payload = '''
+    SMODS.scale_card(self, {
+        ref_table = self.ability,
+        ref_value = "mult",
+        scalar_table = "extra",
+        scalar_value = "hand_add",
+    })
+'''
+
+# Red Card
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+if self.ability.name == 'Red Card' and not context.blueprint then
+    self.ability.mult = self.ability.mult + self.ability.extra
+'''
+position = 'after'
+match_indent = true
+payload = '''
+    SMODS.scale_card(self, {
+        ref_table = self.ability,
+        ref_value = "mult",
+        scalar_value = "extra",
+    })
+'''
+
+# Madness
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+if self.ability.name == 'Madness' and not context.blueprint and not context.blind.boss then
+    self.ability.x_mult = self.ability.x_mult + self.ability.extra
+'''
+position = 'after'
+match_indent = true
+payload = '''
+    SMODS.scale_card(self, {
+        ref_table = self.ability,
+        ref_value = "x_mult",
+        scalar_value = "extra",
+    })
+'''
+
+# Square Joker
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+if self.ability.name == 'Square Joker' and #context.full_hand == 4 and not context.blueprint then
+    self.ability.extra.chips = self.ability.extra.chips + self.ability.extra.chip_mod
+'''
+position = 'after'
+match_indent = true
+payload = '''
+    SMODS.scale_card(self, {
+        ref_table = self.ability.extra,
+        ref_value = "chips",
+        scalar_value = "chip_mod",
+    })
+'''
+
+# Vampire
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+if #enhanced > 0 then 
+    self.ability.x_mult = self.ability.x_mult + self.ability.extra*#enhanced
+'''
+position = 'after'
+match_indent = true
+payload = '''
+    SMODS.scale_card(self, {
+        ref_table = self.ability,
+        ref_value = "x_mult",
+        scalar_value = "extra",
+    })
+'''
+
+# Hologram
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+if self.ability.name == 'Hologram' and (not context.blueprint)
+and context.cards and context.cards[1] then
+    self.ability.x_mult = self.ability.x_mult + #context.cards*self.ability.extra
+'''
+position = 'after'
+match_indent = true
+payload = '''
+    SMODS.scale_card(self, {
+        ref_table = self.ability,
+        ref_value = "x_mult",
+        scalar_value = "extra",
+    })
+'''
+
+# Rocket
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+if self.ability.name == 'Rocket' and G.GAME.blind.boss then
+    self.ability.extra.dollars = self.ability.extra.dollars + self.ability.extra.increase
+'''
+position = 'after'
+match_indent = true
+payload = '''
+    SMODS.scale_card(self, {
+        ref_table = self.ability.extra,
+        ref_value = "dollars",
+        scalar_value = "increase",
+    })
+'''
+
+# Obelisk
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+if reset then
+    if to_big(self.ability.x_mult) > to_big(1) then
+        self.ability.x_mult = 1
+        return {
+            card = self,
+            message = localize('k_reset')
+        }
+    end
+else
+    self.ability.x_mult = self.ability.x_mult + self.ability.extra
+'''
+position = 'after'
+match_indent = true
+payload = '''
+    SMODS.scale_card(self, {
+        ref_table = self.ability,
+        ref_value = "x_mult",
+        scalar_value = "extra",
+    })
+'''
+
+# Turtle Bean
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+self.ability.extra.h_size = self.ability.extra.h_size - self.ability.extra.h_mod
+G.hand:change_size(- self.ability.extra.h_mod)
+'''
+position = 'after'
+match_indent = true
+payload = '''
+SMODS.scale_card(self, {
+    ref_table = self.ability.extra,
+    ref_value = "h_size",
+    scalar_value = "h_mod",
+    operation = "-"
+})
+'''
+
+# Lucky Cat
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+if self.ability.name == 'Lucky Cat' and context.other_card.lucky_trigger and not context.blueprint then
+    self.ability.x_mult = self.ability.x_mult + self.ability.extra
+'''
+position = 'after'
+match_indent = true
+payload = '''
+    SMODS.scale_card(self, {
+        ref_table = self.ability,
+        ref_value = "x_mult",
+        scalar_value = "extra",
+    })
+'''
+
+# Flash Card
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+if self.ability.name == 'Flash Card' and not context.blueprint then
+    self.ability.mult = self.ability.mult + self.ability.extra
+'''
+position = 'after'
+match_indent = true
+payload = '''
+    SMODS.scale_card(self, {
+        ref_table = self.ability,
+        ref_value = "mult",
+        scalar_value = "extra",
+    })
+'''
+
+# Popcorn
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+if self.ability.name == 'Popcorn' and not context.blueprint then
+    if self.ability.mult - self.ability.extra <= 0 then 
+        G.E_MANAGER:add_event(Event({
+            func = function()
+                play_sound('tarot1')
+                self.T.r = -0.2
+                self:juice_up(0.3, 0.4)
+                self.states.drag.is = true
+                self.children.center.pinch.x = true
+                G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.3, blockable = false,
+                    func = function()
+                            G.jokers:remove_card(self)
+                            self:remove()
+                            self = nil
+                        return true; end})) 
+                return true
+            end
+        })) 
+        return {
+            message = localize('k_eaten_ex'),
+            colour = G.C.RED
+        }
+    else
+        self.ability.mult = self.ability.mult - self.ability.extra
+'''
+position = 'after'
+match_indent = true
+payload = '''
+        SMODS.scale_card(self, {
+            ref_table = self.ability,
+            ref_value = "mult",
+            scalar_value = "extra",
+        })
+'''
+
+# Spare Trousers
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+if self.ability.name == 'Spare Trousers' and (next(context.poker_hands['Two Pair']) or next(context.poker_hands['Full House'])) and not context.blueprint then
+    self.ability.mult = self.ability.mult + self.ability.extra
+'''
+position = 'after'
+match_indent = true
+payload = '''
+    SMODS.scale_card(self, {
+        ref_table = self.ability,
+        ref_value = "mult",
+        scalar_value = "extra",
+    })
+'''
+
+# Ramen
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+if self.ability.name == 'Ramen' and not context.blueprint then
+'''
+position = 'after'
+match_indent = true
+payload = '''
+    if self.ability.x_mult - self.ability.extra >= 1 then 
+        SMODS.scale_card(self, {
+            ref_table = self.ability,
+            ref_value = "x_mult",
+            scalar_value = "extra",
+            operation = "-"
+        })
+    end
+'''
+
+# Castle
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+if self.ability.name == 'Castle' and
+not context.other_card.debuff and
+context.other_card:is_suit(G.GAME.current_round.castle_card.suit) and not context.blueprint then
+    self.ability.extra.chips = self.ability.extra.chips + self.ability.extra.chip_mod
+'''
+position = 'after'
+match_indent = true
+payload = '''
+    SMODS.scale_card(self, {
+        ref_table = self.ability.extra,
+        ref_value = "chips",
+        scalar_value = "chip_mod",
+    })
+'''
+
+# Campfire
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+if self.ability.name == 'Campfire' and not context.blueprint then
+    self.ability.x_mult = self.ability.x_mult + self.ability.extra
+'''
+position = 'after'
+match_indent = true
+payload = '''
+    SMODS.scale_card(self, {
+        ref_table = self.ability,
+        ref_value = "x_mult",
+        scalar_value = "extra",
+    })
+'''
+
+# Wee Joker
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+if self.ability.name == 'Wee Joker' and
+    context.other_card:get_id() == 2 and not context.blueprint then
+        self.ability.extra.chips = self.ability.extra.chips + self.ability.extra.chip_mod
+'''
+position = 'after'
+match_indent = true
+payload = '''
+        SMODS.scale_card(self, {
+            ref_table = self.ability.extra,
+            ref_value = "chips",
+            scalar_value = "chip_mod",
+        })
+'''
+
+# Hit The Road
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+if self.ability.name == 'Hit the Road' and
+not context.other_card.debuff and
+context.other_card:get_id() == 11 and not context.blueprint then
+    self.ability.x_mult = self.ability.x_mult + self.ability.extra
+'''
+position = 'after'
+match_indent = true
+payload = '''
+    SMODS.scale_card(self, {
+        ref_table = self.ability,
+        ref_value = "x_mult",
+        scalar_value = "extra",
+    })
+'''
+
+# Yorick
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+if self.ability.name == 'Yorick' and not context.blueprint then
+    if self.ability.yorick_discards <= 1 then
+        self.ability.yorick_discards = self.ability.extra.discards
+        self.ability.x_mult = self.ability.x_mult + self.ability.extra.xmult
+'''
+position = 'after'
+match_indent = true
+payload = '''
+        SMODS.scale_card(self, {
+            ref_table = self.ability,
+            ref_value = "x_mult",
+            scalar_table = self.ability.extra,
+            scalar_value = "xmult",
+        })
+'''

--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -660,6 +660,5 @@ function SMODS.is_eternal(card, trigger) end
 ---@return table? results
 --- Tells Jokers that this card is scaling allowing for scaling detection
 --- Can return scaling_value and scalar_value in results to change the scaling cards values
---- Args must contain ref_table, ref_value, and scalar_value and may optionally contain scalar_table used in place of ref_table for the scalar_value
---- and operation to designate the scaling operation, which defaults to "+"
+--- Args must contain `ref_table`, `ref_value`, and `scalar_value`. It may optionally contain `scalar_table`, used in place of `ref_table` for the `scalar_value`, and `operation` to designate the scaling operation, which defaults to `"+"`
 function SMODS.scale_card(card, args) end

--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -654,3 +654,12 @@ function SMODS.is_poker_hand_visible(handname) end
 --- Checks whether the card is eternal.
 --- `trigger` is the card or effect that runs the check
 function SMODS.is_eternal(card, trigger) end
+
+---@param card Card|table
+---@param args? table
+---@return table? results
+--- Tells Jokers that this card is scaling allowing for scaling detection
+--- Can return scaling_value and scalar_value in results to change the scaling cards values
+--- Args must contain ref_table, ref_value, and scalar_value and may optionally contain scalar_table used in place of ref_table for the scalar_value
+--- and operation to designate the scaling operation, which defaults to "+"
+function SMODS.scale_card(card, args) end

--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -664,7 +664,7 @@ function SMODS.is_eternal(card, trigger) end
 
 ---@param card Card|table
 ---@param args? table
----@return table? results
+---@return message? string
 --- Tells Jokers that this card is scaling allowing for scaling detection
 --- Can return scaling_value and scalar_value in results to change the scaling cards values
 --- Args must contain `ref_table`, `ref_value`, and `scalar_value`. It may optionally contain `scalar_table`, used in place of `ref_table` for the `scalar_value`, and `operation` to designate the scaling operation, which defaults to `"+"`

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2663,6 +2663,7 @@ end
 
 function SMODS.scale_card(card, args)
     if not G.deck then return end
+    local scaling_message
     if not args.operation then args.operation = "+" end
     for _, area in ipairs(SMODS.get_card_areas('jokers')) do
         for _, _card in ipairs(area.cards) do
@@ -2673,10 +2674,12 @@ function SMODS.scale_card(card, args)
                     if ret.scaling_value then args.ref_table[args.ref_value] = ret.scaling_value end
                     if ret.scalar_value then (args.scalar_table or args.ref_table)[args.scalar_value] = ret.scalar_value end
                     SMODS.calculate_effect(ret, _card)
+                    if ret.scaling_message then scaling_message = ret.scaling_message end
                 end
             end
         end
     end
+    return scaling_message
 end
 
 local calculate_jokerref = Card.calculate_joker

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2658,14 +2658,13 @@ function SMODS.scale_card(card, args)
     if not args.operation then args.operation = "+" end
     for _, area in ipairs(SMODS.get_card_areas('jokers')) do
         for _, _card in ipairs(area.cards) do
-            if _card.config and _card.config.center and _card.config.center.calc_scaling and type(_card.config.center.calc_scaling) == "function" then
-                local ret = _card.config.center:calc_scaling(_card, card, args.ref_table[args.ref_value], (args.scalar_table or args.ref_table)[args.scalar_value], args)
+            local obj = _card.config.center
+            if obj.calc_scaling and type(obj.calc_scaling) == "function" then
+                local ret = obj:calc_scaling(_card, card, args.ref_table[args.ref_value], (args.scalar_table or args.ref_table)[args.scalar_value], args)
                 if ret then
                     if ret.scaling_value then args.ref_table[args.ref_value] = ret.scaling_value end
                     if ret.scalar_value then (args.scalar_table or args.ref_table)[args.scalar_value] = ret.scalar_value end
-                    for i2, v2 in pairs(ret) do
-                        SMODS.calculate_individual_effect(ret, _card, i2, result, false)
-                    end
+                    SMODS.calculate_effect(ret, _card)
                 end
             end
         end

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2652,3 +2652,61 @@ function Tag:apply_to_run(_context)
     end
     return res
 end
+
+function SMODS.scale_card(card, args)
+    if not G.deck then return end
+    if not args.operation then args.operation = "+" end
+    for _, area in ipairs(SMODS.get_card_areas('jokers')) do
+        for _, _card in ipairs(area.cards) do
+            if _card.config and _card.config.center and _card.config.center.calc_scaling and type(_card.config.center.calc_scaling) == "function" then
+                local ret = _card.config.center:calc_scaling(_card, card, args.ref_table[args.ref_value], (args.scalar_table or args.ref_table)[args.scalar_value], args)
+                if ret then
+                    if ret.scaling_value then args.ref_table[args.ref_value] = ret.scaling_value end
+                    if ret.scalar_value then (args.scalar_table or args.ref_table)[args.scalar_value] = ret.scalar_value end
+                    for i2, v2 in pairs(ret) do
+                        SMODS.calculate_individual_effect(ret, _card, i2, result, false)
+                    end
+                end
+            end
+        end
+    end
+end
+
+local calculate_jokerref = Card.calculate_joker
+function Card:calculate_joker(context, ...)
+    local ret, ret2 = calculate_jokerref(self, context, ...)
+    if self.ability.name == "Caino" or self.ability.name == "Glass Joker" then
+        if context.remove_playing_cards then
+            if self.ability.name == "Caino" then
+                local faces = 0
+                for k, v in ipairs(context.removed) do
+                    if v:is_face() then
+                        faces = faces + 1
+                    end
+                end
+                if faces > 0 then
+                    SMODS.scale_card(self, {
+                        ref_table = self.ability,
+                        ref_value = "caino_xmult",
+                        scalar_value = "extra",
+                    })
+                end
+            else
+                local glasses = 0
+                for k, v in ipairs(context.removed) do
+                    if v.shattered then
+                        glasses = glasses + 1
+                    end
+                end
+                if glasses > 0 then
+                    SMODS.scale_card(self, {
+                        ref_table = self.ability,
+                        ref_value = "x_mult",
+                        scalar_value = "extra",
+                    })
+                end
+            end
+        end
+    end
+    return ret, ret2
+end


### PR DESCRIPTION
Scale card now returns an optional message that is defined by returning a scaling_message in calc_scaling if the returned message is a non-string the original message will be prevented entirely

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [X] I didn't modify api's or I've updated lsp definitions.
- [X] I didn't make new lovely files or all new lovely files have appropriate priority.
