### PR TITLE
Removed unnecessary (?) / faulty `delay()` call in `ease_dollars()`

### DIFF
--- a/lovely/better_calc.toml
+++ b/lovely/better_calc.toml
@@ -1872,7 +1872,6 @@ else
 end
 '''
 payload = '''
-if not instant then delay(0.4) end
 SMODS.calculate_context({
     money_altered = true,
     amount = mod,


### PR DESCRIPTION
-Title

This fixes #866, though I don't know why the `delay()` call was there...
Hope it ain't crucially important! :)

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
