### PR TITLE
Fixed Card:set_base regression with manual sprites

### DIFF
--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -2312,7 +2312,7 @@ function Blind:modify_hand(cards, poker_hands, text, mult, hand_chips, scoring_h
 end
 
 local card_set_base = Card.set_base
-function Card:set_base(card, initial)
+function Card:set_base(card, initial, manual_sprites)
     if self.playing_card and self.base then
         local new_rank = card and card.value and SMODS.Ranks[card.value] and SMODS.Ranks[card.value].id
         local contexts = {}
@@ -2329,7 +2329,7 @@ function Card:set_base(card, initial)
         end
     end
 
-    card_set_base(self, card, initial)
+    card_set_base(self, card, initial, manual_sprites)
 end
 
 local use_consumeable = Card.use_consumeable


### PR DESCRIPTION
- Added `manual_sprites` argument to a recent `Card:set_base()`, which prevented delaying sprites until manually assigned working correctly.


## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
