### PR TITLE
Revert `ease_dollars` position

### DIFF
--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -2242,7 +2242,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
             func = function()
                 for i = #destroyed_cards, 1, -1 do
                     local card = destroyed_cards[i]
-                    if card.ability.name == 'Glass Card' then
+                    if SMODS.shatters(card) then
                         card:shatter()
                     else
                         card:start_dissolve(nil, i ~= #destroyed_cards)

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -1273,6 +1273,7 @@ SMODS.calculate_individual_effect = function(effect, scored_card, key, amount, f
 
     if (key == 'p_dollars' or key == 'dollars' or key == 'h_dollars') and amount then
         if effect.card and effect.card ~= scored_card then juice_card(effect.card) end
+        ease_dollars(amount)
         if not effect.remove_default_message then
             if effect.dollar_message then
                 card_eval_status_text(effect.message_card or effect.juice_card or scored_card or effect.card or effect.focus, 'extra', nil, percent, nil, effect.dollar_message)
@@ -1280,7 +1281,6 @@ SMODS.calculate_individual_effect = function(effect, scored_card, key, amount, f
                 card_eval_status_text(effect.message_card or effect.juice_card or scored_card or effect.card or effect.focus, 'dollars', amount, percent)
             end
         end
-        ease_dollars(amount)
         return true
     end
 


### PR DESCRIPTION
Previously `context.money_altered` was added as janky patches. It's changed to a hook now, but this part remains, causing `ease_dollars` actions to be delayed considerably.
## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
