### PR TITLE
Add deck loading when reloading a run

### DIFF
--- a/lovely/back.toml
+++ b/lovely/back.toml
@@ -191,3 +191,17 @@ if self.effect.config.jokers then
         }))
     end
 '''
+
+# Load deck when continuing the run
+# Game.start_run
+[[patches]]
+[patches.pattern]
+target = 'game.lua'
+pattern = "self.GAME.selected_back = Back(selected_back)"
+position = 'after'
+match_indent = true
+payload = '''
+if saveTable then
+    self.GAME.selected_back:load(saveTable.BACK)
+end
+'''


### PR DESCRIPTION
Added a missing `Back.load` call when the game starts. This allows saving values to `back.effect` similar to `card.ability`.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
