### PR TITLE
Added `SMODS.context_stack`

### DIFF
--- a/src/utils.lua
+++ b/src/utils.lua
@@ -1846,10 +1846,17 @@ function SMODS.calculate_card_areas(_type, context, return_table, args)
     return flags
 end
 
+-- The context stack list, allows some advanced effects, like:
+-- Individual playing cards modifying probabilities checked during individual scoring, only when they're the context.other_card 
+-- (-> By checking the context in the stack PRIOR to the mod_probability context for the .individual / .other_card flags)
+SMODS.context_stack = {}
+
 -- Used to calculate contexts across G.jokers, scoring_hand (if present), G.play and G.GAME.selected_back
 -- Hook this function to add different areas to MOST calculations
 function SMODS.calculate_context(context, return_table, no_resolve)
     if G.STAGE ~= G.STAGES.RUN then return end
+
+    SMODS.context_stack[#SMODS.context_stack+1] = context
 
     local has_area = context.cardarea and true or nil
     if no_resolve then SMODS.no_resolve = true end
@@ -1864,6 +1871,8 @@ function SMODS.calculate_context(context, return_table, no_resolve)
     context.main_eval = nil
     
     if SMODS.no_resolve then SMODS.no_resolve = nil end
+    
+    table.remove(SMODS.context_stack, #SMODS.context_stack)
     
     if not return_table then
         local ret = {}


### PR DESCRIPTION
+Title

This replaces #821 's rejected `source_context` parameter of `SMODS.get_probability_vars()` and related.

What the `source_context` parameter allowed, which I believe was not possible without it, is to modify the probability of Joker effects on a card during individual scoring, by one of that card's enhancements.
Like, a Seal that guarantees Bloodstone/Business card/etc. hitting, but only for the card it is applied to.

A context stack allows for the same behaviour, without passing a context as a parameter.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
