### PR TITLE
New ante-related contexts

### DIFF
--- a/lovely/better_calc.toml
+++ b/lovely/better_calc.toml
@@ -1864,3 +1864,16 @@ if self.ability.name == 'Campfire' and not context.blueprint then
 payload = '''
 if self.ability.name == 'Campfire' and not context.blueprint and self ~= context.card then
 '''
+
+# Adds ante_end context
+[[patches]]
+[patches.pattern]
+target = 'functions/state_events.lua'
+match_indent = true
+pattern = '''
+delay(0.4); ease_ante(1); delay(0.4); check_for_unlock({type = 'ante_up', ante = G.GAME.round_resets.ante + 1})
+'''
+position = '''after'''
+payload = '''
+SMODS.calculate_context({ante_end = true})
+'''

--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -2345,3 +2345,11 @@ function Card:use_consumeable(area, copier)
     end
 	return ret
 end
+
+local ease_ante_ref = ease_ante
+function ease_ante(mod)
+	local flags = SMODS.calculate_context({modify_ante = true})
+	local new_mod = mod + flags.mod
+	ease_ante_ref(new_mod)
+	SMODS.calculate_context({ante_change = new_mod})
+end


### PR DESCRIPTION
Adds three new contexts related to antes:
- `context.ante_end`: Runs after the player naturally finishes an ante
- `context.modify_ante`: Runs whenever the ante is about to change. Returning a number in the `mod` flag will add that value onto the ante modifier
- `context.ante_change`: Runs after an ante changes. The `context.ante_change` value is equal to the ante modifier

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
