### PR TITLE
Fixing Negative slots

### DIFF
--- a/lovely/negative_limits.toml
+++ b/lovely/negative_limits.toml
@@ -1,0 +1,40 @@
+# manifest
+[manifest]
+version = "0.1.0"
+dump_lua = true
+priority = 0
+
+[[patches]]
+[patches.pattern]
+target = 'card.lua'
+position = 'at'
+pattern = '''
+else
+if self.edition and self.edition.card_limit then
+                    if self.ability.consumeable then
+                        G.consumeables.config.card_limit = G.consumeables.config.card_limit + self.edition.card_limit
+                    else
+                        G.jokers.config.card_limit = G.jokers.config.card_limit + self.edition.card_limit
+                    end
+                end
+'''
+payload = '''
+'''
+match_indent = true
+[[patches]]
+[patches.pattern]
+target = 'card.lua'
+position = 'at'
+pattern = '''
+else
+                if self.edition and self.edition.card_limit then
+                    if self.ability.consumeable then
+                        G.consumeables.config.card_limit = G.consumeables.config.card_limit - self.edition.card_limit
+                    elseif self.ability.set == 'Joker' then
+                        G.jokers.config.card_limit = G.jokers.config.card_limit - self.edition.card_limit
+                    end
+                end
+'''
+payload = '''
+'''
+match_indent = true

--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -2364,10 +2364,6 @@ end
 
 local emplace_ref = CardArea.emplace
 function CardArea:emplace(card, location, stay_flipped)
-    if self == G.consumeables and card.ability.set == 'domain' then
-        G.domain:emplace(card, location, stay_flipped)
-        return
-    end
     if card and card.edition and card.edition.card_limit then
         self.config.card_limit = self.config.card_limit + card.edition.card_limit
     end

--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -2353,3 +2353,23 @@ function ease_ante(mod, ante_end)
 	ease_ante_ref(mod)
 	SMODS.calculate_context({ante_change = mod, ante_end = ante_end})
 end
+
+local carc = CardArea.remove_card
+function CardArea:remove_card(card, discarded_only)
+    if card and card.edition and card.edition.card_limit then
+        self.config.card_limit = self.config.card_limit - card.edition.card_limit
+    end
+    return carc(self, card, discarded_only)
+end
+
+local emplace_ref = CardArea.emplace
+function CardArea:emplace(card, location, stay_flipped)
+    if self == G.consumeables and card.ability.set == 'domain' then
+        G.domain:emplace(card, location, stay_flipped)
+        return
+    end
+    if card and card.edition and card.edition.card_limit then
+        self.config.card_limit = self.config.card_limit + card.edition.card_limit
+    end
+    return emplace_ref(self, card, location, stay_flipped)
+end


### PR DESCRIPTION

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.

with the patches and hooks, cards with `.edition.card_limit` will now affect whatever card area theyre currently in (modified emplace func)
