### PR TITLE
setting_ability Context

### DIFF
--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -2353,3 +2353,12 @@ function ease_ante(mod, ante_end)
 	ease_ante_ref(mod)
 	SMODS.calculate_context({ante_change = mod, ante_end = ante_end})
 end
+
+local set_ability = Card.set_ability
+function Card:set_ability(center, initial, delay_sprites)
+	local old_center = self.config.center
+	set_ability(self, center, initial, delay_sprites)
+	if G.STATE ~= G.STATES.SMODS_BOOSTER_OPENED and G.STATE ~= G.STATES.SHOP and not G.SETTINGS.paused or G.TAROT_INTERRUPT then
+		SMODS.calculate_context({setting_ability = true, card = self, unchanged = old_center.key == self.config.center.key})
+	end
+end

--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -2359,6 +2359,6 @@ function Card:set_ability(center, initial, delay_sprites)
 	local old_center = self.config.center
 	set_ability(self, center, initial, delay_sprites)
 	if G.STATE ~= G.STATES.SMODS_BOOSTER_OPENED and G.STATE ~= G.STATES.SHOP and not G.SETTINGS.paused or G.TAROT_INTERRUPT then
-		SMODS.calculate_context({setting_ability = true, card = self, unchanged = old_center.key == self.config.center.key})
+		SMODS.calculate_context({setting_ability = true, old = old_center.key, new = self.config.center_key, other_card = self, unchanged = old_center.key == self.config.center.key})
 	end
 end


### PR DESCRIPTION
Title, add a context that runs when setting an ability. Flags include the `card` that was affected, the `old_center` of the card, and an `unchanged` boolean that is true if the card's old_center is identical to the "new" one

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
