### PR TITLE
Expanded select_card arg

### DIFF
--- a/lovely/booster.toml
+++ b/lovely/booster.toml
@@ -260,7 +260,7 @@ if card.ability.consumeable then
     if (card.area == G.pack_cards and G.pack_cards) then
 '''
 payload = '''
-if card.ability.consumeable and card.area == G.pack_cards and booster_obj and booster_obj.select_card and card:selectable_from_pack(booster_obj) then
+if card.ability.consumeable and card.area == G.pack_cards and booster_obj and (booster_obj.select_card or card.config.center.select_card or SMODS.ConsumableTypes[card.ability.set].select_card) and card:selectable_from_pack(booster_obj) then
     if (card.area == G.pack_cards and G.pack_cards) then
         return {n=G.UIT.ROOT, config = {padding = 0, colour = G.C.CLEAR}, nodes={
                 {n=G.UIT.R, config={ref_table = card, r = 0.08, padding = 0.1, align = "bm", minw = 0.5*card.T.w - 0.15, maxw = 0.9*card.T.w - 0.15, minh = 0.3*card.T.h, hover = true, shadow = true, colour = G.C.UI.BACKGROUND_INACTIVE, one_press = true, button = 'use_card', func = 'can_select_from_booster'}, nodes={

--- a/lovely/center.toml
+++ b/lovely/center.toml
@@ -492,7 +492,7 @@ match_indent = true
 position = 'at'
 payload = '''
 local nc
-local select_to = card.area == G.pack_cards and booster_obj and booster_obj.select_card and card:selectable_from_pack(booster_obj)
+local select_to = card.area == G.pack_cards and booster_obj and (booster_obj.select_card or card.config.center.select_card or SMODS.ConsumableTypes[card.ability.set].select_card) and card:selectable_from_pack(booster_obj)
 if card.ability.consumeable and not select_to then
     local obj = card.config.center
     if obj.keep_on_use and type(obj.keep_on_use) == 'function' then

--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -630,7 +630,7 @@ function SMODS.merge_effects(...) end
 ---@param from_roll? boolean
 ---@return number numerator
 ---@return number denominator
----@param no_mod boolean|nil
+---@param no_mod boolean|nil optional boolean to bypass other probability modifying effects
 --- Returns a *`numerator` in `denominator`* listed probability opportunely modified by in-game effects
 --- starting from a *`base_numerator` in `base_denominator`* probability. 
 --- 
@@ -642,7 +642,7 @@ function SMODS.get_probability_vars(trigger_obj, base_numerator, base_denominato
 ---@param base_numerator number
 ---@param base_denominator number
 ---@param identifier? string
----@param no_mod boolean|nil
+---@param no_mod boolean|nil optional boolean to bypass other probability modifying effects
 ---@return boolean
 --- Sets the seed to `seed` and runs a *`base_numerator` in `base_denominator`* listed probability check. 
 --- Returns `true` if the probability succeeds. You do not need to multiply `base_numerator` by `G.GAME.probabilities.normal`. 

--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -598,23 +598,25 @@ function SMODS.merge_effects(...) end
 ---@param from_roll boolean|nil
 ---@return number numerator
 ---@return number denominator
+---@param no_mod boolean|nil
 --- Returns a *`numerator` in `denominator`* listed probability opportunely modified by in-game effects
 --- starting from a *`base_numerator` in `base_denominator`* probability. 
 --- 
 --- Can be hooked for more complex probability behaviour. `trigger_obj` is optionally the object that queues the probability.
-function SMODS.get_probability_vars(trigger_obj, base_numerator, base_denominator, key, from_roll) end
+function SMODS.get_probability_vars(trigger_obj, base_numerator, base_denominator, key, from_roll, no_mod) end
 
 ---@param trigger_obj Card|table
 ---@param seed string|number
 ---@param base_numerator number
 ---@param base_denominator number
 ---@param key string
+---@param no_mod boolean|nil
 ---@return boolean
 --- Sets the seed to `seed` and runs a *`base_numerator` in `base_denominator`* listed probability check. 
 --- Returns `true` if the probability succeeds. You do not need to multiply `base_numerator` by `G.GAME.probabilities.normal`. 
 --- 
 --- Can be hooked to run code when a listed probability succeeds and/or fails. `trigger_obj` is optionally the object that queues the probability.
-function SMODS.pseudorandom_probability(trigger_obj, seed, base_numerator, base_denominator, key) end
+function SMODS.pseudorandom_probability(trigger_obj, seed, base_numerator, base_denominator, key, no_mod) end
 
 ---@param handname string
 ---@return boolean

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2586,16 +2586,17 @@ function SMODS.merge_effects(...)
     return ret
 end
 
-function SMODS.get_probability_vars(trigger_obj, base_numerator, base_denominator, identifier, from_roll)
+function SMODS.get_probability_vars(trigger_obj, base_numerator, base_denominator, identifier, from_roll, no_mod)
     if not G.jokers then return base_numerator, base_denominator end
+    if no_mod then return base_numerator, base_denominator end
     local additive = SMODS.calculate_context({mod_probability = true, from_roll = from_roll, trigger_obj = trigger_obj, identifier = identifier, numerator = base_numerator, denominator = base_denominator}, nil, not from_roll)
     additive.numerator = (additive.numerator or base_numerator) * ((G.GAME and G.GAME.probabilities.normal or 1) / (2 ^ #SMODS.find_card('j_oops')))
     local fixed = SMODS.calculate_context({fix_probability = true, from_roll = from_roll, trigger_obj = trigger_obj, identifier = identifier, numerator = additive.numerator or base_numerator, denominator = additive.denominator or base_denominator}, nil, not from_roll)
     return fixed.numerator or additive.numerator or base_numerator, fixed.denominator or additive.denominator or base_denominator
 end
 
-function SMODS.pseudorandom_probability(trigger_obj, seed, base_numerator, base_denominator, identifier)
-    local numerator, denominator = SMODS.get_probability_vars(trigger_obj, base_numerator, base_denominator, identifier or seed, true)
+function SMODS.pseudorandom_probability(trigger_obj, seed, base_numerator, base_denominator, identifier, no_mod)
+    local numerator, denominator = SMODS.get_probability_vars(trigger_obj, base_numerator, base_denominator, identifier or seed, true, no_mod)
     local result = pseudorandom(seed) < numerator / denominator
     SMODS.post_prob = SMODS.post_prob or {}
     SMODS.post_prob[#SMODS.post_prob+1] = {pseudorandom_result = true, result = result, trigger_obj = trigger_obj, numerator = numerator, denominator = denominator, identifier = identifier or seed}

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2238,11 +2238,12 @@ function Card.selectable_from_pack(card, pack)
             if key == card.config.center_key then return false end
         end
     end
-    if pack.select_card then
-        if type(pack.select_card) == 'table' then
-            if pack.select_card[card.ability.set] then return pack.select_card[card.ability.set] else return false end
+    local select_area = pack.select_card or card.config.center.select_card or SMODS.ConsumableTypes[card.ability.set].select_card
+    if select_area then
+        if type(select_area) == 'table' then
+            if select_area[card.ability.set] then return select_area[card.ability.set] else return false end
         end
-        return pack.select_card
+        return select_area
     end
 end
 


### PR DESCRIPTION
Allows the select_card arguments already used in Boosters to also be used on individual card object and ConsumableType declarations

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
