### PR TITLE
Expanded JimboQuip extra

### DIFF
--- a/lovely/center.toml
+++ b/lovely/center.toml
@@ -249,12 +249,15 @@ if obj and obj.set_badges and type(obj.set_badges) == 'function' then
     obj:set_badges(card, badges)
 end'''
 
+# mod badges
 [[patches]]
-[patches.regex]
+[patches.pattern]
 target = 'functions/UI_definitions.lua'
-pattern = "(?<indent>[\t ]*)if AUT.badges then\n([\t ]*.*\n){4}[\t ]*end"
-line_prepend = '$indent'
-position = 'after'
+match_indent = true
+position = 'before'
+pattern = '''
+if AUT.info then
+'''
 payload = '''
 if AUT.card_type ~= 'Locked' and AUT.card_type ~= 'Undiscovered' then
     SMODS.create_mod_badges(card.config.center, badges)
@@ -266,7 +269,8 @@ if AUT.card_type ~= 'Locked' and AUT.card_type ~= 'Undiscovered' then
         SMODS.create_mod_badges(SMODS.Tags[card.config.tag.key], badges)
     end
     badges.mod_set = nil
-end'''
+end
+'''
 
 # set_discover_tallies()
 [[patches]]

--- a/lovely/jimboquip.toml
+++ b/lovely/jimboquip.toml
@@ -139,3 +139,32 @@ local sound_key = extra and extra.sound or 'voice'..math.random(1, 11)
 play_sound(sound_key, G.SPEEDFACTOR*(math.random()*0.2+1), 0.5)
 '''
 match_indent = true
+
+
+# Allow custom delay between talking sounds
+[[patches]]
+[patches.pattern]
+target = 'card_character.lua'
+pattern = '''
+delay = 0.13,
+'''
+position = 'at'
+payload = '''
+delay = extra and extra.delay or 0.13,
+'''
+match_indent = true
+
+
+# Allow custom juice parameters
+[[patches]]
+[patches.pattern]
+target = 'card_character.lua'
+pattern = '''
+self.children.card:juice_up()
+'''
+position = 'at'
+payload = '''
+local juice_params = extra and extra.juice or {nil, nil}
+self.children.card:juice_up(juice_params[1], juice_params[2])
+'''
+match_indent = true

--- a/lovely/jimboquip.toml
+++ b/lovely/jimboquip.toml
@@ -12,7 +12,9 @@ local spot = G.OVERLAY_MENU:get_UIE_by_ID('jimbo_spot')
 spot.config.object:remove()
 spot.config.object = Jimbo
 Jimbo.ui_object_updated = true
-Jimbo:add_speech_bubble('wq_'..math.random(1,7), nil, {quip = true})'''
+Jimbo:add_speech_bubble('wq_'..math.random(1,7), nil, {quip = true})
+Jimbo:say_stuff(5)
+'''
 position = "at"
 payload = '''
 local quip, extra = SMODS.quip("win")
@@ -24,6 +26,7 @@ spot.config.object:remove()
 spot.config.object = Jimbo
 Jimbo.ui_object_updated = true
 Jimbo:add_speech_bubble(quip, nil, {quip = true})
+Jimbo:say_stuff((extra and extra.times) or 5, false, extra)
 '''
 match_indent = true
 
@@ -37,6 +40,7 @@ spot.config.object:remove()
 spot.config.object = Jimbo
 Jimbo.ui_object_updated = true
 Jimbo:add_speech_bubble('lq_'..math.random(1,10), nil, {quip = true})
+Jimbo:say_stuff(5)
 '''
 position = "at"
 payload = '''
@@ -49,6 +53,7 @@ spot.config.object:remove()
 spot.config.object = Jimbo
 Jimbo.ui_object_updated = true
 Jimbo:add_speech_bubble(quip, nil, {quip = true})
+Jimbo:say_stuff((extra and extra.times) or 5, false, extra)
 '''
 match_indent = true
 
@@ -82,3 +87,55 @@ self.children.card = Card(self.T.x, self.T.y, G.CARD_W, G.CARD_H, G.P_CARDS.empt
 payload = '''
 self.children.card = Card(self.T.x, self.T.y, G.CARD_W, G.CARD_H, G.P_CARDS.empty, args.center and G.P_CENTERS[args.center] or G.P_CENTERS.j_joker, {bypass_discovery_center = true})
 '''
+
+# Pass extra table into say_stuff
+[[patches]]
+[patches.pattern]
+target = 'card_character.lua'
+pattern = '''
+function Card_Character:say_stuff(n, not_first)
+'''
+position = 'at'
+payload = '''
+function Card_Character:say_stuff(n, not_first, extra)
+'''
+match_indent = true
+
+[[patches]]
+[patches.pattern]
+target = 'card_character.lua'
+pattern = '''
+self:say_stuff(n, true)
+'''
+position = 'at'
+payload = '''
+self:say_stuff(n, true, extra)
+'''
+match_indent = true
+
+[[patches]]
+[patches.pattern]
+target = 'card_character.lua'
+pattern = '''
+self:say_stuff(n-1, true)
+'''
+position = 'at'
+payload = '''
+self:say_stuff(n-1, true, extra)
+'''
+match_indent = true
+
+
+# Allow custom sounds to be used for the voice
+[[patches]]
+[patches.pattern]
+target = 'card_character.lua'
+pattern = '''
+play_sound('voice'..math.random(1, 11), G.SPEEDFACTOR*(math.random()*0.2+1), 0.5)
+'''
+position = 'at'
+payload = '''
+local sound_key = extra and extra.sound or 'voice'..math.random(1, 11)
+play_sound(sound_key, G.SPEEDFACTOR*(math.random()*0.2+1), 0.5)
+'''
+match_indent = true

--- a/lovely/jimboquip.toml
+++ b/lovely/jimboquip.toml
@@ -135,8 +135,20 @@ play_sound('voice'..math.random(1, 11), G.SPEEDFACTOR*(math.random()*0.2+1), 0.5
 '''
 position = 'at'
 payload = '''
-local sound_key = extra and extra.sound or 'voice'..math.random(1, 11)
-play_sound(sound_key, G.SPEEDFACTOR*(math.random()*0.2+1), 0.5)
+local custom_pitch = extra and extra.pitch
+if extra and extra.sound then
+    if type(extra.sound) == 'table' then
+        for k, v in pairs(extra.sound) do
+            play_sound(v, custom_pitch or G.SPEEDFACTOR*(math.random()*0.2+1), 0.5)
+        end
+    elseif type(extra.sound) == 'string' then
+        play_sound(extra.sound, custom_pitch or G.SPEEDFACTOR*(math.random()*0.2+1), 0.5)
+    else
+        play_sound('voice'..math.random(1, 11), custom_pitch or G.SPEEDFACTOR*(math.random()*0.2+1), 0.5)
+    end
+else
+    play_sound('voice'..math.random(1, 11), custom_pitch or G.SPEEDFACTOR*(math.random()*0.2+1), 0.5)
+end
 '''
 match_indent = true
 

--- a/lovely/jimboquip.toml
+++ b/lovely/jimboquip.toml
@@ -26,7 +26,7 @@ spot.config.object:remove()
 spot.config.object = Jimbo
 Jimbo.ui_object_updated = true
 Jimbo:add_speech_bubble(quip, nil, {quip = true})
-Jimbo:say_stuff((extra and extra.times) or 5, false, extra)
+Jimbo:say_stuff((extra and extra.times) or 5, false, quip)
 '''
 match_indent = true
 
@@ -53,7 +53,7 @@ spot.config.object:remove()
 spot.config.object = Jimbo
 Jimbo.ui_object_updated = true
 Jimbo:add_speech_bubble(quip, nil, {quip = true})
-Jimbo:say_stuff((extra and extra.times) or 5, false, extra)
+Jimbo:say_stuff((extra and extra.times) or 5, false, quip)
 '''
 match_indent = true
 
@@ -97,7 +97,8 @@ function Card_Character:say_stuff(n, not_first)
 '''
 position = 'at'
 payload = '''
-function Card_Character:say_stuff(n, not_first, extra)
+function Card_Character:say_stuff(n, not_first, quip_key)
+    local quip = SMODS.JimboQuips[quip_key]
 '''
 match_indent = true
 
@@ -109,7 +110,7 @@ self:say_stuff(n, true)
 '''
 position = 'at'
 payload = '''
-self:say_stuff(n, true, extra)
+self:say_stuff(n, true, quip_key)
 '''
 match_indent = true
 
@@ -121,7 +122,7 @@ self:say_stuff(n-1, true)
 '''
 position = 'at'
 payload = '''
-self:say_stuff(n-1, true, extra)
+self:say_stuff(n-1, true, quip_key)
 '''
 match_indent = true
 
@@ -135,19 +136,21 @@ play_sound('voice'..math.random(1, 11), G.SPEEDFACTOR*(math.random()*0.2+1), 0.5
 '''
 position = 'at'
 payload = '''
-local custom_pitch = extra and extra.pitch
-if extra and extra.sound then
-    if type(extra.sound) == 'table' then
-        for k, v in pairs(extra.sound) do
+if quip.play_sounds and type(quip.play_sounds) == 'function' then
+    quip:play_sounds(n)
+elseif quip.extra and quip.extra.sound then
+    local custom_pitch = quip.extra.pitch
+    if type(quip.extra.sound) == 'table' then
+        for k, v in pairs(quip.extra.sound) do
             play_sound(v, custom_pitch or G.SPEEDFACTOR*(math.random()*0.2+1), 0.5)
         end
-    elseif type(extra.sound) == 'string' then
-        play_sound(extra.sound, custom_pitch or G.SPEEDFACTOR*(math.random()*0.2+1), 0.5)
+    elseif type(quip.extra.sound) == 'string' then
+        play_sound(quip.extra.sound, custom_pitch or G.SPEEDFACTOR*(math.random()*0.2+1), 0.5)
     else
         play_sound('voice'..math.random(1, 11), custom_pitch or G.SPEEDFACTOR*(math.random()*0.2+1), 0.5)
     end
 else
-    play_sound('voice'..math.random(1, 11), custom_pitch or G.SPEEDFACTOR*(math.random()*0.2+1), 0.5)
+    play_sound('voice'..math.random(1, 11), quip.extra and quip.extra.pitch or G.SPEEDFACTOR*(math.random()*0.2+1), 0.5)
 end
 '''
 match_indent = true
@@ -162,7 +165,7 @@ delay = 0.13,
 '''
 position = 'at'
 payload = '''
-delay = extra and extra.delay or 0.13,
+delay = quip.extra and quip.extra.delay or 0.13,
 '''
 match_indent = true
 
@@ -176,7 +179,7 @@ self.children.card:juice_up()
 '''
 position = 'at'
 payload = '''
-local juice_params = extra and extra.juice or {nil, nil}
+local juice_params = quip.extra and quip.extra.juice or {nil, nil}
 self.children.card:juice_up(juice_params[1], juice_params[2])
 '''
 match_indent = true

--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -3230,7 +3230,6 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
         register = function(self)
             self.config = self.config or {}
             if self.config.card_limit then
-                print(self.key)
                 self.card_limit_keys = self.card_limit_keys or {
                     joker = string.sub(self.key, 3) .. '_SMODS_INTERNAL',
                     consumable = string.sub(self.key, 3) .. '_consumable' .. '_SMODS_INTERNAL',

--- a/version.lua
+++ b/version.lua
@@ -1,1 +1,1 @@
-return "1.0.0~BETA-0821c-STEAMODDED"
+return "1.0.0~BETA-0821d-STEAMODDED"


### PR DESCRIPTION
Adds more arguments to JimboQuip's extra table:
- `sound`: takes a sound key `string` or a `table` of sound key `strings`; allows custom sound(s) for card "voice"
- `times`: takes a `number`; allows custom number of times the card will "speak"
- `delay`: takes a `number`; allows custom timing between speaking events
- `juice`: takes a `table` of `numbers` (i.e. `{0.6, 0.6}`); allows custom juicing of the card for its speaking events
- `pitch`:  takes a `number`; allows custom set pitch for the "voice"

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
