### PR TITLE
Added missing `Card:calculate_joker()` hook for `SMODS.context_stack`

### DIFF
--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -2355,6 +2355,14 @@ function Card:calculate_seal(context, ...)
 	return eff, post
 end
 
+local calculate_joker_ref = Card.calculate_joker
+function Card:calculate_joker(context, ...)
+	SMODS.push_to_context_stack(context, "overrides.lua : Card.calculate_joker")
+	local eff, post = calculate_joker_ref(self, context, ...)
+	SMODS.pop_from_context_stack(context, "overrides.lua : Card.calculate_joker")
+	return eff, post
+end
+
 local set_ability = Card.set_ability
 function Card:set_ability(center, initial, delay_sprites)
 	local old_center = self.config.center


### PR DESCRIPTION
+Title, this was lost in the original merge

I think `Card:calculate_joker()` is still getting called outside of other context evaluations, so I'm adding this back for consistency.
(Else the `context_stack` might not get updated)

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
