### PR TITLE
add `create_card` function to cards

### DIFF
--- a/src/utils.lua
+++ b/src/utils.lua
@@ -401,6 +401,10 @@ function SMODS.create_card(t)
         end
     end
 
+	if _card.config.center.create_card and type(_card.config.center.create_card) == 'function' then
+		_card.config.center.create_card(_card)
+	end
+	
     return _card
 end
 


### PR DESCRIPTION
cards can now be declared with a `create_card` function that is called whenever said card is created using SMODS.create_card.

I found a need for it when I wanted a config variable to be a pseudorandom_element but didnt want to use add_to_deck()



## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
