### PR TITLE
Allow `pseudoshuffle` to take a string as a seed

### DIFF
--- a/lovely/fixes.toml
+++ b/lovely/fixes.toml
@@ -797,5 +797,5 @@ pattern = '''
 function pseudoshuffle(list, seed)
 '''
 payload = '''
-if seed and type(seed) == "string" then seed = pseudoseed(seed) end
+    if seed and type(seed) == "string" then seed = pseudoseed(seed) end
 '''

--- a/lovely/fixes.toml
+++ b/lovely/fixes.toml
@@ -786,3 +786,16 @@ if v ~= chosen_joker then
 payload = '''
 v.getting_sliced = true
 '''
+
+# Allow pseudoshuffle to take a string as a seed
+[[patches]]
+[patches.pattern]
+target = 'functions/misc_functions.lua'
+match_indent = true
+position = 'after'
+pattern = '''
+function pseudoshuffle(list, seed)
+'''
+payload = '''
+if seed and type(seed) == "string" then seed = pseudoseed(seed) end
+'''

--- a/version.lua
+++ b/version.lua
@@ -1,1 +1,1 @@
-return "1.0.0~BETA-0822d-STEAMODDED"
+return "1.0.0~BETA-0824a-STEAMODDED"


### PR DESCRIPTION

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
