### PR TITLE
Fix `SMODS.add_to_pool` being ignored

### DIFF
--- a/lovely/blind.toml
+++ b/lovely/blind.toml
@@ -393,21 +393,39 @@ local loc_target = localize(target)'''
 [[patches]]
 [patches.pattern]
 target = 'functions/common_events.lua'
-pattern = 'elseif not v.boss.showdown*'
+pattern = '''
+if not v.boss then
+
+elseif not v.boss.showdown and (v.boss.min <= math.max(1, G.GAME.round_resets.ante) and ((math.max(1, G.GAME.round_resets.ante))%G.GAME.win_ante ~= 0 or G.GAME.round_resets.ante < 2)) then
+    eligible_bosses[k] = true
+elseif v.boss.showdown and (G.GAME.round_resets.ante)%G.GAME.win_ante == 0 and G.GAME.round_resets.ante >= 2 then
+    eligible_bosses[k] = true
+end
+'''
 match_indent = true
-position = 'before'
+position = 'at'
 payload = '''
+local res, options = SMODS.add_to_pool(v)
+options = options or {}
+if not v.boss then
+
+elseif options.ignore_showdown_check then
+    eligible_bosses[k] = res and true or nil
 elseif v.in_pool and type(v.in_pool) == 'function' then
-    local res, options = SMODS.add_to_pool(v)
     if
         (
             ((G.GAME.round_resets.ante)%G.GAME.win_ante == 0 and G.GAME.round_resets.ante >= 2) ==
             (v.boss.showdown or false)
-        ) or
-        (options or {}).ignore_showdown_check
+        )
     then
         eligible_bosses[k] = res and true or nil
-    end'''
+    end
+elseif not v.boss.showdown and (v.boss.min <= math.max(1, G.GAME.round_resets.ante) and ((math.max(1, G.GAME.round_resets.ante))%G.GAME.win_ante ~= 0 or G.GAME.round_resets.ante < 2)) then
+    eligible_bosses[k] = res and true or nil
+elseif v.boss.showdown and (G.GAME.round_resets.ante)%G.GAME.win_ante == 0 and G.GAME.round_resets.ante >= 2 then
+    eligible_bosses[k] = res and true or nil
+end
+'''
 
 # G.UIDEF.challenge_description_tab
 [[patches]]

--- a/lovely/pool.toml
+++ b/lovely/pool.toml
@@ -143,9 +143,7 @@ pattern = "if add and not G.GAME.banned_keys[v.key] then"
 match_indent = true
 position = 'before'
 payload = '''
-if v.in_pool and type(v.in_pool) == 'function' then
-    add = in_pool and (add or pool_opts.override_base_checks)
-end
+add = in_pool and (add or pool_opts.override_base_checks)
 '''
 
 [[patches]]
@@ -196,7 +194,7 @@ target = "card.lua"
 pattern = '''
 (?<indent>[\t ]*)for k, v in pairs\(G\.P_CENTERS\) do
 [\t ]*if v\.name == self\.ability\.name then
-[\t ]*if not next\(find_joker\(self\.ability\.name, true\)\) then 
+[\t ]*if not next\(find_joker\(self\.ability\.name, true\)\) then
 [\t ]*G\.GAME\.used_jokers\[k\] = nil
 [\t ]*end
 [\t ]*end

--- a/lovely/pool.toml
+++ b/lovely/pool.toml
@@ -194,7 +194,7 @@ target = "card.lua"
 pattern = '''
 (?<indent>[\t ]*)for k, v in pairs\(G\.P_CENTERS\) do
 [\t ]*if v\.name == self\.ability\.name then
-[\t ]*if not next\(find_joker\(self\.ability\.name, true\)\) then
+[\t ]*if not next\(find_joker\(self\.ability\.name, true\)\) then 
 [\t ]*G\.GAME\.used_jokers\[k\] = nil
 [\t ]*end
 [\t ]*end

--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -2184,11 +2184,9 @@ function get_pack(_key, _type)
 		local add
 		v.current_weight = v.get_weight and v:get_weight() or v.weight or 1
         if (not _type or _type == v.kind) then add = true end
-		if v.in_pool and type(v.in_pool) == 'function' then
-			local res, pool_opts = SMODS.add_to_pool(v)
-			pool_opts = pool_opts or {}
-			add = res and (add or pool_opts.override_base_checks)
-		end
+		local res, pool_opts = SMODS.add_to_pool(v)
+		pool_opts = pool_opts or {}
+		add = res and (add or pool_opts.override_base_checks)
 		if add and not G.GAME.banned_keys[v.key] then cume = cume + (v.current_weight or 1); temp_in_pool[v.key] = true end
     end
     local poll = pseudorandom(pseudoseed((_key or 'pack_generic')..G.GAME.round_resets.ante))*cume


### PR DESCRIPTION
Some functions ignore `SMODS.add_to_pool` if the object doesn't have `in_pool` defined.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
