### PR TITLE
context.discard_from_play and context.draw_individual

### DIFF
--- a/lovely/better_calc.toml
+++ b/lovely/better_calc.toml
@@ -1971,3 +1971,63 @@ position = 'at'
 payload = '''
 delay(0.4); ease_ante(1, true); delay(0.4); check_for_unlock({type = 'ante_up', ante = G.GAME.round_resets.ante + 1})
 '''
+
+# Make draw_card and draw_card_from actually use stay_flipped
+[[patches]]
+[patches.pattern]
+target = "cardarea.lua"
+match_indent = true
+pattern = '''
+local stay_flipped = G.GAME and G.GAME.blind and G.GAME.blind:stay_flipped(self, card, area)
+'''
+position = "at"
+payload = '''
+local stay_flipped = G.GAME and G.GAME.blind and G.GAME.blind:stay_flipped(self, card, area) or stay_flipped
+'''
+
+[[patches]]
+[patches.pattern]
+target = "cardarea.lua"
+match_indent = true
+pattern = '''
+local stay_flipped = G.GAME and G.GAME.blind and G.GAME.blind:stay_flipped(to, card, from)
+'''
+position = "at"
+payload = '''
+local stay_flipped = G.GAME and G.GAME.blind and G.GAME.blind:stay_flipped(to, card, from) or stay_flipped
+'''
+
+# Discard From Play context
+[[patches]]
+[patches.pattern]
+target = 'functions/state_events.lua'
+match_indent = true
+pattern = '''
+draw_card(G.play,G.discard, it*100/play_count,'down', false, v)
+'''
+position = 'at'
+payload = '''
+local flags = SMODS.calculate_context({discard_from_play = true, card = v, num_discarded = k})
+sendInfoMessage(flags.cardarea or 'No card area found')
+local discard_to = G[flags.cardarea] or G.discard
+draw_card(G.play,discard_to, it*100/play_count,'down', false, v, nil, nil, flags.stay_flipped)
+'''
+
+# Draw Individual context
+[[patches]]
+[patches.pattern]
+target = 'functions/state_events.lua'
+match_indent = true
+pattern = '''
+else
+    draw_card(G.deck,G.hand, i*100/hand_space,'up', true, cards_to_draw[i])
+end
+'''
+position = 'at'
+payload = '''
+else
+    local flags = SMODS.calculate_context({draw_individual = true, card = cards_to_draw[i], num_drawn = i, played = true})
+    local draw_to = G[flags.cardarea] or G.hand
+    draw_card(G.deck,draw_to, i*100/hand_space,'up', true, cards_to_draw[i], nil, nil, flags.stay_flipped)
+end
+'''

--- a/lovely/better_calc.toml
+++ b/lovely/better_calc.toml
@@ -2008,7 +2008,6 @@ draw_card(G.play,G.discard, it*100/play_count,'down', false, v)
 position = 'at'
 payload = '''
 local flags = SMODS.calculate_context({discard_from_play = true, card = v, num_discarded = k})
-sendInfoMessage(flags.cardarea or 'No card area found')
 local discard_to = G[flags.cardarea] or G.discard
 draw_card(G.play,discard_to, it*100/play_count,'down', false, v, nil, nil, flags.stay_flipped)
 '''

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -1347,7 +1347,7 @@ SMODS.calculate_individual_effect = function(effect, scored_card, key, amount, f
     end
 
     if key == 'remove' or key == 'debuff_text' or key == 'cards_to_draw' or key == 'numerator' or key == 'denominator' or key == 'no_destroy' or 
-        key == 'replace_scoring_name' or key == 'replace_display_name' or key == 'replace_poker_hands' or key == 'modify' then
+        key == 'replace_scoring_name' or key == 'replace_display_name' or key == 'replace_poker_hands' or key == 'modify' or key == 'cardarea' then
         return { [key] = amount }
     end
     
@@ -1448,7 +1448,8 @@ SMODS.other_calculation_keys = {
     'numerator', 'denominator',
     'modify',
     'no_destroy', 'prevent_trigger',
-    'replace_scoring_name', 'replace_display_name', 'replace_poker_hands'
+    'replace_scoring_name', 'replace_display_name', 'replace_poker_hands',
+    'cardarea'
 }
 SMODS.silent_calculation = {
     saved = true, effect = true, remove = true,


### PR DESCRIPTION
Adds two new contexts:
- `context.discard_from_play`: Runs for each card discarded after being played
- `context.draw_individual`: Runs for each card drawn from deck to hand

Both contexts also run with `context.card`, the card being drawn/discarded, and `num_drawn/discarded`, the number of cards (including the current one) that have been drawn/discarded out of the group of cards to be drawn/discarded

Returning `stay_flipped` as a boolean will dictate whether or not a card will stay flipped on draw/discard, and returning `cardarea` as a string (i.e. 'discard') will change what area the card will be drawn/discarded to

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
