### PR TITLE
Small tweak and expansion to Operator API

### DIFF
--- a/lovely/scoring_calculation.toml
+++ b/lovely/scoring_calculation.toml
@@ -129,6 +129,19 @@ for name, parameter in pairs(SMODS.Scoring_Parameters) do
 end
 '''
 
+# pt2
+[[patches]]
+[patches.pattern]
+target = 'functions/common_events.lua'
+match_indent = true
+position = 'before'
+pattern = '''
+if vals.chips and G.GAME.current_round.current_hand.chips ~= vals.chips then
+'''
+payload = '''
+SMODS.refresh_score_UI_list()
+'''
+
 # Reset other values
 [[patches]]
 [patches.pattern]

--- a/lovely/scoring_calculation.toml
+++ b/lovely/scoring_calculation.toml
@@ -101,7 +101,7 @@ if vals.handname and G.GAME.current_round.current_hand.handname ~= vals.handname
 '''
 payload = '''
 for name, parameter in pairs(SMODS.Scoring_Parameters) do
-    if vals[name] and G.GAME.current_round.current_hand[name] ~= vals[name] then
+    if name ~= "mult" and name ~= "chips" and vals[name] and G.GAME.current_round.current_hand[name] ~= vals[name] then
         local delta = (type(vals[name]) == 'number' and type(G.GAME.current_round.current_hand[name]) == 'number') and (vals[name] - G.GAME.current_round.current_hand[name]) or 0
         if delta < 0 then delta = ''..delta; col = G.C.RED
         elseif delta > 0 then delta = '+'..delta

--- a/lovely/scoring_calculation.toml
+++ b/lovely/scoring_calculation.toml
@@ -124,6 +124,7 @@ for name, parameter in pairs(SMODS.Scoring_Parameters) do
                     cover_align = 'cm'
                 })
             end
+            if vals[name.."_juice"] and not G.TAROT_INTERRUPT then G.hand_text_area[hand]:juice_up() end
         end
     end
 end

--- a/lovely/scoring_calculation.toml
+++ b/lovely/scoring_calculation.toml
@@ -92,16 +92,15 @@ end
 
 # Add Scoring_Parameters to update_hand_text
 [[patches]]
-[patches.pattern]
+[patches.regex]
 target = 'functions/common_events.lua'
 match_indent = true
-position = 'before'
-pattern = '''
-if vals.handname and G.GAME.current_round.current_hand.handname ~= vals.handname then
-'''
+position = 'at'
+line_prepend = '$indent'
+pattern = '''(?<indent>[\t ]*)if vals\.[A-z0-9\n\t .~=()'\-+,<;>:{}]+mult:juice_up\(\) end\n[\t ]+end'''
 payload = '''
 for name, parameter in pairs(SMODS.Scoring_Parameters) do
-    if name ~= "mult" and name ~= "chips" and vals[name] and G.GAME.current_round.current_hand[name] ~= vals[name] then
+    if vals[name] and G.GAME.current_round.current_hand[name] ~= vals[name] then
         local delta = (type(vals[name]) == 'number' and type(G.GAME.current_round.current_hand[name]) == 'number') and (vals[name] - G.GAME.current_round.current_hand[name]) or 0
         if delta < 0 then delta = ''..delta; col = G.C.RED
         elseif delta > 0 then delta = '+'..delta
@@ -109,7 +108,7 @@ for name, parameter in pairs(SMODS.Scoring_Parameters) do
         end
         if type(vals[name]) == 'string' then delta = vals[name] end
         G.GAME.current_round.current_hand[name] = vals[name]
-        G.hand_text_area[name] = G.hand_text_area[name] or G.HUD:get_UIE_by_ID('hand_'..name..'_area') or nil
+        G.hand_text_area[name] = G.hand_text_area[name] or G.HUD:get_UIE_by_ID('hand_'..name) or nil
         if G.hand_text_area[name] then
             G.hand_text_area[name]:update(0)
             if vals.StatusText then 
@@ -124,23 +123,10 @@ for name, parameter in pairs(SMODS.Scoring_Parameters) do
                     cover_align = 'cm'
                 })
             end
-            if vals[name.."_juice"] and not G.TAROT_INTERRUPT then G.hand_text_area[hand]:juice_up() end
+            if (vals[name.."_juice"] or parameter.juice_on_update) and not G.TAROT_INTERRUPT then G.hand_text_area[name]:juice_up() end
         end
     end
 end
-'''
-
-# pt2
-[[patches]]
-[patches.pattern]
-target = 'functions/common_events.lua'
-match_indent = true
-position = 'before'
-pattern = '''
-if vals.chips and G.GAME.current_round.current_hand.chips ~= vals.chips then
-'''
-payload = '''
-SMODS.refresh_score_UI_list()
 '''
 
 # Reset other values

--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -3646,6 +3646,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
     SMODS.Scoring_Parameter({
         key = 'mult',
         default_value = 0,
+        juice_on_update = true,
         colour = G.C.UI_MULT,
         calculation_keys = {'mult', 'h_mult', 'mult_mod','x_mult', 'Xmult', 'xmult', 'x_mult_mod', 'Xmult_mod'},
         calc_effect = function(self, effect, scored_card, key, amount, from_edition)

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2687,6 +2687,21 @@ end
 -- Scoring Calculation API
 function SMODS.set_scoring_calculation(key)
     G.GAME.current_scoring_calculation = SMODS.Scoring_Calculations[key]:new()
+    G.FUNCS.SMODS_scoring_calculation_function(G.HUD:get_UIE_by_ID('hand_text_area'))
+    G.HUD:get_UIE_by_ID('hand_operator_container').UIBox:recalculate()
+    SMODS.refresh_score_UI_list()
+end
+
+local game_start_run = Game.start_run
+function Game:start_run(args)
+    game_start_run(self, args)
+    G.E_MANAGER:add_event(Event({
+        trigger = 'immediate',
+        func = function()                
+            SMODS.refresh_score_UI_list()
+            return true
+        end
+    }))
 end
 
 G.FUNCS.SMODS_scoring_calculation_function = function(e)

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2732,6 +2732,11 @@ function SMODS.get_scoring_parameter(key, flames)
     return SMODS.Scoring_Parameters[key].current or SMODS.Scoring_Parameters[key].default_value
 end
 
+function SMODS.refresh_score_UI_list()
+    for name, _ in pairs(SMODS.Scoring_Parameters) do
+        G.hand_text_area[name] = G.HUD:get_UIE_by_ID('hand_'..name)
+    end
+end
 
 -- Adds tag_triggered context
 local tag_apply = Tag.apply_to_run


### PR DESCRIPTION
## Commit explanation:
* 1st commit: The way `SMODS.scoring_parameter` injects itself into `update_hand_text` doesn't remove `chips` and `mult`'s vanilla behavior, so I'm excluding those from the loop. I've tested and they should work without further problems.
* 2nd commit: The API injection at runtime makes some of the elements in `G.hand_text_area` refer to orphaned tables (Object nodes that no longer store an object due to it being overridden), therefore I'm making a new function that refreshes `chips` and `mult` as well as adding new scoring parameters if applicable.
* 3rd commit: Back to 1st commit, the previous injection makes `mult` behave inconsistently with the juice effect. It is restored now, but I feel like this could be expanded, so I'm adding a new argument for the `vals` table in `update_hand_text`: `parameter_juice` - which shall apply the juice effect previously seen in `mult` when set to `true`. This could easily be achieved within the `modify` method of a scoring parameter. 2nd commit also addresses `G.hand_text_area` having non-existent elements for new scoring parameters.


## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
