### PR TITLE
Fixed infinite "Getter" context loops

### DIFF
--- a/lovely/better_calc.toml
+++ b/lovely/better_calc.toml
@@ -288,7 +288,7 @@ if card.area and area_set[card.area] then
     if type(jokers) ~= 'table' then jokers = nil end
     if jokers or triggered then
         ret.jokers = jokers
-        if not (context.retrigger_joker_check or context.retrigger_joker) and not (jokers and jokers.no_retrigger) and not context.mod_probability and not context.fix_probability then
+        if not (context.retrigger_joker_check or context.retrigger_joker) and not (jokers and jokers.no_retrigger) and not SMODS.is_getter_context(context) then
             local retriggers = SMODS.calculate_retriggers(card, context, ret)
             if next(retriggers) then
                 ret.retriggers = retriggers

--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -716,3 +716,19 @@ function SMODS.pop_from_context_stack(context, func) end
 --- Useful for Seals/Enhancements determining whether a playing card was being individually evaluated,
 --- when a Joker called (e.g.) SMODS.pseudorandom_probability().
 function SMODS.get_previous_context() end
+
+---@param context CalcContext|table The context checked
+---@return string|false
+--- Either returns a getter context identifier string 
+--- (e.g. "enhancement" for context.check_enhancement) 
+--- or false if the [context] isn't a getter context.
+function SMODS.is_getter_context(context) end
+
+
+---@param eval_object SMODS.GameObject|table The object that will be evaluated next if this returns false
+---@return boolean
+--- This functions checks whether a previous getter context of the same type
+--- as the current context (last SMODS.context_stack context) has caused the
+--- [eval_object] to incite any getter context, if yes returns false,
+--- skipping the evaluation of the object and preventing an infinite loop.
+function SMODS.check_looping_context(eval_object) end

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -1639,6 +1639,10 @@ function SMODS.calculate_card_areas(_type, context, return_table, args)
             if args and args.joker_area and not args.has_area then context.cardarea = area end
             for _, _card in ipairs(area.cards) do
                 --calculate the joker effects
+                if SMODS.check_looping_context(_card) then
+                    goto skip
+                end
+                SMODS.current_evaluated_object = _card
                 local eval, post = eval_card(_card, context)
                 if args and args.main_scoring and eval.jokers then
                     eval.jokers.juice_card = eval.jokers.juice_card or eval.jokers.card or _card
@@ -1685,6 +1689,7 @@ function SMODS.calculate_card_areas(_type, context, return_table, args)
                     if flags.denominator then context.denominator = flags.denominator end
                     if flags.cards_to_draw then context.amount = flags.cards_to_draw end
                 end
+                ::skip::
             end
         end
     end
@@ -1701,18 +1706,26 @@ function SMODS.calculate_card_areas(_type, context, return_table, args)
                 -- For example; A seal can double the probability of Blood Stone hitting for the playing card it is applied to.
                 if context.mod_probability or context.fix_probability then
                     for _, card in ipairs(area.cards) do
+                        if SMODS.check_looping_context(card) then
+                            goto skip
+                        end
+                        SMODS.current_evaluated_object = card
                         local effects = {eval_card(card, context)}
                         local f = SMODS.trigger_effects(effects, card)
                         for k,v in pairs(f) do flags[k] = v end
                         if flags.numerator then context.numerator = flags.numerator end
                         if flags.denominator then context.denominator = flags.denominator end
                         if flags.cards_to_draw then context.amount = flags.cards_to_draw end
+                        ::skip::
                     end
                 end
                 goto continue
             end
             if not args or not args.has_area then context.cardarea = area end
             for _, card in ipairs(area.cards) do
+                if SMODS.check_looping_context(card) then
+                    goto skip
+                end
                 if not args or not args.has_area then
                     if area == G.play then
                         context.cardarea = SMODS.in_scoring(card, context.scoring_hand) and G.play or 'unscored'
@@ -1722,11 +1735,13 @@ function SMODS.calculate_card_areas(_type, context, return_table, args)
                         context.cardarea = area
                     end
                 end
-            --calculate the played card effects
+                --calculate the played card effects
                 if return_table then
+                    SMODS.current_evaluated_object = card
                     return_table[#return_table+1] = eval_card(card, context)
                     SMODS.calculate_quantum_enhancements(card, return_table, context)
                 else
+                    SMODS.current_evaluated_object = card
                     local effects = {eval_card(card, context)}
                     SMODS.calculate_quantum_enhancements(card, effects, context)
                     local f = SMODS.trigger_effects(effects, card)
@@ -1735,6 +1750,7 @@ function SMODS.calculate_card_areas(_type, context, return_table, args)
                     if flags.denominator then context.denominator = flags.denominator end
                     if flags.cards_to_draw then context.amount = flags.cards_to_draw end
                 end
+                ::skip::
             end
             ::continue::
         end
@@ -1742,6 +1758,10 @@ function SMODS.calculate_card_areas(_type, context, return_table, args)
 
     if _type == 'individual' then
         for _, area in ipairs(SMODS.get_card_areas('individual')) do
+            if SMODS.check_looping_context(area.object) then
+                goto skip
+            end
+            SMODS.current_evaluated_object = area.object
             local eval, post = SMODS.eval_individual(area, context)
             if args and args.main_scoring and eval.individual then
                 eval.individual.juice_card = eval.individual.juice_card or eval.individual.card or area.scored_card
@@ -1772,13 +1792,47 @@ function SMODS.calculate_card_areas(_type, context, return_table, args)
                 if flags.numerator then context.numerator = flags.numerator end
                 if flags.denominator then context.denominator = flags.denominator end
             end
+            ::skip::
         end
     end
+    SMODS.current_evaluated_object = nil
     return flags
 end
 
+
+SMODS.current_evaluated_object = nil
+
+-- Used to avoid looping getter context calls. Example;
+-- Joker A: Doubles lucky card probabilities
+-- Joker B: 1 in 3 chance that a card counts as a lucky card
+-- Joker A calls SMODS.has_enhancement() during a probability context to check whether it should double the numerator
+-- Joker B calls SMODS.pseudorandom_probability() to check whether it should trigger
+-- A loop is caused (ignore the fact that Joker B would be the trigger_obj and not a playing card) (I'd write a Quantum Ranks example, If I had any!!)
+-- To avoid this; Check before evaluating any object, whether the current getter context type (if it's a getter context) has previously caused said object to create a getter context,
+-- if yes, don't evaluate the object. 
+function SMODS.is_getter_context(context)
+    if context.mod_probability or context.fix_probability then return "probability" end
+    if context.check_enhancement then return "enhancement" end
+    return nil
+end
+
+
+function SMODS.check_looping_context(eval_object)
+    local getter_type = SMODS.is_getter_context(SMODS.context_stack[#SMODS.context_stack].context)
+    if not getter_type then return end
+    for i, t in ipairs(SMODS.context_stack) do
+        local other_type = SMODS.is_getter_context(t.context)
+        local next_context = SMODS.context_stack[i+1]
+        -- If the current kind of getter context has caused the eval_object to incite a getter context before, dont evaluate the object again
+        if other_type == getter_type and next_context and SMODS.is_getter_context(next_context) and next_context.caller == eval_object then
+            return true
+        end
+    end
+    return false
+end
+
 -- The context stack list, structured like so;
--- SMODS.context_stack = {1: {context = [unique context 1], count = [number of times it was added consecutively]}, ...}
+-- SMODS.context_stack = {1: {context = [unique context 1], count = [number of times it was added consecutively], caller = [the SMODS.current_evaluated_object when the context was added]}, ...}
 -- (Contexts may repeat non-consecutively, though I don't think they ever should..)
 -- Allows some advanced effects, like:
 -- Individual playing cards modifying probabilities checked during individual scoring, only when they're the context.other_card 
@@ -1791,7 +1845,7 @@ function SMODS.push_to_context_stack(context, func)
     end
     local len = #SMODS.context_stack
     if len <= 0 or SMODS.context_stack[len].context ~= context then
-        SMODS.context_stack[len+1] = {context = context, count = 1}
+        SMODS.context_stack[len+1] = {context = context, count = 1, caller = SMODS.current_evaluated_object}
     else
         SMODS.context_stack[len].count = SMODS.context_stack[len].count + 1
     end

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -1813,18 +1813,19 @@ SMODS.current_evaluated_object = nil
 function SMODS.is_getter_context(context)
     if context.mod_probability or context.fix_probability then return "probability" end
     if context.check_enhancement then return "enhancement" end
-    return nil
+    return false
 end
 
 
 function SMODS.check_looping_context(eval_object)
+    if #SMODS.context_stack < 2 then return false end
     local getter_type = SMODS.is_getter_context(SMODS.context_stack[#SMODS.context_stack].context)
     if not getter_type then return end
     for i, t in ipairs(SMODS.context_stack) do
         local other_type = SMODS.is_getter_context(t.context)
         local next_context = SMODS.context_stack[i+1]
         -- If the current kind of getter context has caused the eval_object to incite a getter context before, dont evaluate the object again
-        if other_type == getter_type and next_context and SMODS.is_getter_context(next_context) and next_context.caller == eval_object then
+        if other_type == getter_type and next_context and SMODS.is_getter_context(next_context.context) and next_context.caller == eval_object then
             return true
         end
     end


### PR DESCRIPTION
*Title, what I mean by "Getter" context is any of these contexts (currently), `mod_probability`, `fix_probability` and `check_enhancement` (and `get_ranks` if Quantum Ranks gets merged)

This fix checks the following before `eval`ing any object (currently only during the `SMODS.calculate_card_areas` of a complete `SMODS.calculate_context` call, no external `eval` calls).
(The example uses Quantum Rank stuff but this problem occurs with just Quantum Enhancements too)

Example:
Joker A: All lucky cards count as 7s
Joker B: All 7s count as lucky cards
Joker A is eval'd in a `get_ranks` context, calls `SMODS.has_enhancement()` and causes a `check_enhancements` context
Joker B is then eval'd, calls `Card:is_rank()` and causes a `get_ranks` context
The game gets stuck in an infinite loop and burns into a pile of ashes

Fix:
Joker A is eval'd in a `get_ranks` context, causes a `check_enhancements` context and is set as that context's caller in the `SMODS.context_stack`.
Joker B is then eval'd and causes a `get_ranks` context.
`SMODS.calculate_card_areas` checks _before_ calling `eval_card()` on Joker A whether a previous _getter_ context of the same type as the current getter context (`get_ranks`) in the `context_stack` has caused this object (Joker A) to call any getter context, if yes, it skips evaluating Joker A.
No loop is caused! :) 

In simpler terms, this prevents an object from directly or indirectly calling itself through getter contexts.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
