### PR TITLE
make destroy_cards not crash when passed an empty table

### DIFF
--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2471,8 +2471,12 @@ function SMODS.info_queue_desc_from_rows(desc_nodes, empty, maxw)
 end
 
 function SMODS.destroy_cards(cards, bypass_eternal, immediate, skip_anim)
-    if not cards[1] and Object.is(cards, Card) then
-        cards = {cards}
+    if not cards[1] then
+        if Object.is(cards, Card) then
+            cards = {cards}
+        else
+            return
+        end
     end
     local glass_shattered = {}
     local playing_cards = {}

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2471,7 +2471,7 @@ function SMODS.info_queue_desc_from_rows(desc_nodes, empty, maxw)
 end
 
 function SMODS.destroy_cards(cards, bypass_eternal, immediate, skip_anim)
-    if not cards[1] then
+    if not cards[1] and Object.is(cards, Card) then
         cards = {cards}
     end
     local glass_shattered = {}


### PR DESCRIPTION
Crashes this fixes:
- Crash when passing the `cards` field of an empty CardArea (if a modder wanted to destroy every card in that area)
- Crash when passing a table containing a nil result from pseudorandom_element (if a modder wanted a random card in that area)
Other than preventing these crashes, this has no additional effect.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
