### PR TITLE
Shop Card Editing 

### DIFF
--- a/lovely/shop.toml
+++ b/lovely/shop.toml
@@ -251,3 +251,19 @@ card:set_edition(edition)
 position = 'at'
 match_indent = true
 payload = '''card:set_edition(poll_edition('illusion', nil, true, true))'''
+
+
+# modify_shop_card context for allowing shop cards to be modified (duh)
+[[patches]]
+[patches.pattern]
+target = 'functions/UI_definitions.lua'
+pattern = '''
+local card = create_card(v.type, area, nil, nil, nil, nil, nil, 'sho')
+'''
+position = 'at'
+payload = '''
+local create_flags = SMODS.calculate_context({create_shop_card = true, type = v.type})
+local card = SMODS.create_card({set = create_flags.type or v.type, area = area, rarity = create_flags.rarity or nil, legendary = create_flags.legendary or nil, soulable = create_flags.soulable or nil, key = create_flags.forced_key or nil, key_append = 'sho'})
+SMODS.calculate_context({modify_shop_card = true, card = card})
+'''
+match_indent = true

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -1346,8 +1346,9 @@ SMODS.calculate_individual_effect = function(effect, scored_card, key, amount, f
         return key
     end
 
-    if key == 'remove' or key == 'debuff_text' or key == 'cards_to_draw' or key == 'numerator' or key == 'denominator' or key == 'no_destroy' or 
-        key == 'replace_scoring_name' or key == 'replace_display_name' or key == 'replace_poker_hands' or key == 'modify' then
+    if key == 'remove' or key == 'debuff_text' or key == 'cards_to_draw' or key == 'numerator' or key == 'denominator' or key == 'no_destroy' or
+        key == 'replace_scoring_name' or key == 'replace_display_name' or key == 'replace_poker_hands' or key == 'modify' or key == 'rarity' or
+        key == 'type' or key == 'forced_key' or key == 'legendary' or key == 'soulable'  then
         return { [key] = amount }
     end
     
@@ -1448,7 +1449,8 @@ SMODS.other_calculation_keys = {
     'numerator', 'denominator',
     'modify',
     'no_destroy', 'prevent_trigger',
-    'replace_scoring_name', 'replace_display_name', 'replace_poker_hands'
+    'replace_scoring_name', 'replace_display_name', 'replace_poker_hands',
+    'rarity', 'type', 'legendary', 'forced_key', 'soulable'
 }
 SMODS.silent_calculation = {
     saved = true, effect = true, remove = true,


### PR DESCRIPTION
This PR adds two new contexts: `create_shop_card` and `modify_shop_card`

- `create_shop_card` is run when a shop card is about to be created and specifies the card's `type`. Returning any of the following values will change the attributes of the shop card that will be generated:
   - `type` (string): Changes the type of the card that will be generated
   - `rarity` (number): Allows the rarity of the card that will be generated to be fixed
   - `legendary` (boolean): Returning `true` will guarantee the generated card will be legendary
   - `soulable` (boolean): Returning `true` will allow soul cards of the card type to spawn in the shop (same odds as a booster)
   - `forced_key` (string): Allows exact specification of what card will spawn

- `modify_shop_card` is run after a shop card is created and specifies the `card` object itself

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
