### PR TITLE
Fixed incorrect hand size when reloading with `negative` playing cards in hand

### DIFF
--- a/lovely/card_limit.toml
+++ b/lovely/card_limit.toml
@@ -108,6 +108,19 @@ function CardArea:emplace(card, location, stay_flipped)
 payload = '''
     self:handle_card_limit(card.ability.card_limit, card.ability.extra_slots_used)
 '''
+# CardArea:load()
+# Reloads card_limit 
+[[patches]]
+[patches.pattern]
+target = 'cardarea.lua'
+match_indent = true
+position = 'after'
+pattern = '''
+    self:hard_set_cards()
+'''
+payload = '''
+self:load_card_limit()
+'''
 # CardArea:update()
 [[patches]]
 [patches.pattern]

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -3110,7 +3110,7 @@ function CardArea:handle_card_limit(card_limit, card_slots)
             }))
             
         end
-        if G.hand and self == G.hand and card_limit - card_slots > 0 then 
+        if G.hand and self == G.hand and card_limit - card_slots > 0 then
             if G.STATE == G.STATES.DRAW_TO_HAND then 
                 G.E_MANAGER:add_event(Event({
                     trigger = 'immediate',
@@ -3122,6 +3122,19 @@ function CardArea:handle_card_limit(card_limit, card_slots)
             end
             if G.STATE == G.STATES.SELECTING_HAND then G.FUNCS.draw_from_deck_to_hand(math.min(card_limit - card_slots, (self.config.card_limit + card_limit - card_slots) - #self.cards)) end
             check_for_unlock({type = 'min_hand_size'})
+        end
+    end
+end
+
+function CardArea:load_card_limit()
+    if SMODS.should_handle_limit(self) and self.cards then
+        for _, card in ipairs(self.cards) do
+            local card_limit = card.ability and card.ability.card_limit or 0
+            local card_slots = card.ability and card.ability.extra_slots_used or 0
+            self.config.card_limit = self.config.card_limit + card_limit
+            self.config.no_true_limit = true
+            self.config.card_limit = self.config.card_limit - card_slots
+            self.config.no_true_limit = false
         end
     end
 end


### PR DESCRIPTION
*Title

Fixes #965 

There's an issue when drawing negative playing cards after discarding; 
Two cards are drawn instead of one. I don't know where the second one's coming from.


## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
