### PR TITLE
Custom ConsumableType usage tracking

### DIFF
--- a/lovely/better_calc.toml
+++ b/lovely/better_calc.toml
@@ -1978,3 +1978,17 @@ position = 'at'
 payload = '''
 delay(0.4); SMODS.ante_end = true; ease_ante(1); SMODS.ante_end = nil; delay(0.4); check_for_unlock({type = 'ante_up', ante = G.GAME.round_resets.ante + 1})
 '''
+
+[[patches]]
+[patches.pattern]
+target = 'functions/misc_functions.lua'
+pattern = '''
+elseif card.config.center.set == 'Spectral' then  G.GAME.consumeable_usage_total.spectral = G.GAME.consumeable_usage_total.spectral + 1
+'''
+position = 'after'
+payload = '''
+else 
+    G.GAME.consumeable_usage_total[card.config.center.set] = G.GAME.consumeable_usage_total[card.config.center.set] or 0
+    G.GAME.consumeable_usage_total[card.config.center.set] = G.GAME.consumeable_usage_total[card.config.center.set] + 1
+'''
+match_indent = true


### PR DESCRIPTION
A small patch that allows tracking of custom ConsumableTypes in `G.GAME.consumeable_usage_total`

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
