### PR TITLE
Better sticker apply processes

### DIFF
--- a/lovely/sticker.toml
+++ b/lovely/sticker.toml
@@ -59,7 +59,9 @@ payload = '''
 for k, v in ipairs(SMODS.Sticker.obj_buffer) do
     local sticker = SMODS.Stickers[v]
     if sticker.should_apply and type(sticker.should_apply) == 'function' and sticker:should_apply(card, center, area) then
-        sticker:apply(card, true)
+        SMODS.sticker_from_game = true
+        card:add_sticker(sticker.key)
+        SMODS.sticker_from_game = nil
     end
 end'''
 
@@ -109,3 +111,30 @@ pattern = '''table.sort(self.cards, function (a, b) return a.T.x + a.T.w/2 - 100
 position = 'at'
 match_indent = true
 payload = '''table.sort(self.cards, function (a, b) return a.T.x + a.T.w/2 - 100*((a.pinned and not a.ignore_pinned) and a.sort_id or 0) < b.T.x + b.T.w/2 - 100*((b.pinned and not b.ignore_pinned) and b.sort_id or 0) end)'''
+
+# Change challenge apply processes to use SMODS.sticker_from_game
+[[patches]]
+[patches.pattern]
+target = 'functions/UI_definitions.lua'
+pattern = "if v.eternal then card:set_eternal(true) end"
+position = 'at'
+payload = '''
+if v.eternal then 
+    SMODS.sticker_from_game = true
+    card:set_eternal(true) 
+    SMODS.sticker_from_game = nil
+end
+'''
+
+[[patches]]
+[patches.pattern]
+target = 'functions/UI_definitions.lua'
+pattern = "if v.pinned then card.pinned = true end"
+position = 'at'
+payload = '''
+if v.pinned then 
+    SMODS.sticker_from_game = true
+    card:add_sticker('pinned')
+    SMODS.sticker_from_game = nil
+end
+'''

--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -2407,3 +2407,27 @@ function Card:set_ability(center, initial, delay_sprites)
 		SMODS.calculate_context({setting_ability = true, old = old_center.key, new = self.config.center_key, other_card = self, unchanged = old_center.key == self.config.center.key})
 	end
 end
+
+function Card:set_eternal(_eternal)
+    if not self.ability.eternal and _eternal then
+		self:add_sticker('eternal')
+	elseif self.ability.eternal and not _eternal then
+		self:remove_sticker('eternal')
+	end
+end
+
+function Card:set_perishable(_perishable)
+    if not self.ability.perishable and _perishable then
+		self:add_sticker('perishable')
+	elseif self.ability.perishable and not _perishable then
+		self:remove_sticker('perishable')
+	end
+end
+
+function Card:set_rental(_rental)
+    if not self.ability.rental and _rental then
+		self:add_sticker('rental')
+	elseif self.ability.rental and not _rental then
+		self:remove_sticker('rental')
+	end
+end

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -917,6 +917,7 @@ function Card:add_sticker(sticker, bypass_check)
     if bypass_check or (sticker and sticker.should_apply and type(sticker.should_apply) == 'function' and sticker:should_apply(self, self.config.center, self.area, true)) then
         sticker:apply(self, true)
         SMODS.enh_cache:write(self, nil)
+        SMODS.calculate_context({apply_sticker = true, other_card = self, sticker = sticker, applied_by_game = SMODS.sticker_from_game or false})
     end
 end
 
@@ -924,6 +925,7 @@ function Card:remove_sticker(sticker)
     if self.ability[sticker] then
         SMODS.Stickers[sticker]:apply(self, false)
         SMODS.enh_cache:write(self, nil)
+        SMODS.calculate_context({remove_sticker = true, other_card = self, sticker = sticker})
     end
 end
 


### PR DESCRIPTION
Allows better functionality when applying and removing stickers. Runs two new contexts `apply_sticker = true` and `remove_sticker = true` along with the card and sticker. 
- `apply_sticker` context also differentiates between stickers applied to cards by the game (i.e. higher stake shops and challenges) and stickers applied by modded objects. Done via global value `SMODS.sticker_from_game`

Also overrides vanilla sticker applying functions (e.g. Card:set_eternal) to use SMODS funcs instead to allow for backwards compatibility

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
