### PR TITLE
no_collection items in collection_pool & card_collection_UIBox

### DIFF
--- a/src/ui.lua
+++ b/src/ui.lua
@@ -1888,8 +1888,9 @@ SMODS.card_collection_UIBox = function(_pool, rows, args)
     args.w_mod = args.w_mod or 1
     args.h_mod = args.h_mod or 1
     args.card_scale = args.card_scale or 1
+    args.show_hidden = args.show_hidden or false
     local deck_tables = {}
-    local pool = SMODS.collection_pool(_pool)
+    local pool = SMODS.collection_pool(_pool, args.show_hidden)
 
     G.your_collection = {}
     local cards_per_page = 0

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -1088,13 +1088,13 @@ function SMODS.never_scores(card)
     end
 end
 
-SMODS.collection_pool = function(_base_pool)
+SMODS.collection_pool = function(_base_pool, show_no_collection)
     local pool = {}
     if type(_base_pool) ~= 'table' then return pool end
     local is_array = _base_pool[1]
     local ipairs = is_array and ipairs or pairs
     for _, v in ipairs(_base_pool) do
-        if (not G.ACTIVE_MOD_UI or v.mod == G.ACTIVE_MOD_UI) and not v.no_collection then
+        if (not G.ACTIVE_MOD_UI or v.mod == G.ACTIVE_MOD_UI) and (show_no_collection or not v.no_collection) then
             pool[#pool+1] = v
         end
     end


### PR DESCRIPTION
SMODS.card_collection_UIBox & SMODS.collection_pool now have an argument option to show/gather items that use no_collection.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
