### PR TITLE
Card.selectable_from_pack null check

### DIFF
--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2310,12 +2310,12 @@ G.FUNCS.can_select_from_booster = function(e)
 
 function Card.selectable_from_pack(card, pack)
     if card.config.center.select_card then return card.config.center.select_card end
-    if pack.select_exclusions then
+    if pack and pack.select_exclusions then
         for _, key in ipairs(pack.select_exclusions) do
             if key == card.config.center_key then return false end
         end
     end
-    if pack.select_card then
+    if pack and pack.select_card then
         if type(pack.select_card) == 'table' then
             if pack.select_card[card.ability.set] then return pack.select_card[card.ability.set] else return false end
         end


### PR DESCRIPTION
I'm not sure exactly what error I had gotten that this fixes (It may have been a voucher pack from the Betmma Mods suite crashing?), but this _does_ fix it.



## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [X] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [X] I didn't modify api's or I've updated lsp definitions.
- [X] I didn't make new lovely files or all new lovely files have appropriate priority.
