### PR TITLE
add text_alignment to Scoring_Parameter

### DIFF
--- a/lovely/scoring_calculation.toml
+++ b/lovely/scoring_calculation.toml
@@ -113,14 +113,14 @@ for name, parameter in pairs(SMODS.Scoring_Parameters) do
             G.hand_text_area[name]:update(0)
             if vals.StatusText then 
                 attention_text({
-                    text =delta,
+                    text = delta,
                     scale = 0.8, 
                     hold = 1,
                     cover = G.hand_text_area[name].parent,
                     cover_colour = mix_colours(parameter.colour, col, 0.1),
                     emboss = 0.05,
                     align = 'cm',
-                    cover_align = 'cm'
+                    cover_align = parameter.text_alignment or 'cm'
                 })
             end
             if (vals[name.."_juice"] or parameter.juice_on_update) and not G.TAROT_INTERRUPT then G.hand_text_area[name]:juice_up() end

--- a/lsp_def/classes/scoring_calculation.lua
+++ b/lsp_def/classes/scoring_calculation.lua
@@ -61,6 +61,7 @@ SMODS.calculate_round_score = function(flames) end
 ---@field key string Used to reference the parameter, mod_prefix is added
 ---@field default_value number Default value of the parameter
 ---@field colour? table HEX colour
+---@field text_alignment? string Must be two letters, first indicates vertical alignment, second indicates horizontal alignment
 ---@field calculation_keys? string[] Valid return keys from calculate functions
 ---@field hands? table[] Used to add custom values for different poker hands
 ---@field modify? fun(self: SMODS.Scoring_Parameter, amount: number) Alters the value of the parameter

--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -3581,6 +3581,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
             'key',
             'default_value',
         },
+        text_alignment = "cm",
         inject = function(self)
             self.colour = self.colour or G.C.UI_MULT
             self.lick = {1, 1, 1, 1}
@@ -3625,6 +3626,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
         key = 'chips',
         default_value = 0,
         colour = G.C.UI_CHIPS,
+        text_alignment = "cr",
         calculation_keys = {'chips', 'h_chips', 'chip_mod', 'x_chips', 'xchips', 'Xchip_mod',},
         calc_effect = function(self, effect, scored_card, key, amount, from_edition)
             if not SMODS.Calculation_Controls.chips then return end
@@ -3677,6 +3679,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
         default_value = 0,
         juice_on_update = true,
         colour = G.C.UI_MULT,
+        text_alignment = "cl",
         calculation_keys = {'mult', 'h_mult', 'mult_mod','x_mult', 'Xmult', 'xmult', 'x_mult_mod', 'Xmult_mod'},
         calc_effect = function(self, effect, scored_card, key, amount, from_edition)
             if not SMODS.Calculation_Controls.mult then return end


### PR DESCRIPTION
_Should_ fix #984 by adding a `text_alignment` property to SMODS.Scoring_Parameter.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [X] I didn't modify api's or I've updated lsp definitions.
- [X] I didn't make new lovely files or all new lovely files have appropriate priority.
