### PR TITLE
Add shader patching for lovely 0.9.0+

### DIFF
--- a/lovely/shaders.toml
+++ b/lovely/shaders.toml
@@ -13,7 +13,7 @@ payload = '''
 local shader = "resources/shaders/"..filename
 local lovely_success, lovely = pcall(require, "lovely")
 if lovely_success and lovely.apply_patches then
-    assert(lovely.apply_patches(filename, love.filesystem.read(shader)))
+    shader = assert(lovely.apply_patches(filename, love.filesystem.read(shader)))
 end
 self.SHADERS[shader_name] = love.graphics.newShader(shader)
 '''

--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -3215,7 +3215,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
             local file = NFS.read(self.full_path)
             local lovely_success, lovely = pcall(require, "lovely")
             if lovely_success and lovely.apply_patches then
-                assert(lovely.apply_patches("=[SMODS " .. self.mod.id .. ' "' .. self.path .. '"]', file))
+                file = assert(lovely.apply_patches("=[SMODS " .. self.mod.id .. ' "' .. self.path .. '"]', file))
             end
             love.filesystem.write(self.key .. "-temp.fs", file)
             G.SHADERS[self.key] = love.graphics.newShader(self.key .. "-temp.fs")


### PR DESCRIPTION
This feature is reliant on the [lovely 0.9.0 apply_patches](https://github.com/ethangreen-dev/lovely-injector/pull/300) function, but does not create backwards incompatibility; 
If apply_patches does not exist, it does nothing.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
