### PR TITLE
Fix orphaned info_queue Dynatext appearing in the top left of the screen for a frame

### DIFF
--- a/lovely/ui.toml
+++ b/lovely/ui.toml
@@ -378,6 +378,22 @@ match_indent = true
 
 [[patches]]
 [patches.pattern]
+target = 'engine/node.lua'
+pattern = '''
+self.children.h_popup.states.drag.can = true
+'''
+position = "after"
+payload = '''
+-- Fixes styled info_queue names
+-- This ensures show_infotip runs just after the main hover box is created instead of being able to fall one frame after
+if ((self.children.h_popup.UIRoot.children[1] or {}).config or {}).func == "show_infotip" then
+  G.FUNCS.show_infotip(self.children.h_popup.UIRoot.children[1])
+end
+'''
+match_indent = true
+
+[[patches]]
+[patches.pattern]
 target = 'functions/UI_definitions.lua'
 pattern = '''
 {n=G.UIT.R, config={align = "tm", minh = 0.36, padding = 0.03}, nodes={{n=G.UIT.T, config={text = name, scale = 0.32, colour = G.C.UI.TEXT_LIGHT}}}},


### PR DESCRIPTION
This fixes the problem added by #839 where the stylized name appears briefly sometimes when hovering a card with an info_queue.

This seems to be caused by the `func` attribute of the node sometimes running a frame after the main description UIBox is created so the Dynatext stays orphaned for a frame. This fixes it by running `G.FUNCS.show_infotip` immediately after creating the main description popup.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
