### PR TITLE
implement CanvasSprite class

### DIFF
--- a/src/card_draw.lua
+++ b/src/card_draw.lua
@@ -353,8 +353,8 @@ SMODS.DrawStep {
     key = 'canvas_text',
     order = 45,
     func = function(self, layer)
-        if self.canvas_text then
-            for _, sprite in ipairs(self.canvas_text[1] and self.canvas_text or {self.canvas_text}) do
+        if self.children.canvas_text then
+            for _, sprite in ipairs(self.children.canvas_text[1] and self.children.canvas_text or {self.children.canvas_text}) do
                 love.graphics.push()
                 love.graphics.origin()
                 sprite.canvas:renderTo(love.graphics.clear, 0, 0, 0, 0)
@@ -497,7 +497,7 @@ SMODS.DrawStep {
 
 -- All keys in this table will not be automatically drawn with a default `draw()` call in the "others" DrawStep.
 SMODS.draw_ignore_keys = {
-    focused_ui = true, front = true, back = true, soul_parts = true, center = true, floating_sprite = true, shadow = true, use_button = true, buy_button = true, buy_and_use_button = true, debuff = true, price = true, particles = true, h_popup = true
+    focused_ui = true, front = true, back = true, soul_parts = true, center = true, floating_sprite = true, shadow = true, use_button = true, buy_button = true, buy_and_use_button = true, debuff = true, price = true, particles = true, h_popup = true, canvas_text = true
 }
 SMODS.DrawStep {
     key = 'others',


### PR DESCRIPTION
This is the beginnings of a new feature that, among other possibilities, allows for text that changes mid-game to be drawn as if it was printed on a card. Really, this is far more broad than that, and you can render *anything* to the canvas if you'd like.

My usage so far has entailed treating it like a shared sprite (similar to how seal sprites behave) and directly rendering to the canvas with `love.graphics` calls, but ideally this feature would come with some utility functions to handle the rendering for the user. That said, I'm a little stupid so I'm going to push this as a draft PR now and shamelessly let other people suggest how the utility functions should work :3 It also probably needs tweaking/adjustments/etc but I'd rather get it out now so I'm not flailing around in the dark

Demonstration, using my dice mod (the timing is wrong but the demonstration still works):
https://github.com/user-attachments/assets/1c4d4ab8-5936-488d-8d1b-b84a5139b15a
An example of how to use the CanvasSprite is in the dev branch of [the aforementioned dice mod](https://github.com/MetaNite64/High-Roller/tree/dev), primarily in the DrawStep in the main HighRoller.lua file (the CanvasSprites are created in the `inject` function that each die object has)


## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
