### PR TITLE
Overhaul SMODS.destroy_cards()

### DIFF
--- a/lovely/better_calc.toml
+++ b/lovely/better_calc.toml
@@ -1810,25 +1810,6 @@ payload = '''
         local flags = SMODS.calculate_context({joker_type_destroyed = true, card = self})
         if flags.no_destroy then self.getting_sliced = nil; return end
     end
-    if self.skip_destroy_animation then
-        G.E_MANAGER:add_event(Event({
-            func = function()
-                play_sound('tarot1')
-                self.T.r = -0.2
-                self:juice_up(0.3, 0.4)
-                self.states.drag.is = true
-                self.children.center.pinch.x = true
-                G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.3, blockable = false,
-                    func = function()
-                            G.jokers:remove_card(self)
-                            self:remove()
-                            self = nil
-                        return true; end})) 
-                return true
-            end
-        })) 
-        return
-    end
 '''
 [[patches]]
 [patches.pattern]
@@ -1842,25 +1823,6 @@ payload = '''
     if self.getting_sliced and not (self.ability.set == 'Default' or self.ability.set == 'Enhanced') then
         local flags = SMODS.calculate_context({joker_type_destroyed = true, card = self, shatters = true})
         if flags.no_destroy then self.getting_sliced = nil; return end
-    end
-    if self.skip_destroy_animation then
-        G.E_MANAGER:add_event(Event({
-            func = function()
-                play_sound('tarot1')
-                self.T.r = -0.2
-                self:juice_up(0.3, 0.4)
-                self.states.drag.is = true
-                self.children.center.pinch.x = true
-                G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.3, blockable = false,
-                    func = function()
-                            G.jokers:remove_card(self)
-                            self:remove()
-                            self = nil
-                        return true; end})) 
-                return true
-            end
-        })) 
-        return
     end
 '''
 

--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -638,10 +638,24 @@ function SMODS.localize_box(lines, args) end
 function SMODS.get_multi_boxes(multi_box) end
 
 ---@param cards Card|Card[]
----@param bypass_eternal boolean?
----@param immediate boolean?
---- Destroys the cards passed to the function, handling calculation events that need to happen
-function SMODS.destroy_cards(cards, bypass_eternal, immediate) end
+---@param args? {bypass_eternal?: boolean, immediate?: boolean, pinch_anim?: boolean, delay?: number, no_run?: false}
+---@return {destroyed: Card[]}
+--- Destroys the cards passed to the function, handling calculation events that need to happen.
+--- Returns list of cards successfully destroyed in `result.destroyed`.
+function SMODS.destroy_cards(cards, args) end
+---@param cards Card|Card[]
+---@param args? {bypass_eternal?: boolean, immediate?: boolean, pinch_anim?: boolean, delay?: number, no_run: true}
+---@return {destroyed: Card[], run_destroy: (fun(): nil), run_calc: (fun(): nil)}
+--- When `args.no_run` is true, doesn't run anything; returns functions
+--- `result.run_destroy` and `result.run_calc` that you can run yourself
+function SMODS.destroy_cards(cards, args) end
+-- Old signature
+---@param cards Card|Card[]
+---@param bypass_eternal? boolean
+---@param immediate? boolean
+---@param pinch_anim? boolean
+---@return {destroyed: Card[], run_destroy?: (fun(): nil), run_calc?: (fun(): nil)}
+function SMODS.destroy_cards(cards, bypass_eternal, immediate, pinch_anim) end
 
 ---@param hand_space number
 --- Used to draw cards to hand outside of the normal card draw

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2547,16 +2547,38 @@ function SMODS.info_queue_desc_from_rows(desc_nodes, empty, maxw)
   }}
 end
 
-function SMODS.destroy_cards(cards, bypass_eternal, immediate, skip_anim)
+-- Private helper function, taken from vanilla Seltzer/etc. consumed animation
+-- For SMODS.destroy_cards only.
+function SMODS.pinch_anim(card)
+    play_sound('tarot1')
+    card.T.r = -0.2
+    card:juice_up(0.3, 0.4)
+    card.states.drag.is = true
+    card.children.center.pinch.x = true
+    G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.3, blockable = false,
+        func = function()
+            G.jokers:remove_card(card)
+            card:remove()
+            card = nil
+            return true; end}))
+end
+
+function SMODS.destroy_cards(cards, bypass_eternal, immediate, pinch_anim)
     if not cards[1] then
         if Object.is(cards, Card) then
             cards = {cards}
-        else
-            return
         end
     end
+    local args = type(bypass_eternal) == 'table' and bypass_eternal or {}
+    if type(bypass_eternal) == 'table' then
+        bypass_eternal, immediate, pinch_anim =
+            bypass_eternal.bypass_eternal, bypass_eternal.immediate, bypass_eternal.pinch_anim
+    end
+    local args_delay = args.delay
+
     local glass_shattered = {}
     local playing_cards = {}
+    local destroyed, destroyed2 = {}, {}
     for _, card in ipairs(cards) do
         if bypass_eternal or not SMODS.is_eternal(card, {destroy_cards = true}) then
             card.getting_sliced = true
@@ -2569,34 +2591,59 @@ function SMODS.destroy_cards(cards, bypass_eternal, immediate, skip_anim)
             if card.base.name then
                 playing_cards[#playing_cards + 1] = card
             end
-            card.skip_destroy_animation = skip_anim
+            destroyed[#destroyed + 1] = card
+            destroyed2[#destroyed2 + 1] = card
         end
     end
-    
-    check_for_unlock{type = 'shatter', shattered = glass_shattered}
-    
-    if next(playing_cards) then SMODS.calculate_context({scoring_hand = cards, remove_playing_cards = true, removed = playing_cards}) end
 
-    for i = 1, #cards do
-        if immediate or skip_anim then
-            if cards[i].shattered then
-                cards[i]:shatter()
-            elseif cards[i].destroyed then
-                cards[i]:start_dissolve()
+    check_for_unlock{type = 'shatter', shattered = glass_shattered}
+
+    local function destroy_f()
+        for i = 1, #destroyed do
+            if pinch_anim then
+                SMODS.pinch_anim(destroyed[i])
+            else
+                if destroyed[i].shattered then
+                    destroyed[i]:shatter()
+                elseif destroyed[i].destroyed then
+                    destroyed[i]:start_dissolve(nil, i ~= 1)
+                end
             end
+        end
+        return true
+    end
+
+    local function run_destroy()
+        if immediate then
+            destroy_f()
+            -- args_delay has no effect
         else
             G.E_MANAGER:add_event(Event({
-                func = function()
-                    if cards[i].shattered then
-                        cards[i]:shatter()
-                    elseif cards[i].destroyed then
-                        cards[i]:start_dissolve()
-                    end
-                    return true
-                end
+                func = destroy_f
             }))
+            if args_delay then delay(args_delay) end
         end
     end
+
+    local function run_calc()
+        if next(playing_cards) then
+            SMODS.calculate_context({scoring_hand = cards, remove_playing_cards = true, removed = playing_cards})
+        end
+    end
+
+    if not args.no_run then
+        run_destroy()
+        run_calc()
+    end
+
+    local result = {
+        destroyed = destroyed2, -- return a copy to avoid weirdness with closures
+    }
+    if args.no_run then
+        result.run_destroy = run_destroy
+        result.run_calc = run_calc
+    end
+    return result
 end
 
 -- Hand Limit API


### PR DESCRIPTION
- Returns destroyed cards in `.destroyed`
- uses a table for arguments
- skip_destroy_animation is refactored out
- rename `skip_anim` arg. to `pinch_anim`, this makes more sense as we are using a specific animation
- `args.delay` inserts a delay between destroy animation and calc. Vanilla Hanged Man uses 0.3. In the general case, this makes the result look a lot better
- `args.no_run` allows the user to use the logic of this function however they want (see Immolate for use case)

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
