### PR TITLE
Fix crash if a modded stake has multiple applied stakes

### DIFF
--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -531,7 +531,7 @@ function SMODS.applied_stakes_UI(i, stake_desc_rows, num_added)
 							_full_desc},}}
 				end
 				num_added.val = num_added.val + 1
-				num_added.val = SMODS.applied_stakes_UI(G.P_STAKES[v].stake_level, stake_desc_rows,
+				SMODS.applied_stakes_UI(G.P_STAKES[v].stake_level, stake_desc_rows,
 					num_added)
 			end
 		end


### PR DESCRIPTION
`SMODS.applied_stakes_UI()` has never returned anything, so attempting to assign its result to `num_added.val` resulted in niling it out and crashing if the game looked at it again in the same loop. Which conveniently only happened if people gave their stakes a branch-and-bottleneck structure that I guess nobody ever thought was worth the effort. 

It's fucky in some other ways but that's the one I think I understand enough to fix.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
