### PR TITLE
Add context.blueprint_copier

### DIFF
--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2098,14 +2098,17 @@ function SMODS.blueprint_effect(copier, copied_card, context)
     local old_context_blueprint_card = context.blueprint_card
     context.blueprint_card = context.blueprint_card or copier
 
-    local old_context_blueprint_copier = context.blueprint_copier
-    context.blueprint_copier = copier
+    context.blueprint_copiers_stack = context.blueprint_copiers_stack or {}
+    context.blueprint_copiers_stack[#context.blueprint_copiers_stack + 1] = copier
+    context.blueprint_copier = context.blueprint_copiers_stack[#context.blueprint_copiers_stack]
 
     local eff_card = context.blueprint_card
     local other_joker_ret = copied_card:calculate_joker(context)
+
     context.blueprint = old_context_blueprint
     context.blueprint_card = old_context_blueprint_card
-    context.blueprint_copier = old_context_blueprint_copier
+    table.remove(context.blueprint_copiers_stack, #context.blueprint_copiers_stack)
+    context.blueprint_copier = context.blueprint_copiers_stack[#context.blueprint_copiers_stack]
 
     if other_joker_ret then
         other_joker_ret.card = eff_card


### PR DESCRIPTION
This PR adds `context.blueprint_copier`, which contains the Joker in the `copier` argument of `SMODS.blueprint_effect`. This also lovely patches Blueprint and Brainstorm to use `SMODS.blueprint_effect` so they also use this context.
This is useful for multi-blueprint effects trying to avoid infinite loop interactions, as they can check if they're attempting to copy `context.blueprint_copier` and not copy the card if they are. Two-way blueprint effects are quite common, so many of them would find this useful.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [X] I didn't make new lovely files or all new lovely files have appropriate priority.
