### PR TITLE
Add optional automatic generation for atlases in centers

### DIFF
--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -33,18 +33,18 @@ function loadAPIs()
         -- also updates o.prefix_config
         SMODS.add_prefixes(self, o)
         if o:check_duplicate_key() then return end
-        if (self.default_size or (self.px and self.py) or self.size) and self.path then
+        if self ~= SMODS.Atlas and (o.default_size or (o.px and o.py) or o.size) and o.path then
             key_unique = key_unique + 1;
-            local size = self.size or self.default_size -- if a mod wants to override
-            local px, py = self.px or size.px, self.py or size.py
+            local size = o.size or o.default_size -- if a mod wants to override
+            local px, py = o.px or size.px, o.py or size.py
             SMODS.Atlas {
-                key = "__autogen_atlas_" .. self.key .. "_" .. key_unique,
-                path = self.path,
+                key = "__autogen_atlas_" .. o.key .. "_" .. key_unique,
+                path = o.path,
                 px = px,
                 py = py,
                 raw_key = true,
             }
-            self.atlas = "__autogen_atlas_" .. self.key .. "_" .. key_unique
+            o.atlas = "__autogen_atlas_" .. o.key .. "_" .. key_unique
         end
         o:register()
         return o


### PR DESCRIPTION
This PR allows you to write code like the following:

```lua
SMODS.Joker { --or any other center
    key = "my_joker",
    path = "my_joker_image.png",
}
```
omitting the `SMODS.Atlas` entirely. The above code is equivalent to this:
```lua
SMODS.Atlas {
    key = "my_joker_atlas",
    path = "my_joker_image.png",
    px = 71,
    py = 95
}

SMODS.Joker { 
    key = "my_joker",
    atlas = "my_joker_atlas"
}
```

SMODS creates an automatically generated atlas pointing at `assets/xx/my_joker.png`. This is intended to be used for atlases that contain an image for just one center. As such, a custom `pos` is not supported (but `soul_pos` is).

`SMODS.Center.register` handles the atlas generation, but `default_size` (which is what informs `SMODS.Center` what should be filled in for `px` and `py`) is optional for extending classes (despite all 7 centers using 71x95 by default). This is because some mods extend `SMODS.Center` and have a different default size (take `CardSleeve`, which is 73x95).

Setting `size` as a parameter overrides `default_size`, and setting `px` and `py` individually also overrides the size used. Other than that, you can't use other parameters for `SMODS.Atlas` in `SMODS.Center`s.

Encouraging mods to not have monolith asset files is nice, mainly for collaborative purposes. Conflicts in asset files are not easy to resolve, and often require a lot of manual labor. When multiple people are working on the same mod at once, having one file per card eliminates the risk of needing to do all this tedious work. 

Also: I'm not sure how best to describe this on the wiki, should there be a note in `SMODS.Atlas` stating you can do this? I'm sure the `path` parameter should be described on the individual `SMODS.Center` pages in some way.


## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
