### PR TITLE
Streamline G.viewed_stake logic

### DIFF
--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -572,7 +572,11 @@ function G.UIDEF.stake_option(_type)
 	local stake_options = {}
 	local curr_options = {}
 	local deck_usage = G.PROFILES[G.SETTINGS.profile].deck_usage[G.GAME.viewed_back.effect.center.key]
-	G.viewed_stake = deck_usage and ((deck_usage.wins_by_key[SMODS.stake_from_index(G.viewed_stake)] or G.PROFILES[G.SETTINGS.profile].all_unlocked) and G.viewed_stake or (get_deck_win_stake(G.GAME.viewed_back.effect.center.key) + 1)) or 1
+	local is_all_unlocked = G.PROFILES[G.SETTINGS.profile].all_unlocked
+	local is_stake_available = SMODS.check_applied_stakes(G.P_CENTER_POOLS.Stake[G.viewed_stake], deck_usage or {wins_by_key = {}})
+	G.viewed_stake = (is_all_unlocked or is_stake_available) and G.viewed_stake
+		or (deck_usage and (math.min(get_deck_win_stake(G.GAME.viewed_back.effect.center.key) + 1, #G.P_CENTER_POOLS.Stake)))
+		or 1
 	for i=1, #G.P_CENTER_POOLS.Stake do
 		if G.PROFILES[G.SETTINGS.profile].all_unlocked or SMODS.check_applied_stakes(G.P_CENTER_POOLS.Stake[i], deck_usage or {wins_by_key = {}}) then
 			stake_options[#stake_options + 1] = i


### PR DESCRIPTION
The logic for `G.viewed_stake` can be streamlined into the following 4 cases:

1. If the profile has everything unlocked (`all_unlocked`), nothing else matters and any stake can be viewed.
2. If the stake is available, it can be viewed as well. According to the logic of `SMODS.check_applied_stakes`, a stake is considered available if it exists without depending on any applied stakes, or if it has applied stakes, all of them have to be beaten beforehand.
3. If the stake is not available, the deck usage data is checked for the most often won stake, and the stake after that is chosen.
4. If all else fails, displays the first stake overall.

An additional check to see if a stake is unlocked could be done, but I have failed to catch any edge cases after repeated manual tests. Therefore, a check for applied stakes should suffice.

This should also work for multiple stakes that could be available right from the start of a new profile (e.g. several variations of the White Stake).

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
