### PR TITLE
calc_scaling operation override

### DIFF
--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2872,6 +2872,7 @@ function SMODS.scale_card(card, args)
                 if ret then
                     if ret.override_value and not args.block_overrides.value then initial = ret.override_value.value; SMODS.calculate_effect(ret.override_value, _card) end
                     if ret.override_scalar_value and not args.block_overrides.scalar then scalar_value = ret.override_scalar_value.value; SMODS.calculate_effect(ret.override_scalar_value, _card) end
+                    if ret.override_operation and not args.block_overrides.operation then args.operation = ret.override_operation.value end 
                     if ret.override_message and not args.block_overrides.message then scaling_message = SMODS.merge_defaults(ret.override_message, scaling_message) end
                     if ret.post then ret.post.source = _card; scaling_responses[#scaling_responses + 1] = ret.post end
                     SMODS.calculate_effect(ret, _card)


### PR DESCRIPTION
allows cards in calc_scaling to provide an override operation (e.g. making all other scaling jokers scale multiplicitively)

sorry for no lsp defs i didnt see anything relating to the arguments of calc_scaling's return values

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [X] I didn't make new lovely files or all new lovely files have appropriate priority.
