### PR TITLE
Fix replace sound infinite loop

### DIFF
--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -276,7 +276,6 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
     -------------------------------------------------------------------------------------------------
     ----- API CODE GameObject.Font
     -------------------------------------------------------------------------------------------------
-
     SMODS.Fonts = {}
     SMODS.Font = SMODS.GameObject:extend {
         obj_table = SMODS.Fonts,
@@ -311,7 +310,6 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
                 ('Failed to collect file data for Font %s'):format(self.key))
             self.FONT = assert(love.graphics.newFont(file_data, self.render_scale or G.TILESIZE),
                 ('Failed to initialize font data for Font %s'):format(self.key))
-
         end,
         process_loc_text = function() end,
     }
@@ -319,7 +317,6 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
     -------------------------------------------------------------------------------------------------
     ----- API CODE GameObject.DynaTextEffect
     -------------------------------------------------------------------------------------------------
-
     SMODS.DynaTextEffects = {}
     SMODS.DynaTextEffect = SMODS.GameObject:extend {
         obj_table = SMODS.DynaTextEffects,
@@ -1176,7 +1173,6 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
             end
 
             localize(target)
-
             if res.main_end then
                 desc_nodes[#desc_nodes + 1] = res.main_end
             end
@@ -2042,7 +2038,6 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
                 else
                     table.insert(self.obj_buffer, self.key)
                 end
-
             end
         end,
         process_loc_text = function(self)
@@ -3603,7 +3598,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
         end,
         flame_handler = function(self)
             return {
-                id = 'flame_'..self.key,
+                id = 'flame_'..self.key, 
                 arg_tab = self.key..'_flames',
                 colour = self.colour,
                 accent = self.lick
@@ -3621,7 +3616,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
             if amount then
                 if effect.card and effect.card ~= scored_card then juice_card(effect.card) end
                 self:modify(amount)
-                card_eval_status_text(scored_card, 'extra', nil, percent, nil,
+                card_eval_status_text(scored_card, 'extra', nil, percent, nil, 
                     {message = localize{type = 'variable', key = amount > 0 and 'a_chips' or 'a_chips_minus', vars = {amount}}, colour = self.colour})
                 return true
             end
@@ -3798,7 +3793,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
         key = "multiply",
         func = function(self, chips, mult, flames) return chips * mult end,
         text = 'X'
-    }
+    } 
 
     SMODS.Scoring_Calculation {
         key = "add",


### PR DESCRIPTION
The hook for play_sound to utilize SMODS.Sound.replace_sounds was incorrectly calling itself, rather than the hook ref, resulting in an infinite loop. People must not use this feature a lot since seemingly the rest of the code was written a year and a half ago and this was never caught.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
