### PR TITLE
Add Poker Hand `key` to G.GAME.hands

### DIFF
--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -1492,7 +1492,7 @@ function Game:init_game_object()
             -- are fine.
             -- In fact, the check should just warn you if you have a key that
             -- can't be serialized.
-			if type(v) == 'number' or type(v) == 'boolean' or k == 'example' then
+			if type(v) == 'number' or type(v) == 'boolean' or k == 'example' or k == 'key' then
 				t.hands[key][k] = v
 			end
 		end


### PR DESCRIPTION
See title. A case that has come up for this is finding the keys in ScoringParameter's `level_up_hand` since it receives the G.GAME.hands table but it would probably be nicer to have this for general use instead of solving that particular issue.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
