### PR TITLE
Fix crash on unlocking any vanilla item

### DIFF
--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -1909,7 +1909,7 @@ function create_UIBox_notify_alert(_achievement, _type)
     end
 
   if SMODS.Achievements[_achievement] then _c = SMODS.Achievements[_achievement]; _atlas = SMODS.get_atlas(_c.atlas) end
-  local t_s =  SMODS.create_sprite(0,0,1.5*(_atlas.px/_atlas.py),1.5, _atlas.key,  _c and _c.pos or {x=3, y=0})
+  local t_s =  SMODS.create_sprite(0,0,1.5*(_atlas.px/_atlas.py),1.5, _atlas.key or _atlas.name,  _c and _c.pos or {x=3, y=0})
 
   t_s.states.drag.can = false
   t_s.states.hover.can = false


### PR DESCRIPTION
Did you know: Vanilla atlases do not have a `key` value, only a `name`?


## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
