### PR TITLE
Add default values for scaling functions

### DIFF
--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2916,10 +2916,14 @@ function SMODS.scale_card(card, args)
 end
 
 function SMODS.additive_scaling(ref_table, ref_value, initial, modifier)
+    initial  = initial  or 0
+    modifier = modifier or 0
     ref_table[ref_value] = initial + modifier
 end
 
 function SMODS.multiplicative_scaling(ref_table, ref_value, initial, modifier)
+    initial  = initial  or 1
+    modifier = modifier or 1
     ref_table[ref_value] = initial * modifier
 end
 


### PR DESCRIPTION
bad fix to nullpointer in scaling function
I found an npe when playing equal chances deck after playing some cards. This is a messy fix to only that issue, i have not checked why are the modifiers 0. This is probably a bad fix but if someone needs it or finds the same issue its here and its fast.


## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [X] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [X] I didn't modify api's or I've updated lsp definitions.
- [X] I didn't make new lovely files or all new lovely files have appropriate priority.
