### PR TITLE
consistently define "added_to_deck" for playing cards

### DIFF
--- a/lovely/fixes.toml
+++ b/lovely/fixes.toml
@@ -829,3 +829,15 @@ if control.g then _card:set_seal(control.g, true, true) end
 payload = '''
 _card:add_to_deck()
 '''
+## Add cards created by create_playing_card to deck
+[[patches]]
+[patches.pattern]
+target = 'functions/common_events.lua'
+match_indent = true
+position = 'after'
+pattern = '''
+local card = Card(_area.T.x, _area.T.y, G.CARD_W, G.CARD_H, card_init.front, card_init.center, {playing_card = G.playing_card})
+'''
+payload = '''
+card:add_to_deck()
+'''


### PR DESCRIPTION
`Card:add_to_deck` is not called on any initial cards in your deck, nor any cards created by `create_playing_card` (used by cards such as the Certificate Joker or the Incantation Spectral), but it _is_ called for _all_ other methods of adding cards to your deck (such as taking cards from Standard Packs, or creating copies with DNA or Cryptid). this means that currently, `added_to_deck` is useless for being able to identify whether a card is in your deck or not, as it will be arbitrarily false for most (but not all) cards in your deck

this PR fixes this by calling `Card:add_to_deck` on all cards created by `card_from_control` and `create_playing_card`, making it consistent with all other methods of adding cards to your deck. from my testing, this has no gameplay consequences, and only serves to make `added_to_deck` a reliable method of identifying whether a card is currently in your deck or not

disclaimer that this is a vanilla bug, not one introduced by SMODS; i'm unsure whether fixing vanilla issues in this manner in order to make modding more convenient is something that is of interest, and so rejecting this PR on those grounds would be reasonable if such a change is undesired

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
