### PR TITLE
log when card=nil is triggered

### DIFF
--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2792,7 +2792,7 @@ function SMODS.is_eternal(card, trigger)
     SMODS.calculate_context({check_eternal = true, other_card = card, trigger = trigger, no_blueprint = true,}, calc_return)
     for _,eff in pairs(calc_return) do
         for _,tab in pairs(eff) do
-            if tab.no_destroy then 
+            if tab.no_destroy then  --Reuses key from context.joker_type_destroyed
                 ret = true
                 if type(tab.no_destroy) == 'table' then
                     if tab.no_destroy.override_compat then ovr_compat = true end


### PR DESCRIPTION
## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.

_disclaimer_
**I don't know lua like at all(I did all of this by searching a bunch of stuff on the internet) and this is somewhat of a personal discovery , I had to make it work for myself so I can advance in my run(since it was causing a crash)**

**what  I will say here is  probably going to sound kinda stupid or maybe too obvious... if there is a reason why such thing wasn't done before, either because I wasn't ... smart enough.. to find the actual reason or there is some sort of intended use case by the smods, by all means, do tell me**

This PR want to add a non-invasive logging to `SMODS.is_eternal()` to diagnose
rare crashes originating from nil card objects being passed into SMODS
scoring/context logic.



The crash manifests as:

    [SMODS _ "src/utils.lua"]:2778: attempt to index local 'card' (a nil value)

(it can happen in a lot of other places, this is just an example)

this can occur during extreme late-game scenarios or in some rare cases early on, with multiple
mods active (e.g., Cryptid + Talisman), but the source of the nil is still
unknown. SMODS sits at the shared context layer, so this is the correct place
to record diagnostic info(I think)


### Performance impact

Negligible (one nil-check).
Measured impact : 2–8 ns per call.
in a 2M-calculation hands → ~0.01 ms overhead.


### where is the rest or what is the purpose?
an example:
1. A joker or voucher creates a delayed scoring effect.
2. Another mod replaces or destroys that card before SMODS evaluates the effect.
3. SMODS receives the effect entry but the corresponding card object is now nil.
4. `is_eternal()` attempts to read `card.ability.*`, causing:

       attempt to index local 'card' (a nil value)
       

I was able to get rid of the crash caused by this in sort of a ... brute force method .... by basically blocking card=nil for is_eternal at runtime
I'm adding this debug clause , so it's a bit more clear to find out which, if any, other mods are cuasing such things.. who knows? maybe it is useful for some other dev?

**(again, I don't know lua or toml for that matter, kindly do excuse me)**

if anyone is interested, below is what I did for personal use(it can be adapted to other places if it is actually applicable and worthwhile):

at Mods/zzz_safety_patch/lovely.toml:
                                               
```
[manifest]
version = "0.0.2"
dump_lua = true
priority = 999

[[patches]]
[patches.pattern]
target = "SMODS/_/src/utils.lua"
pattern = "function SMODS.is_eternal(card, trigger)"
position = "after"
match_indent = true
payload = '''
    -- guard against nil card being passed from other mods
    if not card then
        return false
    end
'''

```

### additional notes:
hopefully.. it is table and tbl... right?
in the code I mean


