### PR TITLE
add 'retrigger_joker_cashout' feature

### DIFF
--- a/lovely/better_calc.toml
+++ b/lovely/better_calc.toml
@@ -760,16 +760,28 @@ position = 'at'
 match_indent = true
 payload = '''
 local i = 0
+local function add_joker_row(ret, _card)
+    i = i+1
+    add_round_eval_row({dollars = ret, bonus = true, name='joker'..i, pitch = pitch, card = _card})
+    pitch = pitch + 0.06
+    dollars = dollars + ret
+end
 for _, area in ipairs(SMODS.get_card_areas('jokers')) do
-        for _, _card in ipairs(area.cards) do
+    for _, _card in ipairs(area.cards) do
         local ret = _card:calculate_dollar_bonus()
 
         -- TARGET: calc_dollar_bonus per card
         if ret then
-            i = i+1
-            add_round_eval_row({dollars = ret, bonus = true, name='joker'..i, pitch = pitch, card = _card})
-            pitch = pitch + 0.06
-            dollars = dollars + ret
+            add_joker_row(ret, _card)
+            if SMODS.optional_features.retrigger_joker_cashout then
+                local retriggers = SMODS.calculate_retriggers(_card, {cashout_retrigger = true}, ret)
+                for _,rep in ipairs(retriggers) do
+                    for _=1,rep.repetitions do
+                        SMODS.calculate_effect(rep)
+                        add_joker_row(ret, _card)
+                    end
+                end
+            end
         end
     end
 end

--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -123,6 +123,7 @@ function SMODS.merge_lists(...) end
 ---@class SMODS.optional_features: table
 ---@field quantum_enhancements? boolean Enables "Quantum Enhancement" contexts. Cards can count as having multiple enhancements at once.
 ---@field retrigger_joker? boolean Enables "Joker Retrigger" contexts. Jokers can be retriggered by other jokers or effects.
+---@field retrigger_joker_cashout? boolean If `retrigger_joker` is also enabled, allows Jokers that return end-of-round cash to be retriggered as well.
 ---@field post_trigger? boolean Enables "Post Trigger" contexts. Allows calculating effects after a Joker has been calculated.
 ---@field cardareas? SMODS.optional_features.cardareas Enables additional CardArea calculation.
 


### PR DESCRIPTION
allows jokers that give end-of-round cash to be retriggered by other jokers. locked behind a new optional feature, as to not immediately change behavior of existing mods

the `retrigger_joker` context will receive a `cashout_retrigger` argument when this is being performed; if mods want to explicitly prevent this feature, they can check `and not context.cashout_retrigger` in their retrigger joker's code.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
  - to-do: update [available features](https://github.com/Steamodded/smods/wiki/The-Mod-Object#available-features) (can do this myself if this gets merged)
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
