### PR TITLE
add 'set_cost' and 'set_sell_cost' contexts

### DIFF
--- a/lovely/better_calc.toml
+++ b/lovely/better_calc.toml
@@ -1938,12 +1938,12 @@ self.sell_cost = math.max(1, math.floor(self.cost/2)) + (self.ability.extra_valu
 '''
 payload = '''
 if not loading then
-    local cost_flags = SMODS.calculate_context({set_cost = true, card = self}) or {}
+    local cost_flags = SMODS.calculate_context({set_cost = true, cost = self.cost, card = self}) or {}
     if cost_flags.cost then self.cost = cost_flags.cost end
 end
 self.sell_cost = math.max(1, math.floor(self.cost/2)) + (self.ability.extra_value or 0)
 if not loading then
-    local sell_flags = SMODS.calculate_context({set_sell_cost = true, card = self}) or {}
+    local sell_flags = SMODS.calculate_context({set_sell_cost = true, sell_cost = self.sell_cost, card = self}) or {}
     if sell_flags.sell_cost then self.sell_cost = sell_flags.sell_cost end
 end
 '''

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -1820,6 +1820,8 @@ function SMODS.update_context_flags(context, flags)
     if flags.numerator then context.numerator = flags.numerator end
     if flags.denominator then context.denominator = flags.denominator end
     if flags.cards_to_draw then context.amount = flags.cards_to_draw end
+    if flags.cost then context.cost = flags.cost end
+    if flags.sell_cost then context.sell_cost = flags.sell_cost end
     if flags.saved then context.game_over = false end
     if flags.modify then
         -- insert general modified value updating here


### PR DESCRIPTION
these contexts can be used to create effects that alter the cost and sell value of cards dynamically. needs to be 2 contexts, so that the original sell value can be based on the new cost, while also allowing new sell values to be based on the original sell value. 'tis a little ugly (and will be mildly annoying to document in a concise way), but it's the best way i could find to do it and make it sufficiently flexible

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
  - contexts need to be documented later
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
