### PR TITLE
Fix a memory leak that occurs when quickly switching menus/tabs that contain text inputs

### DIFF
--- a/lovely/ui_elements.toml
+++ b/lovely/ui_elements.toml
@@ -96,8 +96,6 @@ position = 'at'
 payload = '''if G.CONTROLLER.text_input_hook and G.CONTROLLER.text_input_id == e.config.id:sub(1,string.len(G.CONTROLLER.text_input_id)) then'''
 match_indent = true
 
-
-
 # TRANSPOSE_TEXT_INPUT()
 [[patches]]
 [patches.pattern]


### PR DESCRIPTION
The fact that I discovered this is a miracle.

The `G.FUNCS.flash` callback, on the first frame of a new UIBox containing a text input, immediately calls the UIBox to recalculate because its width is set to 0.1 on creation, and it wants to default to 0 when out of focus. When quickly switching between tabs that both have text inputs, the recalculate seemingly causes a memory leak by preventing the old tab from being flagged for garbage collection after it's replaced.

Huh.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
