### PR TITLE
`SMODS.Back.initial_deck`

### DIFF
--- a/lovely/playing_card.toml
+++ b/lovely/playing_card.toml
@@ -52,7 +52,7 @@ payload = '''
 if self.GAME.selected_back_key.initial_deck then
     local _id = self.GAME.selected_back_key.initial_deck
     local _exclude = _id.exclude
-    for i,_tab in ipairs({_id.Ranks, _id.Suits}) do
+    for i,_tab in ipairs({_id.Ranks or _id.exclude and {} or SMODS.Rank.obj_buffer, _id.Suits}) do
         if _tab ~= nil then
             local _create = not not _exclude
             for _,_v in ipairs(_tab) do


### PR DESCRIPTION
Adds a parameter to SMODS.Back to allow decks to define what ranks and suits should be included at the start of a run
`initial_deck.Ranks` is a list of the keys of ranks to include
`initial_deck.Suits` is a list of the keys of suits to include
`initial_deck.exclude` is a booleen that causes ranks and suits to be excluded when true


## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
