### PR TITLE
Minor pseudorandom_element LSP fix

### DIFF
--- a/lsp_def/vanilla.lua
+++ b/lsp_def/vanilla.lua
@@ -245,8 +245,8 @@ function get_straight(hand, min_length, skip, wrap) end
 function tally_sprite(pos, value, tooltip, suit) end
 
 ---@param _t table
----@param seed string
----@param args table|{starting_deck?: boolean, in_pool?: fun(v: any, args: table)}
+---@param seed string|number
+---@param args? table|{starting_deck?: boolean, in_pool?: fun(v: any, args: table):boolean}
 ---@return any
 ---@return string|number key
 --- Sets the seed to `seed` and randomly selects an element within `_t`.


### PR DESCRIPTION
Adds return type to `args.in_pool` and number type for the seed (for `pseudoseed`) and made args optional.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
