### PR TITLE
Add context for altering Poker Hands

### DIFF
--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -111,6 +111,11 @@
 ---@field old? string Key of the old center after a card's ability is set.
 ---@field new? string Key of the new center after a card's ability is set.
 ---@field unchanged? boolean `true` if the key of the old center is the same as the new one after a card's ability is set.
+---@field poker_hand_changed? boolean `true` if a poker hand's values are being altered.
+---@field old_level? integer Level of the poker hand before the alteration, if it was changed.
+---@field new_level? integer Level of the poker hand after the alteration, if it was changed.
+---@field old_parameters? table<'chips'|'mult'|string, number> Altered scoring parameters of the poker hand before the alteration.
+---@field new_parameters? table<'chips'|'mult'|string, number> Altered scoring parameters of the poker hand after the alteration.
 
 --- Util Functions
 

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -3313,8 +3313,11 @@ function SMODS.upgrade_poker_hands(args)
     end
         
     local displayed = false
+    ---@type CalcContext
+    local context = {card = args.from, poker_hand_changed = true}
     for _, hand in ipairs(args.hands) do
         displayed = hand == SMODS.displayed_hand
+        context.scoring_name = hand
         if not instant then
             update_hand_text({sound = 'button', volume = 0.7, pitch = 0.8, delay = 0.3}, {handname=localize(hand, 'poker_hands'), level=G.GAME.hands[hand].level})
             for name, p in pairs(SMODS.Scoring_Parameters) do
@@ -3322,9 +3325,13 @@ function SMODS.upgrade_poker_hands(args)
                 update_hand_text({nopulse = nil, delay = 0}, {[name] = p.current})
             end
         end
+        context.old_parameters = {}
+        context.new_parameters = {}
         for i, parameter in ipairs(args.parameters) do
             if G.GAME.hands[hand][parameter] then
+                context.old_parameters[parameter] = G.GAME.hands[hand][parameter]
                 G.GAME.hands[hand][parameter] = args.func(G.GAME.hands[hand][parameter], hand, parameter)
+                context.new_parameters[parameter] = G.GAME.hands[hand][parameter]
                 if not instant then
                     G.E_MANAGER:add_event(Event({trigger = 'after', delay = i == 1 and 0.2 or 0.9, func = function()
                         play_sound('tarot1')
@@ -3336,7 +3343,9 @@ function SMODS.upgrade_poker_hands(args)
             end
         end
         if args.level_up then
+            context.old_level = G.GAME.hands[hand].level
             G.GAME.hands[hand].level = G.GAME.hands[hand].level + (type(args.level_up) == 'number' and args.level_up or 1)
+            context.new_level = G.GAME.hands[hand].level
             if not instant then
                 G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.9, func = function()
                     play_sound('tarot1')
@@ -3347,6 +3356,7 @@ function SMODS.upgrade_poker_hands(args)
             end
         end
         if not instant then delay(1.3) end
+        SMODS.calculate_context(context)
     end
 
     if not instant and not displayed then


### PR DESCRIPTION
Adds a new context, used when poker hands' values are changed (primarily through being leveled up). This is different than `context.using_consumable`, as it also affects other ways of leveling up hands (e.g. [Space Joker](https://balatrowiki.org/w/Space_Joker)).
```lua
if context.poker_hand_changed then
```
```lua
context.old_level, context.new_level
context.old_parameters, context.new_parameters -- only contains scoring parameters that were changed
context.scoring_name, context.card
```
## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
