### PR TITLE
fix: crash with attention_text with text as table

### DIFF
--- a/lovely/calc_returns.toml
+++ b/lovely/calc_returns.toml
@@ -8,13 +8,12 @@ priority = -10
 [patches.pattern]
 target = 'functions/UI_definitions.lua'
 match_indent = true
-position = 'at'
+position = 'before'
 pattern = '''
 {n=G.UIT.O, config={draw_layer = 1, object = DynaText({scale = args.scale, string = args.text, maxw = args.maxw, colours = {args.colour},float = true, shadow = true, silent = not args.noisy, args.scale, pop_in = 0, pop_in_rate = 6, rotate = args.rotate or nil})}},
 '''
 payload = '''
-type(args.text) == 'string' and {n=G.UIT.O, config={draw_layer = 1, object = DynaText({scale = args.scale, string = args.text, maxw = args.maxw, colours = {args.colour},float = true, shadow = true, silent = not args.noisy, args.scale, pop_in = 0, pop_in_rate = 6, rotate = args.rotate or nil})}} or
-args.text,
+type(args.text) == "table" and args.text.n and args.text or
 '''
 [[patches]]
 [patches.pattern]


### PR DESCRIPTION
`attention_text` can normally accept `text` as table, e.g. `text = { "^1.05 Mult" }`.
However the new addition turns the array of text into an UI element definition, making it incompatible with array of text.
The resulting element generated is `{ nodes = { { "^1.05 Mult" } } }`, rather than `{ nodes = { { n = G.UIT.O, ... } } }`.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
