### PR TITLE
Ignore folders with .lovelyignore when running find_self

### DIFF
--- a/src/core.lua
+++ b/src/core.lua
@@ -50,8 +50,10 @@ local function find_self(directory, target_filename, target_line, depth)
         local file_path = directory .. "/" .. filename
         local file_type = NFS.getInfo(file_path).type
         if file_type == 'directory' or file_type == 'symlink' then
-            local f = find_self(file_path, target_filename, target_line, depth+1)
-            if f then return f end
+            if not NFS.getInfo(file_path.."/.lovelyignore") then
+                local f = find_self(file_path, target_filename, target_line, depth+1)
+                if f then return f end
+            end
         elseif filename == target_filename then
             local first_line = NFS.read(file_path):match('^(.-)\n')
             if first_line == target_line then


### PR DESCRIPTION

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
