### PR TITLE
Multiple ways to allow duplicate Vouchers to spawn

### DIFF
--- a/lovely/pool.toml
+++ b/lovely/pool.toml
@@ -140,6 +140,14 @@ payload = '''elseif not (G.GAME.used_jokers[v.key] and not pool_opts.allow_dupli
 [[patches]]
 [patches.pattern]
 target = 'functions/common_events.lua'
+pattern = 'if not G.GAME.used_vouchers[v.key] then '
+match_indent = true
+position = 'at'
+payload = '''if not (G.GAME.used_vouchers[v.key] and not pool_opts.allow_duplicates and not SMODS.voucherman(v.key) then'''
+
+[[patches]]
+[patches.pattern]
+target = 'functions/common_events.lua'
 pattern = "if add and not G.GAME.banned_keys[v.key] then"
 match_indent = true
 position = 'before'

--- a/lovely/pool.toml
+++ b/lovely/pool.toml
@@ -135,7 +135,7 @@ target = 'functions/common_events.lua'
 pattern = 'elseif not (G.GAME.used_jokers[v.key] and not next(find_joker("Showman"))) and'
 match_indent = true
 position = 'at'
-payload = '''elseif not (G.GAME.used_jokers[v.key] and not pool_opts.allow_duplicates and not SMODS.showman(v.key)) and'''
+payload = '''elseif not (G.GAME.used_jokers[v.key] and not pool_opts.allow_duplicates and not SMODS.showman(v.key) and not SMODS.voucherman(v.key)) and'''
 
 [[patches]]
 [patches.pattern]

--- a/lovely/pool.toml
+++ b/lovely/pool.toml
@@ -135,7 +135,7 @@ target = 'functions/common_events.lua'
 pattern = 'elseif not (G.GAME.used_jokers[v.key] and not next(find_joker("Showman"))) and'
 match_indent = true
 position = 'at'
-payload = '''elseif not (G.GAME.used_jokers[v.key] and not pool_opts.allow_duplicates and not SMODS.showman(v.key) and not SMODS.voucherman(v.key)) and'''
+payload = '''elseif not (G.GAME.used_jokers[v.key] and not pool_opts.allow_duplicates and not SMODS.showman(v.key) and not (v.set == "Voucher" and SMODS.voucherman(v.key))) and'''
 
 [[patches]]
 [patches.pattern]

--- a/lovely/voucher.toml
+++ b/lovely/voucher.toml
@@ -1,0 +1,74 @@
+[manifest]
+version = "1.0.0"
+dump_lua = true
+priority = -4 #latest priority, since lovely dump was used as reference for patch targets.
+
+## used_vouchers entry should be a number to allow for checking voucher count easily
+# back.lua
+[[patches]]
+[patches.pattern]
+target = "back.lua"
+pattern = "G.GAME.used_vouchers[self.effect.config.voucher] = true"
+position = "at"
+payload = "G.GAME.used_vouchers[self.effect.config.voucher] = (G.GAME.used_vouchers[self.effect.config.voucher] or 0) + 1"
+match_indent = true
+
+[[patches]]
+[patches.pattern]
+target = "back.lua"
+pattern = "G.GAME.used_vouchers[v ] = true"
+position = "at"
+payload = "G.GAME.used_vouchers[v] = (G.GAME.used_vouchers[v] or 0) + 1"
+match_indent = true
+
+# card.lua
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = "G.GAME.used_vouchers[self.config.center_key] = true"
+position = "at"
+payload = "G.GAME.used_vouchers[self.config.center_key] = (G.GAME.used_vouchers[self.config.center.key] or 0) + 1"
+match_indent = true
+
+# game.lua
+[[patches]]
+[patches.pattern]
+target = "game.lua"
+pattern = "G.GAME.used_vouchers[v.id] = true"
+position = "at"
+payload = "G.GAME.used_vouchers[v.id] = (G.GAME.used_vouchers[v.id] or 0) + 1"
+match_indent = true
+
+## unlocks should count duplicate vouchers
+# common_events.lua
+[[patches]]
+[patches.pattern]
+target = "functions/common_events.lua"
+pattern = '''
+for k, v in pairs(G.GAME.used_vouchers) do
+    _v = _v + 1
+end
+'''
+position = "at"
+payload = '''
+for k, v in pairs(G.GAME.used_vouchers) do
+    _v = _v + (type(v) == "number" and v or 1)
+end
+'''
+match_indent = true
+
+[[patches]]
+[patches.pattern]
+target = "functions/common_events.lua"
+pattern = '''
+for k, v in pairs(G.GAME.used_vouchers) do
+    vouchers_redeemed = vouchers_redeemed + 1
+end
+'''
+position = "at"
+payload = '''
+for k, v in pairs(G.GAME.used_vouchers) do
+    vouchers_redeemed = vouchers_redeemed + (type(v) == "number" and v or 1)
+end
+'''
+match_indent = true

--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -769,3 +769,9 @@ function SMODS.challenge_is_unlocked(challenge, k) end
 --- be limited to specific ones, or default to using all of `G.GAME.hands` and `SMODS.Scoring_Parameters`.
 --- Use `level_up` to control whether the level of the hand is upgraded.
     function SMODS.upgrade_poker_hands(args) end
+
+---@param voucher_key string The key of the voucher being checked
+---@return boolean
+--- Similar to SMODS.showman, but works for duplicate voucher spawning.
+--- Returns `true` if duplicates of the voucher with the given key should spawn.
+function SMODS.voucherman(voucher_key) end

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2678,6 +2678,13 @@ function SMODS.showman(card_key)
     return false
 end
 
+function SMODS.voucherman(voucher_key)
+    if SMODS.create_card_allow_duplicates then
+        return true
+    end
+    return false
+end
+
 function SMODS.four_fingers(hand_type)
     if next(SMODS.find_card('j_four_fingers')) then
         return 4


### PR DESCRIPTION
Fixes `allow_duplicates = true` in `in_pool` and `SMODS.create_card` so that it works for allowing duplicate vouchers

Additionally adds a new `SMODS.voucherman(voucher_key)` function, which acts similarly to `SMODS.showman` but works for only vouchers. This is made a seperate function as to not change behaviour of existing `SMODS.showman` hooks.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
