### PR TITLE
Add SMODS.get_clean_pool

### DIFF
--- a/src/utils.lua
+++ b/src/utils.lua
@@ -3413,10 +3413,11 @@ end
 
 function SMODS.get_clean_pool(_type, _rarity, _legendary, _append)
     local pool = get_current_pool(_type, _rarity, _legendary, _append)
+    local clean_pool = {}
     for i, v in ipairs(pool) do
-        if v == 'UNAVAILABLE' then
-            pool[i] = nil
+        if v ~= 'UNAVAILABLE' then
+            table.insert(clean_pool, v)
         end
     end
-    return pool
+    return clean_pool
 end


### PR DESCRIPTION
A simple helper function that returns the current specified pool without any `'UNAVAILABLE'` values. Takes the same arguments as vanilla's `get_current_pool`

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
