### PR TITLE
[FIX] SMODS.is_eternal does not properly work for objects without a default eternal_compat value

### DIFF
--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2778,7 +2778,7 @@ function SMODS.is_eternal(card, trigger)
         end
     end
     if card.ability.eternal then ret = true end
-    if not card.config.center.eternal_compat and not ovr_compat then ret = false end
+    if card.config.center.eternal_compat == false and not ovr_compat then ret = false end
     return ret
 end
 


### PR DESCRIPTION
This is a small change that prevents SMODS.is_eternal for falsely assuming incompatibility for objects without a default `eternal_compat` value

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
