### PR TITLE
align_buttons cardarea config option

### DIFF
--- a/lovely/cardareas.toml
+++ b/lovely/cardareas.toml
@@ -15,9 +15,37 @@ G.playing_cards = {}
 set_screen_positions()
 '''
 payload = '''
+-- Add align config to existing areas that should use it
+self.jokers.config.align_buttons = true
+self.consumeables.config.align_buttons = true
+
 for _, mod in ipairs(SMODS.mod_list) do
     if mod.can_load and mod.custom_card_areas and type(mod.custom_card_areas) == "function" then
         mod.custom_card_areas(self)
     end
 end
+'''
+
+# Check area.config.align_buttons if an area should align buttons like normal
+[[patches]]
+[patches.pattern]
+target = 'card.lua'
+match_indent = true
+position = 'at'
+pattern = '''
+((self.area == G.jokers) or (self.area == G.consumeables)) and "cr" or
+'''
+payload = '''
+self.area.config.align_buttons and "cr" or
+'''
+[[patches]]
+[patches.pattern]
+target = 'card.lua'
+match_indent = true
+position = 'at'
+pattern = '''
+((self.area == G.jokers) or (self.area == G.consumeables)) and {x=x_off - 0.4,y=0} or
+'''
+payload = '''
+self.area.config.align_buttons and {x=x_off - 0.4,y=0} or
 '''


### PR DESCRIPTION
Creates an `align_buttons` cardarea config option that allows default card button alignment behavior on areas with this option enabled. This will prevent destructive patches or janky hooks that were previously required to get this behavior on custom areas.

(I also apologize for the commit history, I have no clue why it did that)

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
