### PR TITLE
Fixed Blind:calculate() args

### DIFF
--- a/src/utils.lua
+++ b/src/utils.lua
@@ -334,7 +334,7 @@ function SMODS.modify_rank(card, amount, manual_sprites)
             rank_data = SMODS.Ranks[rank_key]
         end
     end
-    
+
     return SMODS.change_base(card, nil, rank_key, manual_sprites)
 end
 
@@ -1038,7 +1038,7 @@ function SMODS.calculate_quantum_enhancements(card, effects, context)
     local old_center = card.config.center
     local old_center_key = card.config.center_key
     -- Note: For now, just trigger extra enhancements in order.
-    -- Future work: combine enhancements during 
+    -- Future work: combine enhancements during
     -- playing card scoring (ex. Mult comes before Glass because +_mult
     -- naturally comes before x_mult)
     local extra_enhancements_list = {}
@@ -1239,7 +1239,7 @@ SMODS.calculate_individual_effect = function(effect, scored_card, key, amount, f
     if (key == 'p_dollars' or key == 'dollars' or key == 'h_dollars') and amount then
         if effect.card and effect.card ~= scored_card then juice_card(effect.card) end
         SMODS.ease_dollars_calc = true
-        ease_dollars(amount)    
+        ease_dollars(amount)
         SMODS.ease_dollars_calc = nil
         if not effect.remove_default_message then
             if effect.dollar_message then
@@ -1299,7 +1299,7 @@ SMODS.calculate_individual_effect = function(effect, scored_card, key, amount, f
                     blockable = false,
                     blocking = false,
                     delay =  0.8,
-                    func = (function() 
+                    func = (function()
                             ease_colour(G.C.UI_CHIPS, G.C.BLUE, 0.8)
                             ease_colour(G.C.UI_MULT, G.C.RED, 0.8)
                         return true
@@ -1311,7 +1311,7 @@ SMODS.calculate_individual_effect = function(effect, scored_card, key, amount, f
                     blocking = false,
                     no_delete = true,
                     delay =  1.3,
-                    func = (function() 
+                    func = (function()
                         G.C.UI_CHIPS[1], G.C.UI_CHIPS[2], G.C.UI_CHIPS[3], G.C.UI_CHIPS[4] = G.C.BLUE[1], G.C.BLUE[2], G.C.BLUE[3], G.C.BLUE[4]
                         G.C.UI_MULT[1], G.C.UI_MULT[2], G.C.UI_MULT[3], G.C.UI_MULT[4] = G.C.RED[1], G.C.RED[2], G.C.RED[3], G.C.RED[4]
                         return true
@@ -1352,7 +1352,7 @@ SMODS.calculate_individual_effect = function(effect, scored_card, key, amount, f
     if key == 'effect' then
         return true
     end
-    
+
     if key == 'prevent_debuff' or key == 'add_to_hand' or key == 'remove_from_hand' or key == 'stay_flipped' or key == 'prevent_stay_flipped' or key == 'prevent_trigger' then
         return key
     end
@@ -1361,7 +1361,7 @@ SMODS.calculate_individual_effect = function(effect, scored_card, key, amount, f
         key == 'replace_scoring_name' or key == 'replace_display_name' or key == 'replace_poker_hands' or key == 'modify' or key == 'shop_create_flags'  then
         return { [key] = amount }
     end
-    
+
     if key == 'debuff' then
         return { [key] = amount, debuff_source = scored_card }
     end
@@ -1531,20 +1531,20 @@ SMODS.calculate_repetitions = function(card, context, reps)
                     -- After each inserted repetition we insert the post effects
                     local new_size = #reps
                     for i = curr_size + 1, new_size do
-                        if not first then 
+                        if not first then
                             post = {}
                             if not context.post_trigger and SMODS.optional_features.post_trigger then
                                 SMODS.calculate_context({blueprint_card = context.blueprint_card, post_trigger = true, other_card = _card, other_context = context, other_ret = eval}, post)
                             end
                         end
                         first = nil
-                        if next(post) then 
+                        if next(post) then
                             reps[#reps - new_size + i].retriggers.retrigger_flag = true
                         else break end
                         -- index from behind since that doesn't change
                         for idx, eff in ipairs(post) do
                             if next(eff) then
-                                select(2, next(eff)).retrigger_flag = true          
+                                select(2, next(eff)).retrigger_flag = true
                                 table.insert(reps, #reps + 1 - new_size + i, eff)
                             end
                         end
@@ -1643,7 +1643,7 @@ function Card:calculate_edition(context)
             end
         end
     end
-end 
+end
 
 function SMODS.calculate_card_areas(_type, context, return_table, args)
     local flags = {}
@@ -1664,7 +1664,7 @@ function SMODS.calculate_card_areas(_type, context, return_table, args)
 
                 local effects = {eval}
                 for _,v in ipairs(post) do effects[#effects+1] = v end
-    
+
                 if context.other_joker then
                     for k, v in pairs(effects[1]) do
                         v.other_card = _card
@@ -1829,7 +1829,7 @@ SMODS.current_evaluated_object = nil
 -- Joker B calls SMODS.pseudorandom_probability() to check whether it should trigger
 -- A loop is caused (ignore the fact that Joker B would be the trigger_obj and not a playing card) (I'd write a Quantum Ranks example, If I had any!!)
 -- To avoid this; Check before evaluating any object, whether the current getter context type (if it's a getter context) has previously caused said object to create a getter context,
--- if yes, don't evaluate the object. 
+-- if yes, don't evaluate the object.
 function SMODS.is_getter_context(context)
     if context.mod_probability or context.fix_probability then return "probability" end
     if context.check_enhancement then return "enhancement" end
@@ -1856,7 +1856,7 @@ end
 -- SMODS.context_stack = {1: {context = [unique context 1], count = [number of times it was added consecutively], caller = [the SMODS.current_evaluated_object when the context was added]}, ...}
 -- (Contexts may repeat non-consecutively, though I don't think they ever should..)
 -- Allows some advanced effects, like:
--- Individual playing cards modifying probabilities checked during individual scoring, only when they're the context.other_card 
+-- Individual playing cards modifying probabilities checked during individual scoring, only when they're the context.other_card
 -- (-> By checking the context in the stack PRIOR to the mod_probability context for the .individual / .other_card flags)
 SMODS.context_stack = {}
 
@@ -1901,16 +1901,16 @@ function SMODS.calculate_context(context, return_table, no_resolve)
     context.main_eval = true
     flags[#flags+1] = SMODS.calculate_card_areas('jokers', context, return_table, { joker_area = true, has_area = has_area })
     context.main_eval = nil
-    
+
     flags[#flags+1] = SMODS.calculate_card_areas('playing_cards', context, return_table, { has_area = has_area })
     context.main_eval = true
     flags[#flags+1] = SMODS.calculate_card_areas('individual', context, return_table)
     context.main_eval = nil
-    
+
     if SMODS.no_resolve then SMODS.no_resolve = nil end
-    
+
     SMODS.pop_from_context_stack(context, "utils.lua : SMODS.calculate_context")
-    
+
     if not return_table then
         local ret = {}
         for i,f in ipairs(flags) do
@@ -1933,8 +1933,8 @@ function SMODS.score_card(card, context)
     while j <= #reps do
         if reps[j] ~= 1 then
             local _, eff = next(reps[j])
-            while eff.retrigger_flag do 
-                SMODS.calculate_effect(eff, eff.card); j = j+1; _, eff = next(reps[j]) 
+            while eff.retrigger_flag do
+                SMODS.calculate_effect(eff, eff.card); j = j+1; _, eff = next(reps[j])
             end
             SMODS.calculate_effect(eff, eff.card)
             percent = percent + percent_delta
@@ -1980,7 +1980,7 @@ function SMODS.calculate_main_scoring(context, scoring_hand)
         end
         --if card is debuffed
         if scoring_hand and card.debuff then
-            if in_scoring then 
+            if in_scoring then
                 G.GAME.blind.triggered = true
                 G.E_MANAGER:add_event(Event({
                     trigger = 'immediate',
@@ -2046,7 +2046,7 @@ function SMODS.calculate_destroying_cards(context, cards_destroyed, scoring_hand
         local destroyed = nil
         --un-highlight all cards
         local in_scoring = scoring_hand and SMODS.in_scoring(card, context.scoring_hand)
-        if scoring_hand and in_scoring and not card.destroyed then 
+        if scoring_hand and in_scoring and not card.destroyed then
             -- Use index of card in scoring hand to determine pitch
             local m = 1
             for j, _card in pairs(scoring_hand) do
@@ -2089,7 +2089,7 @@ function SMODS.blueprint_effect(copier, copied_card, context)
 
     local old_context_blueprint = context.blueprint
     context.blueprint = (context.blueprint and (context.blueprint + 1)) or 1
-    
+
     local old_context_blueprint_card = context.blueprint_card
     context.blueprint_card = context.blueprint_card or copier
 
@@ -2151,10 +2151,10 @@ function SMODS.get_card_areas(_type, _context)
             { object = G.GAME.selected_back, scored_card = G.deck.cards[1] or G.deck },
         }
 
-        if G.GAME.blind and G.GAME.blind.children and G.GAME.blind.children.animatedSprite then 
-            t[#t + 1] = { object = G.GAME.blind, scored_card = G.GAME.blind.children.animatedSprite } 
+        if G.GAME.blind and G.GAME.blind.children and G.GAME.blind.children.animatedSprite then
+            t[#t + 1] = { object = G.GAME.blind, scored_card = G.GAME.blind.children.animatedSprite }
         end
-        if G.GAME.challenge then t[#t + 1] = { object = SMODS.Challenges[G.GAME.challenge], scored_card = G.deck.cards[1] or G.deck } end 
+        if G.GAME.challenge then t[#t + 1] = { object = SMODS.Challenges[G.GAME.challenge], scored_card = G.deck.cards[1] or G.deck } end
         for _, stake in ipairs(SMODS.get_stake_scoring_targets()) do
             t[#t + 1] = { object = stake, scored_card = G.deck.cards[1] or G.deck }
         end
@@ -2173,7 +2173,7 @@ end
 function Blind:calculate(context)
     local obj = self.config.blind
     if type(obj.calculate) == 'function' then
-        return obj:calculate(self, context)
+        return obj:calculate(context)
     end
 end
 
@@ -2585,9 +2585,9 @@ function SMODS.destroy_cards(cards, bypass_eternal, immediate, skip_anim)
             card.skip_destroy_animation = skip_anim
         end
     end
-    
+
     check_for_unlock{type = 'shatter', shattered = glass_shattered}
-    
+
     if next(playing_cards) then SMODS.calculate_context({scoring_hand = cards, remove_playing_cards = true, removed = playing_cards}) end
 
     for i = 1, #cards do
@@ -2639,8 +2639,8 @@ end
 
 function SMODS.draw_cards(hand_space)
     if not (G.STATE == G.STATES.TAROT_PACK or G.STATE == G.STATES.SPECTRAL_PACK or G.STATE == G.STATES.SMODS_BOOSTER_OPENED) and
-        G.hand.config.card_limit <= 0 and #G.hand.cards == 0 then 
-        G.STATE = G.STATES.GAME_OVER; G.STATE_COMPLETE = false 
+        G.hand.config.card_limit <= 0 and #G.hand.cards == 0 then
+        G.STATE = G.STATES.GAME_OVER; G.STATE_COMPLETE = false
         return true
     end
 
@@ -2649,7 +2649,7 @@ function SMODS.draw_cards(hand_space)
     delay(0.3)
     SMODS.drawn_cards = {}
     for i=1, hand_space do --draw cards from deckL
-        if G.STATE == G.STATES.TAROT_PACK or G.STATE == G.STATES.SPECTRAL_PACK then 
+        if G.STATE == G.STATES.TAROT_PACK or G.STATE == G.STATES.SPECTRAL_PACK then
             draw_card(G.deck,G.hand, i*100/hand_space,'up', true)
         else
             draw_card(G.deck,G.hand, i*100/hand_space,'up', true)
@@ -2700,7 +2700,7 @@ function SMODS.merge_effects(...)
     local t = {}
     for _, v in ipairs({...}) do
         for _, vv in ipairs(v) do
-            if vv == true or (type(vv) == "table" and next(vv)) then 
+            if vv == true or (type(vv) == "table" and next(vv)) then
                 table.insert(t, vv)
             end
         end
@@ -2795,7 +2795,7 @@ function Game:start_run(args)
     game_start_run(self, args)
     G.E_MANAGER:add_event(Event({
         trigger = 'immediate',
-        func = function()                
+        func = function()
             SMODS.refresh_score_UI_list()
             return true
         end
@@ -2814,14 +2814,14 @@ G.FUNCS.SMODS_scoring_calculation_function = function(e)
         else
             e.children[1].UIBox:add_child(SMODS.GUI.hand_chips_container(scale), e.children[1])
         end
-        e.config.current_scoring_calculation = G.GAME.current_scoring_calculation.key 
+        e.config.current_scoring_calculation = G.GAME.current_scoring_calculation.key
     end
 
     local container = e.children[1].children[2]
     local chip_display = container.UIBox:get_UIE_by_ID('hand_chips_container')
     local operator = container.UIBox:get_UIE_by_ID('hand_operator_container')
     local mult_display = container.UIBox:get_UIE_by_ID('hand_mult_container')
-    
+
     if G.GAME.current_scoring_calculation.update_ui then
         G.GAME.current_scoring_calculation:update_ui(container, chip_display, mult_display, operator)
     else
@@ -2888,7 +2888,7 @@ function SMODS.scale_card(card, args)
             end
         end
     end
-    
+
     if type(args.operation) == 'function' then
         args.operation(args.ref_table, args.ref_value, initial, scalar_value)
     elseif args.operation == 'X' then
@@ -2898,7 +2898,7 @@ function SMODS.scale_card(card, args)
     else
         SMODS.additive_scaling(args.ref_table, args.ref_value, initial, scalar_value)
     end
-    
+
     scaling_message = scaling_message or {
         message = localize(args.message_key and {type='variable',key=args.message_key,vars={args.message_key =='a_xmult' and args.ref_table[args.ref_value] or scalar_value}} or 'k_upgrade_ex'),
         colour = args.message_colour or G.C.FILTER,
@@ -3081,7 +3081,7 @@ function UIElement:draw_pixellated_under(_type, _parallax, _emboss, _progress)
         self.pixellated_rect.sw ~= self.shadow_parrallax.x or
         self.pixellated_rect.sh ~= self.shadow_parrallax.y or
         self.pixellated_rect.progress ~= (_progress or 1)
-    then 
+    then
         self.pixellated_rect = {
             w = self.VT.w,
             h = self.VT.h,
@@ -3199,7 +3199,7 @@ function CardArea:handle_card_limit()
             self.config.card_limits.extra_slots_used = self:count_property('extra_slots_used')
         end
         self.config.card_count = #self.cards + self.config.card_limits.extra_slots_used
-        
+
         if G.hand and self == G.hand and (self.config.card_count or 0) + (SMODS.cards_to_draw or 0) < (self.config.card_limits.total_slots or 0) then
             if G.STATE == G.STATES.DRAW_TO_HAND and not SMODS.blind_modifies_draw(G.GAME.blind.config.blind.key) and not SMODS.draw_queued then
                 SMODS.draw_queued = true
@@ -3211,7 +3211,7 @@ function CardArea:handle_card_limit()
                             trigger = 'immediate',
                             func = function()
                                 if (self.config.card_limits.total_slots - self.config.card_count - (SMODS.cards_to_draw or 0)) > 0 and #G.deck.cards > (SMODS.cards_to_draw or 0) then
-                                    G.FUNCS.draw_from_deck_to_hand(self.config.card_limits.total_slots - self.config.card_count - (SMODS.cards_to_draw or 0))                
+                                    G.FUNCS.draw_from_deck_to_hand(self.config.card_limits.total_slots - self.config.card_count - (SMODS.cards_to_draw or 0))
                                 end
                                 return true
                             end
@@ -3224,7 +3224,7 @@ function CardArea:handle_card_limit()
                     G.FUNCS.draw_from_deck_to_hand((self.config.card_limits.total_slots - self.config.card_limits.old_slots))
                 end
             end
-            if self == G.hand and G.STATE == G.STATES.SELECTING_HAND or G.STATE == G.STATES.DRAW_TO_HAND then 
+            if self == G.hand and G.STATE == G.STATES.SELECTING_HAND or G.STATE == G.STATES.DRAW_TO_HAND then
                 self.config.card_limits.old_slots = self.config.card_limits.total_slots or 0
             end
             return
@@ -3298,7 +3298,7 @@ function SMODS.upgrade_poker_hands(args)
         end
         return
     end
-    
+
     assert(type(args.func) == 'function', "Invalid func provided to SMODS.upgrade_hands")
 
     local vals_after_level
@@ -3311,7 +3311,7 @@ function SMODS.upgrade_poker_hands(args)
             vals_after_level[name] = p.current
         end
     end
-        
+
     local displayed = false
     for _, hand in ipairs(args.hands) do
         displayed = hand == SMODS.displayed_hand


### PR DESCRIPTION
`Blind:calculate()` was incorrectly calling the calculate function on the center with a duplicate `self` arg while calling the function with the colon operator, despite the spec giving the arguments as only `self` and `context`

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
