### PR TITLE
Custom StatusText in `update_hand_text`

### DIFF
--- a/lovely/poker_hand_text.toml
+++ b/lovely/poker_hand_text.toml
@@ -3,6 +3,15 @@ version = "1.0.0"
 dump_lua = true
 priority = -5
 
+# statustext parameter in level_up_hand
+[[patches]]
+[patches.pattern]
+target = 'functions/common_events.lua'
+pattern = 'function level_up_hand(card, hand, instant, amount)'
+position = 'at'
+match_indent = true
+payload = 'function level_up_hand(card, hand, instant, amount, statustext)'
+
 # Allow custom StatusText values in update_hand_text
 [[patches]]
 [patches.regex]
@@ -22,10 +31,10 @@ if vals.StatusText then
         align = 'cm',
         cover_align = G.hand_text_area[name].parent.config.align
     }
-    if type(vals.StatusText) == 'string' then StatusText.text = vals.StatusText end
-    if type(vals.StatusText) == 'table' then
+    if type(vals.StatusText) == 'string' then StatusText.text = vals.StatusText
+    elseif type(vals.StatusText) == 'table' then
         for k,v in pairs(vals.StatusText) do
-            StatusText[k] = v
+            if v ~= nil then StatusText[k] = v end
         end
     end
     attention_text(StatusText)

--- a/lovely/scoring_calculation.toml
+++ b/lovely/scoring_calculation.toml
@@ -238,7 +238,8 @@ SMODS.upgrade_poker_hands({
     end,
     level_up = amount,
     from = card,
-    instant = instant
+    instant = instant,
+    StatusText = statustext
 })
 --[[
 '''

--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -763,13 +763,13 @@ function SMODS.is_active_blind(key, ignore_disabled) end
 ---@return boolean
 function SMODS.challenge_is_unlocked(challenge, k) end
 
----@param args table|{hands?: table, parameters?: table, level_up?: number|boolean, func?: fun(base: number, hand: string, param: string), instant?: boolean, StatusText?: boolean|string|table}
+---@param args table|{hands?: table, parameters?: table, level_up?: number|boolean, func?: fun(base: number, hand: string, param: string), instant?: boolean, StatusText?: boolean|string|table|fun(hand: string, parameter: string)}
 --- This functions handles upgrading poker hands in more complex ways. You can define
 --- a custom `func` to modify the values in specific ways. `hands` and `parameters` can
 --- be limited to specific ones, or default to using all of `G.GAME.hands` and `SMODS.Scoring_Parameters`.
 --- Use `level_up` to control whether the level of the hand is upgraded.
---- Use `StatusText` to control the text that appears when a parameter is upgraded, it can be a string,
---- which changes the displayed text; a table, which defines the `attention_text` function settings;
---- or a boolean, which disables StatusText when set to `false`. Setting `StatusText[parameter]` will
---- apply a setting only for that parameter.
+--- Use `StatusText` to control the text that appears when a parameter is upgraded, it can be:
+--- a string, which changes the displayed text, a boolean, which disables StatusText when set to `false`,
+--- a table, which defines the `attention_text` function settings, or a function that takes the key of
+--- the hand and scoring parameter being upgraded as arguments and returns a boolean, string or table
     function SMODS.upgrade_poker_hands(args) end


### PR DESCRIPTION
Adds the ability to set a custom `StatusText` value in the `update_hand_text` and `SMODS.upgrade_poker_hands` functions


## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
