### PR TITLE
Add `text_colour` to challenges

### DIFF
--- a/lovely/challenge.toml
+++ b/lovely/challenge.toml
@@ -39,7 +39,7 @@ pattern = "UIBox_button({id = k, col = true, label = {challenge_unlocked and loc
 position = 'at'
 match_indent = true
 payload = '''
-UIBox_button({id = k, col = true, label = {challenge_unlocked and localize(v.id, 'challenge_names') or localize('k_locked'),}, button = challenge_unlocked and 'change_challenge_description' or 'nil', colour = challenge_unlocked and (v.button_colour or G.C.RED) or G.C.GREY, minw = 4, scale = 0.4, minh = 0.6, focus_args = {snap_to = not snapped}}),
+UIBox_button({id = k, col = true, label = {challenge_unlocked and localize(v.id, 'challenge_names') or localize('k_locked'),}, button = challenge_unlocked and 'change_challenge_description' or 'nil', text_colour = v.text_colour, colour = challenge_unlocked and (v.button_colour or G.C.RED) or G.C.GREY, minw = 4, scale = 0.4, minh = 0.6, focus_args = {snap_to = not snapped}}),
 '''
 
 [[patches]]

--- a/lsp_def/classes/challenge.lua
+++ b/lsp_def/classes/challenge.lua
@@ -25,7 +25,8 @@
 ---@field take_ownership? fun(self: SMODS.Challenge|table, key: string, obj: SMODS.Challenge|table, silent?: boolean): nil|table|SMODS.Challenge Takes control of vanilla objects. Child class must have get_obj for this to function
 ---@field get_obj? fun(self: SMODS.Challenge|table, key: string): SMODS.Challenge|table? Returns an object if one matches the `key`.
 ---@field unlocked? fun(self: SMODS.Challenge|table): boolean | boolean
----@field button_colour? table HEX color of the button on the challenge list.
+---@field text_colour? table Colour of the text on the challenge list.
+---@field button_colour? table Colour of the button on the challenge list.
 ---@field calculate? fun(self: SMODS.Challenge|table, context: CalcContext|table): table?, boolean? Calculates effects based on parameters in `context`. See [SMODS calculation](https://github.com/Steamodded/smods/wiki/calculate_functions) docs for details. 
 ---@field apply? fun(self: SMODS.Challenge|table) Applied modifiers at the start of a run. 
 ---@overload fun(self: SMODS.Challenge): SMODS.Challenge


### PR DESCRIPTION
Similar to `button_colour` but for the text.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
