### PR TITLE
Fix crash in check_applied_stakes when stake.applied_stakes is nil

### DIFF
--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -562,13 +562,17 @@ function G.UIDEF.deck_stake_column(_deck_key)
 end
 
 function SMODS.check_applied_stakes(stake, deck)
-	if next(stake.applied_stakes) then
-		for _, applied_stake in ipairs(stake.applied_stakes) do
-			if not deck.wins_by_key[applied_stake] then return false end
-		end
-	end
-	return true
+    local applied = stake and stake.applied_stakes
+    if type(applied) == "table" and next(applied) ~= nil then
+        for _, applied_stake in ipairs(applied) do
+            if not (deck and deck.wins_by_key and deck.wins_by_key[applied_stake]) then
+                return false
+            end
+        end
+    end
+    return true
 end
+
 
 function G.UIDEF.stake_option(_type)
 	


### PR DESCRIPTION
Single-play often crashes after installing this mode and multi-play mode
<img width="1534" height="865" alt="err" src="https://github.com/user-attachments/assets/b77f45a6-00b7-4a36-9962-0dfe9186008b" />
<h3>cause</h3>
Some mod workflows create or pass stake objects without an applied_stakes field.
Calling next() on a nil value causes a runtime error.
<h3>fix</h3>

Guard access to stake.applied_stakes using type(applied) == "table" before calling next() or ipairs().

This change makes check_applied_stakes nil-safe without altering existing behavior, preventing crashes caused by mod-generated stake objects missing the applied_stakes field.