### PR TITLE
SMODS.should_keep_on_use for finer control over keep_on_use

### DIFF
--- a/lovely/center.toml
+++ b/lovely/center.toml
@@ -515,10 +515,7 @@ payload = '''
 local nc
 local select_to = card.area == G.pack_cards and G.pack_cards and booster_obj and SMODS.card_select_area(card, booster_obj) and card:selectable_from_pack(booster_obj)
 if card.ability.consumeable and not select_to then
-    local obj = card.config.center
-    if obj.keep_on_use and type(obj.keep_on_use) == 'function' then
-        nc = obj:keep_on_use(card)
-    end
+    nc = SMODS.should_keep_on_use(card)
 end
 if G.booster_pack and not G.booster_pack.alignment.offset.py and ((not select_to and card.ability.consumeable) or not (G.GAME.pack_choices and G.GAME.pack_choices > 1)) then
 

--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -769,3 +769,7 @@ function SMODS.challenge_is_unlocked(challenge, k) end
 --- be limited to specific ones, or default to using all of `G.GAME.hands` and `SMODS.Scoring_Parameters`.
 --- Use `level_up` to control whether the level of the hand is upgraded.
     function SMODS.upgrade_poker_hands(args) end
+
+---@param card Card|table The card being checked to keep on usage
+---@return boolean
+function SMODS.should_keep_on_use(card) end

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -3429,3 +3429,10 @@ function SMODS.get_clean_pool(_type, _rarity, _legendary, _append)
     end
     return clean_pool
 end
+
+function SMODS.should_keep_on_use(card)
+    local obj = card.config.center
+    if type(obj.keep_on_use) == "function" then
+        return obj:keep_on_use(card)
+    end
+end

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -3435,4 +3435,5 @@ function SMODS.should_keep_on_use(card)
     if type(obj.keep_on_use) == "function" then
         return obj:keep_on_use(card)
     end
+    return false
 end


### PR DESCRIPTION
Adds `SMODS.should_keep_on_use(card)`, which now handles calling a center's `keep_on_use`. This can be hooked to more easily allow external effects to keep used consumables, whereas previously all mods would have to patch the same piece of code to achieve this.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
