### PR TITLE
Multiple columns for additional Ranks

### DIFF
--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -1056,11 +1056,11 @@ function G.UIDEF.view_deck(unplayed_only)
     end
 
     if #temp_cols > 0 then
-        table.insert(rank_cols, {
+        rank_cols[#rank_cols + 1] = {
             n = G.UIT.C,
             config = { align = "cm" },
             nodes = temp_cols
-        })
+        }
     end
 
 	local tally_ui = {


### PR DESCRIPTION

Normally if you have a lot of modded ranks it makes a really long column of ranks cluttering the screen, This separates it into multiple columns of 13

before:
<img width="1919" height="1079" alt="Screenshot 2026-01-25 103516" src="https://github.com/user-attachments/assets/fccb4a76-f7c5-4313-8f11-b6d231863850" />
after:
<img width="1919" height="1079" alt="Screenshot 2026-01-25 102940" src="https://github.com/user-attachments/assets/ea3db123-1c59-4f54-bec1-9a62b76c34ff" />

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
