### PR TITLE
add winning hand info to context.end_of_round

### DIFF
--- a/lovely/better_calc.toml
+++ b/lovely/better_calc.toml
@@ -586,9 +586,14 @@ match_indent = true
 position = "at"
 payload = '''
 -- context.before calculations
-local cards = {}
-for i, v in pairs(G.play.cards) do cards[#cards+1] = v end
-SMODS.last_hand = {scoring_hand = scoring_hand, scoring_name = text, full_hand = cards}
+if SMODS.last_hand then
+    for _, v in ipairs({'scoring_hand', 'full_hand'}) do
+        for _, _c in ipairs(SMODS.last_hand[v]) do
+            _c.ability['SMODS_'..v] = nil
+        end
+    end
+end
+SMODS.last_hand = {scoring_hand = scoring_hand, scoring_name = text, full_hand = G.play.cards}
 SMODS.calculate_context({full_hand = G.play.cards, scoring_hand = scoring_hand, scoring_name = text, poker_hands = poker_hands, before = true})
 
 -- TARGET: effects before scoring starts
@@ -2003,5 +2008,30 @@ local ret = SMODS.blueprint_effect(self, other_joker, context)
 if ret then
     ret.colour = G.C.RED
     return ret
+end
+'''
+
+# Reload SMODS.last_hand
+[[patches]]
+[patches.pattern]
+target = 'game.lua'
+match_indent = true
+position = 'before'
+pattern = '''
+table.sort(G.playing_cards, function (a, b) return a.playing_card > b.playing_card end )
+'''
+payload = '''
+if saveTable then
+    if saveTable.SMODS then
+        SMODS.last_hand = {scoring_hand = {}, full_hand = {}, scoring_name = saveTable.SMODS.last_hand.scoring_name}
+        print(#G.playing_cards)
+        for _, v in ipairs({'scoring_hand','full_hand'}) do
+            for _, card in ipairs(G.playing_cards) do
+                if card.ability['SMODS_'..v] then
+                    SMODS.last_hand[v][card.ability['SMODS_'..v]] = card
+                end
+            end
+        end
+	end
 end
 '''

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -3438,3 +3438,24 @@ function SMODS.get_clean_pool(_type, _rarity, _legendary, _append)
     end
     return clean_pool
 end
+
+local smods_hook_save_run = save_run
+function save_run()
+    if SMODS.last_hand then
+        for _, v in ipairs({'scoring_hand','full_hand'}) do
+            for i, card in ipairs(SMODS.last_hand[v]) do
+                card.ability['SMODS_'..v] = i
+            end
+        end
+    end
+    smods_hook_save_run()
+    if SMODS.last_hand then
+        G.culled_table.SMODS = {
+        last_hand = {
+                scoring_name = SMODS.last_hand.scoring_name,
+                scoring_hand = {},
+                full_hand = {}
+            }
+        }
+    end
+end


### PR DESCRIPTION
Adds scoring_hand scoring_text and full_hand to context.end_of_round containing a list of scored cards the last scored hand name and the list of all played cards in the hand that wins the round

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
