### PR TITLE
`menu_cards` fixes

### DIFF
--- a/src/ui.lua
+++ b/src/ui.lua
@@ -99,7 +99,7 @@ function Game:main_menu(change_context)
     local remove_original = false
     for i, v in pairs(SMODS.Mods) do
         if not v.disabled and v.menu_cards then
-            local tbl = v.menu_cards()
+            local tbl = v.menu_cards() or {}
             if tbl.func then funcs[#funcs + 1] = tbl.func end
             if tbl.remove_original then remove_original = true end
             if tbl.set or tbl.key then tbl = { tbl } end
@@ -134,7 +134,7 @@ function Game:main_menu(change_context)
                 
                 G.E_MANAGER:add_event(Event({
                     trigger = "after",
-                    delay = 0,
+                    delay = change_context == 'game' and 1.5 or 0,
                     blockable = false,
                     blocking = false,
                     func = function()


### PR DESCRIPTION
* Adds an empty table default so you can return `nil` (as the LSP indicates, also just nice to disable the main menu cards)
* Fixes the animation when going from a run to the main menu

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
