### PR TITLE
Blind description formatting

### DIFF
--- a/lovely/blind.toml
+++ b/lovely/blind.toml
@@ -258,6 +258,9 @@ if obj.loc_vars and type(obj.loc_vars) == 'function' then
     local res = obj:loc_vars() or {}
     target.vars = res.vars or target.vars
     target.key = res.key or target.key
+    target.set = res.set or target.set
+    target.scale = res.scale
+    target.text_colour = res.text_colour
 end
 local loc_target = localize(target)'''
 
@@ -374,8 +377,21 @@ if obj.loc_vars and _G['type'](obj.loc_vars) == 'function' then
     local res = obj:loc_vars() or {}
     target.vars = res.vars or target.vars
     target.key = res.key or target.key
+    target.set = res.set or target.set
+    target.scale = res.scale
+    target.text_colour = res.text_colour
 end
-local loc_target = localize(target)'''
+'''
+
+[[patches]]
+[patches.pattern]
+target = 'functions/UI_definitions.lua'
+pattern = "local text_table = loc_target"
+match_indent = true
+position = 'at'
+payload = '''
+local text_table = G.localization.descriptions[target.set][target.key].text_parsed
+'''
 
 # create_UIBox_blind_popup()
 [[patches]]
@@ -390,8 +406,23 @@ if blind.collection_loc_vars and type(blind.collection_loc_vars) == 'function' t
     local res = blind:collection_loc_vars() or {}
     target.vars = res.vars or target.vars
     target.key = res.key or target.key
+    target.set = res.set or target.set
+    target.scale = res.scale
+    target.text_colour = res.text_colour
 end
-local loc_target = localize(target)'''
+local loc_target = G.localization.descriptions[target.set][target.key].text_parsed'''
+
+[[patches]]
+[patches.pattern]
+target = 'functions/UI_definitions.lua'
+pattern = '''
+ability_text[#ability_text + 1] = {n=G.UIT.R, config={align = "cm"}, nodes={{n=G.UIT.T, config={text = (k ==1 and blind.name == 'The Wheel' and '1' or '')..v, scale = 0.35, shadow = true, colour = G.C.WHITE}}}}
+'''
+match_indent = true
+position = 'at'
+payload = '''
+ability_text[#ability_text + 1] = {n=G.UIT.R, config={align = "cm"}, nodes=SMODS.localize_box(v, {default_col = target.text_colour or G.C.WHITE, shadow = true, vars = target.vars, scale = target.scale})}
+'''
 
 # get_new_boss()
 [[patches]]

--- a/lovely/blind_ui.toml
+++ b/lovely/blind_ui.toml
@@ -14,9 +14,7 @@ position = 'after'
 payload = '''
 local blind_desc_nodes = {}
 for k, v in ipairs(text_table) do
-  blind_desc_nodes[#blind_desc_nodes+1] = {n=G.UIT.R, config={align = "cm", maxw = 2.8}, nodes={
-    {n=G.UIT.T, config={text = v or '-', scale = 0.32, colour = disabled and G.C.UI.TEXT_INACTIVE or G.C.WHITE, shadow = not disabled}}
-  }}
+  blind_desc_nodes[#blind_desc_nodes+1] = {n=G.UIT.R, config={align = "cm", maxw = 2.8}, nodes=SMODS.localize_box(v, {default_col = disabled and G.C.UI.TEXT_INACTIVE or target.text_colour or G.C.WHITE, shadow = not disabled, vars = target.vars, scale = target.scale})}
 end'''
 match_indent = true
 
@@ -74,15 +72,21 @@ line_prepend = '$indent'
 target = "blind.lua"
 pattern = "for k, v in ipairs(loc_target) do"
 position = 'before'
-payload = 'EMPTY(self.loc_debuff_lines)'
-match_indent = true
-
-[[patches]]
-[patches.pattern]
-target = "blind.lua"
-pattern = "self.loc_debuff_text = self.loc_debuff_text..v..(k <= #loc_target and ' ' or '')"
-position = 'after'
-payload = "self.loc_debuff_lines[k] = v"
+payload = '''
+EMPTY(self.loc_debuff_lines)
+if G.localization.descriptions[target.set][target.key] then
+    for k, v in ipairs(G.localization.descriptions[target.set][target.key].text_parsed) do
+        self.loc_debuff_lines[k] = v
+    end
+    self.loc_debuff_lines.vars = target.vars
+    self.loc_debuff_lines.scale = target.scale
+    self.loc_debuff_lines.text_colour = target.text_colour
+else
+    for k, v in ipairs(loc_target) do
+        self.loc_debuff_lines[k] = v
+    end
+end
+'''
 match_indent = true
 
 [[patches]]

--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -19,9 +19,14 @@ G.FUNCS.HUD_blind_debuff = function(e)
 	end
 	e.config.padding = padding
 	if num_lines > #e.children then
-		for i = #e.children+1, num_lines do
-			local node_def = {n = G.UIT.R, config = {align = "cm", minh = 0.3, maxw = 4.2}, nodes = {
+        for i = #e.children + 1, num_lines do
+			local node_def 
+			if type(G.GAME.blind.loc_debuff_lines[i]) == "string" then
+				node_def = {n = G.UIT.R, config = {align = "cm", minh = 0.3, maxw = 4.2}, nodes = {
 				{n = G.UIT.T, config = {ref_table = G.GAME.blind.loc_debuff_lines, ref_value = i, scale = scale * 0.9, colour = G.C.UI.TEXT_LIGHT}}}}
+			else
+				node_def = {n = G.UIT.R, config = {align = "cm", minh = 0.3, maxw = 4.2}, nodes = SMODS.localize_box(G.GAME.blind.loc_debuff_lines[i], {default_col = G.GAME.blind.loc_debuff_lines.text_colour or G.C.UI.TEXT_LIGHT, scale = 1.125 * (G.GAME.blind.loc_debuff_lines.scale or 1), vars = G.GAME.blind.loc_debuff_lines.vars or {}})}
+			end
 			e.UIBox:set_parent_child(node_def, e)
 		end
 	elseif num_lines < #e.children then


### PR DESCRIPTION
Allows blinds to have text formatting in descriptions, this includes collection, blind select and during the round. It additionally adds the ability to use `set`, `scale` and `text_colour` in `loc_vars`.

Limitations: It doesn't format the "debuff text" at the start of the blind (I think it looks better without tbh) or the blind's name. With my implementation, using a multibox description crashes it.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
