### PR TITLE
`button` support for text formatting

### DIFF
--- a/lovely/ui_additional_text_props.toml
+++ b/lovely/ui_additional_text_props.toml
@@ -359,3 +359,28 @@ final_line[#final_line].nodes[1] = {n=G.UIT.O, config={
 payload = '''
 underline = part.control.u and loc_colour(part.control.u),
 '''
+
+# Add button support for text formatting
+[[patches]]
+[patches.pattern]
+target = 'functions/misc_functions.lua'
+match_indent = true
+position = 'after'
+pattern = '''
+font = SMODS.Fonts[part.control.f] or G.FONTS[tonumber(part.control.f)],
+'''
+payload = '''
+button = part.control.L,
+'''
+
+[[patches]]
+[patches.pattern]
+target = 'functions/misc_functions.lua'
+match_indent = true
+position = 'after'
+pattern = '''
+final_line[#final_line].nodes[1] = {n=G.UIT.O, config={
+'''
+payload = '''
+button = part.control.L,
+'''

--- a/lovely/ui_additional_text_props.toml
+++ b/lovely/ui_additional_text_props.toml
@@ -370,7 +370,7 @@ pattern = '''
 font = SMODS.Fonts[part.control.f] or G.FONTS[tonumber(part.control.f)],
 '''
 payload = '''
-button = part.control.L,
+button = part.control.button,
 '''
 
 [[patches]]
@@ -382,5 +382,5 @@ pattern = '''
 final_line[#final_line].nodes[1] = {n=G.UIT.O, config={
 '''
 payload = '''
-button = part.control.L,
+button = part.control.button,
 '''


### PR DESCRIPTION
Adds option to use `{L:string}` in text formatting which will make a section of the text clickable and call `G.FUNCS[string]`. Just like `T:` it only makes sense to use when the text is actually clickable on the screen.

I named it L because I'm using it for links and all the other letters I thought of were taken

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
