### PR TITLE
SMODS.get_table_keys

### DIFF
--- a/src/utils.lua
+++ b/src/utils.lua
@@ -3227,6 +3227,15 @@ function SMODS.blind_modifies_draw(key)
     if SMODS.Blinds.modifies_draw[key] then return true end
 end
 
+-- Gets all keys from a table
+function SMODS.get_table_keys(t)
+	local keys = {}
+	for k, _ in pairs(t) do
+		keys[#keys+1] = k
+	end
+	return keys
+end
+
 function SMODS.upgrade_poker_hands(args)
     -- args.hands
     -- args.parameters
@@ -3236,17 +3245,9 @@ function SMODS.upgrade_poker_hands(args)
     -- args.from
     -- args.StatusText
 
-    local function get_keys(t)
-        local keys = {}
-        for k, _ in pairs(t) do
-            table.insert(keys, k)
-        end
-        return keys
-    end
-
-    args.hands = args.hands or get_keys(G.GAME.hands)
+    args.hands = args.hands or SMODS.get_table_keys(G.GAME.hands)
     if type(args.hands) == 'string' then args.hands = {args.hands} end
-    args.parameters = args.parameters or get_keys(SMODS.Scoring_Parameters)
+    args.parameters = args.parameters or SMODS.get_table_keys(SMODS.Scoring_Parameters)
     local instant = args.instant
 
     if not args.func then


### PR DESCRIPTION
Turns the local `get_keys` function from `SMODS.upgrade_poker_hands` into a separate utility function, `SMODS.get_table_keys`, since it can be useful in some circumstances for modders to have access to. It takes a table as input and returns a table containing all of that table's keys as values.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [X] I didn't make new lovely files or all new lovely files have appropriate priority.
