### PR TITLE
fix and optimize sounds and music (on macos?)

### DIFF
--- a/lovely/sound.toml
+++ b/lovely/sound.toml
@@ -98,7 +98,7 @@ elseif request.type == 'sound_source' then
     SMODS_Sounds[request.sound_code] = {
         sound_code = request.sound_code,
         data = request.data,
-        sound = sound,
+        should_stream = request.should_stream,
         per = request.per,
         vol = request.vol,
     }
@@ -130,6 +130,31 @@ pattern = "RESTART_MUSIC()"
 match_indent = true
 position = 'at'
 payload = 'RESTART_MUSIC(request)'
+
+[[patches]]
+[patches.regex]
+target = 'engine/sound_manager.lua'
+pattern = """(?<indent>[\t ]*)function RESTART_MUSIC\\(args\\)(\n.*){14}"""
+line_prepend = '$indent'
+position = 'at'
+payload = """function RESTART_MUSIC(args)
+    for k, v in pairs(SOURCES) do
+        if string.find(k,'music') then
+            for i, s in ipairs(v) do
+                s.sound:stop()
+            end
+            SOURCES[k] = {}
+            if not SMODS_Sounds[k] or k == args.desired_track then
+                args.per = 0.7
+                args.vol = 0.6
+                args.sound_code = k
+                local s = PLAY_SOUND(args)
+                if s then s.initialized = true end
+            end
+        end
+    end
+  end
+"""
 
 # fix looping for music of different length
 

--- a/lovely/sound.toml
+++ b/lovely/sound.toml
@@ -132,29 +132,26 @@ position = 'at'
 payload = 'RESTART_MUSIC(request)'
 
 [[patches]]
-[patches.regex]
+[patches.pattern]
 target = 'engine/sound_manager.lua'
-pattern = """(?<indent>[\t ]*)function RESTART_MUSIC\\(args\\)(\n.*){14}"""
-line_prepend = '$indent'
+pattern = '''SOURCES[k] = {}
+            args.per = 0.7'''
+match_indent = true
 position = 'at'
-payload = """function RESTART_MUSIC(args)
-    for k, v in pairs(SOURCES) do
-        if string.find(k,'music') then
-            for i, s in ipairs(v) do
-                s.sound:stop()
-            end
-            SOURCES[k] = {}
+payload = '''SOURCES[k] = {}
             if not SMODS_Sounds[k] or k == args.desired_track then
-                args.per = 0.7
-                args.vol = 0.6
-                args.sound_code = k
-                local s = PLAY_SOUND(args)
-                if s then s.initialized = true end
-            end
-        end
-    end
-  end
-"""
+            args.per = 0.7'''
+
+[[patches]]
+[patches.pattern]
+target = 'engine/sound_manager.lua'
+pattern = '''local s = PLAY_SOUND(args)
+            s.initialized = true'''
+match_indent = true
+position = 'at'
+payload = '''local s = PLAY_SOUND(args)
+            if s then s.initialized = true end
+            end'''
 
 # fix looping for music of different length
 


### PR DESCRIPTION
On MacOS, with enough mods enabled which load sounds and/or music, the game goes completely silent. I think I have tracked down the root issue for this: OpenAL has a maximum playing instances limit (see https://github.com/MonoGame/MonoGame/issues/4403). And if I understood the code correctly, vanilla loads and plays all songs simultaneously and just changes the volume when switching from one song to another. This is fine for the limited songs in vanilla, but seemingly exhausts that OpenAL limit with mods. I couldn't find much more info on this, but this fix, to only load vanilla songs and the one `desired_track` actually needed, at least worked on my machine. 😝 This may cause either "unexpected" additional calls of `RESTART_MUSIC` or even delays, when a mod tries to play a song mid-game. But I guess that's better than silence.

The `should_stream` thing was my first attempt at fixing this when I first thought this was a memory issue...it still seems useful, because if I understood everything correctly, it should avoid sounds being fully decoded into memory in runtime. Feel free to remove it from this PR, if this is too out-of-scope.

I tested neither of those on a Windows PC though, so I wouldn't merge this before checking that.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
