### PR TITLE
Changes to badge colour handling

### DIFF
--- a/lovely/edition.toml
+++ b/lovely/edition.toml
@@ -93,6 +93,7 @@ pattern = 'return G.BADGE_COL[key] or {1, 0, 0, 1}'
 position = 'before'
 match_indent = true
 payload = '''
+if G.BADGE_COL[key] then return G.BADGE_COL[key] end
 for _, v in ipairs(G.P_CENTER_POOLS.Edition) do
 	G.BADGE_COL[v.key:sub(3)] = v.badge_colour
 end'''

--- a/lovely/ui.toml
+++ b/lovely/ui.toml
@@ -294,7 +294,7 @@ target = 'functions/UI_definitions.lua'
 pattern = 'local card_type_colour = get_type_colour(card.config.center or card.config, card)'
 position = 'after'
 match_indent = true
-payload = 'local card_type_text_colour = (AUT.card_type and SMODS.ConsumableTypes[AUT.card_type] and SMODS.ConsumableTypes[AUT.card_type].text_colour) or G.C.UI.TEXT_LIGHT'
+payload = "local card_type_text_colour = SMODS.get_badge_text_colour(debuffed and 'debuffed' or nil, AUT.card_type, card.config.center or card.config, card)"
 
 # G.UIDEF.card_h_popup():
 # pass "card_type_text_colour" variable to create_badge() when creating the badge for a card type
@@ -305,6 +305,26 @@ pattern = "badges[#badges + 1] = create_badge(((card.ability.name == 'Pluto' or 
 position = 'at'
 match_indent = true
 payload = "badges[#badges + 1] = create_badge(((card.ability.name == 'Pluto' or card.ability.name == 'Ceres' or card.ability.name == 'Eris') and localize('k_dwarf_planet')) or (card.ability.name == 'Planet X' and localize('k_planet_q') or card_type), card_type_colour, card_type_text_colour, 1.2)"
+
+# G.UIDEF.card_h_popup():
+# pass text colour when creating other badges
+[[patches]]
+[patches.pattern]
+target = 'functions/UI_definitions.lua'
+pattern = 'badges[#badges + 1] = create_badge(localize(v, "labels"), get_badge_colour(v))'
+position = 'at'
+match_indent = true
+payload = 'badges[#badges + 1] = create_badge(localize(v, "labels"), get_badge_colour(v), SMODS.get_badge_text_colour(v))'
+
+# get_type_colour:
+# get badge colour from centers
+[[patches]]
+[patches.pattern]
+target = 'functions/common_events.lua'
+pattern = "(_c.set == 'Joker' and G.C.RARITY[_c.rarity]) or "
+position = 'before'
+match_indent = true
+payload = "_c.badge_colour or"
 
 # Fixing description error when info_queue has multi-box descriptions.
 

--- a/lovely/ui.toml
+++ b/lovely/ui.toml
@@ -294,7 +294,7 @@ target = 'functions/UI_definitions.lua'
 pattern = 'local card_type_colour = get_type_colour(card.config.center or card.config, card)'
 position = 'after'
 match_indent = true
-payload = "local card_type_text_colour = SMODS.get_badge_text_colour(debuffed and 'debuffed' or nil, AUT.card_type, card.config.center or card.config, card)"
+payload = "local card_type_text_colour = SMODS.get_badge_text_colour(nil, AUT.card_type, card.config.center or card.config, card)"
 
 # G.UIDEF.card_h_popup():
 # pass "card_type_text_colour" variable to create_badge() when creating the badge for a card type

--- a/lovely/ui.toml
+++ b/lovely/ui.toml
@@ -294,7 +294,7 @@ target = 'functions/UI_definitions.lua'
 pattern = 'local card_type_colour = get_type_colour(card.config.center or card.config, card)'
 position = 'after'
 match_indent = true
-payload = "local card_type_text_colour = SMODS.get_badge_text_colour(nil, AUT.card_type, card.config.center or card.config, card)"
+payload = "local card_type_text_colour = SMODS.get_card_type_text_colour(AUT.card_type, card.config.center or card.config, card)"
 
 # G.UIDEF.card_h_popup():
 # pass "card_type_text_colour" variable to create_badge() when creating the badge for a card type

--- a/lsp_def/classes/center.lua
+++ b/lsp_def/classes/center.lua
@@ -17,7 +17,9 @@
 ---@field eternal_compat? boolean Sets whether the center can have "Eternal" sticker. 
 ---@field perishable_compat? boolean Sets whether the center can have "Perishable" sticker. 
 ---@field display_size? table|{w: integer, h: integer} Changes the display size of card. 
----@field pixel_size? table|{w: integer, h: integer} Change the size of the sprite drawn onto the card. 
+---@field pixel_size? table|{w: integer, h: integer} Change the size of the sprite drawn onto the card.
+---@field badge_text_colour? table Colour of the label for the badge (supersedes Rarities and ConsumableTypes).
+---@field badge_colour? table Colour of the badge (supersedes Rarities and ConsumableTypes).
 ---@field __call? fun(self: SMODS.Center|table, o: SMODS.Center|table): nil|table|SMODS.Center
 ---@field extend? fun(self: SMODS.Center|table, o: SMODS.Center|table): table Primary method of creating a class. 
 ---@field check_duplicate_register? fun(self: SMODS.Center|table): boolean? Ensures objects already registered will not register. 

--- a/lsp_def/classes/edition.lua
+++ b/lsp_def/classes/edition.lua
@@ -10,7 +10,8 @@
 ---@field in_shop? boolean Sets if the Edition spawns naturally in the shop. 
 ---@field weight? number The weight of the Edition. 
 ---@field extra_cost? number Extra cost applied to cards in the shop with this Edition. 
----@field apply_to_float? boolean Sets if the shader is drawn on floating sprites. 
+---@field apply_to_float? boolean Sets if the shader is drawn on floating sprites.
+---@field text_colour? table Colour of the label for the badge.
 ---@field badge_colour? table HEX color of the Edition's badge
 ---@field sound? table|{sound: string, per?: number, vol?: number} Used to set a custom sound when the Edition is applied. 
 ---@field disable_shadow? boolean Sets if the shadow is drawn under the card with this Edition. 

--- a/lsp_def/classes/rarity.lua
+++ b/lsp_def/classes/rarity.lua
@@ -6,7 +6,8 @@
 ---@field loc_txt? table|{name: string} Contains strings used for displaying text related to this object. 
 ---@field super? SMODS.GameObject|table Parent class. 
 ---@field pools? table Table with a list of ObjectTypes keys this rarity should be added to.
----@field badge_colour? table HEX color the rarity badge uses. 
+---@field text_colour? table Colour of the label for the badge.
+---@field badge_colour? table HEX color the rarity badge uses.
 ---@field default_weight? number Default weight of the rarity. When referenced in ObjectTypes with just the key, this value is used as the default. 
 ---@field disable_if_empty? boolean Disables polling of the rarity if set to `true` if there are no available objects.
 ---@field __call? fun(self: SMODS.Rarity|table, o: SMODS.Rarity|table): nil|table|SMODS.Rarity

--- a/lsp_def/classes/seal.lua
+++ b/lsp_def/classes/seal.lua
@@ -8,6 +8,7 @@
 ---@field atlas? string Key to the seal's atlas. 
 ---@field pos? table|{x: integer, y: integer} Position of the seal's sprite. 
 ---@field unlocked? boolean Sets the unlock state of the center. 
+---@field text_colour? table Colour of the label for the badge.
 ---@field badge_colour? table HEX color the seal badge uses. 
 ---@field sound? table|{} Controls the sound that plays when the seal is applied. `sound`: Key to the sound, `per`: Sound pitch, `vol`: Sound volume. 
 ---@field badge_to_key? string[] Contains keys to each seal indexed by seal badge (`key:lower()..'_seal`). 

--- a/lsp_def/classes/sticker.lua
+++ b/lsp_def/classes/sticker.lua
@@ -9,6 +9,7 @@
 ---@field order? number Position of the sticker in collections menu. 
 ---@field rate? number Change of this sticker applying onto an eligible card. 
 ---@field hide_badge? boolean Sets if the sticker badge shows up on the card. 
+---@field text_colour? table Colour of the label for the badge.
 ---@field badge_colour? table HEX color the sticker badge uses. 
 ---@field default_compat? boolean Default compatibility with cards. 
 ---@field compat_exceptions? string[] Array of keys to centers that are exceptions to `default_compat`. 

--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -773,4 +773,16 @@ function SMODS.challenge_is_unlocked(challenge, k) end
 --- a string, which changes the displayed text, a boolean, which disables StatusText when set to `false`,
 --- a table, which defines the `attention_text` function settings, or a function that takes the key of
 --- the hand and scoring parameter being upgraded as arguments and returns a boolean, string or table
-    function SMODS.upgrade_poker_hands(args) end
+function SMODS.upgrade_poker_hands(args) end
+
+---Returns the text colour for the card type's badge or nil if none
+---@param type string?
+---@param center SMODS.Center|table?
+---@param card Card|table?
+---@return table?
+function SMODS.get_card_type_text_colour(type, center, card) end
+
+---Returns the text colour for the badge of an object with this key or nil if none
+---@param key string
+---@return table?
+function SMODS.get_badge_text_colour(key) end

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -3421,20 +3421,19 @@ SMODS.custom_debuff_handling = {
     'j_shoot_the_moon', 'j_baron', 'j_reserved_parking', 'j_raised_fist'
 }
 
-function SMODS.get_badge_text_colour(key, type, center, card)
-    if (center or {}).badge_text_colour then
-        if (card or {}).debuff then return end
-        return center.badge_text_colour
-    end
+function SMODS.get_card_type_text_colour(type, center, card)
+    if (card or {}).debuff then return end
+    if (center or {}).badge_text_colour then return center.badge_text_colour end
     if type == 'Joker' and center then
-        if (card or {}).debuff then return end
         local rarity = ({"Common", "Uncommon", "Rare", "Legendary"})[center.rarity] or center.rarity
         return SMODS.Rarities[rarity] and SMODS.Rarities[rarity].text_colour
     end
     if type and SMODS.ConsumableTypes[type] then
-        if (card or {}).debuff then return end
         return SMODS.ConsumableTypes[type].text_colour
     end
+end
+
+function SMODS.get_badge_text_colour(key)
     if not key then return end
     if (SMODS.Rarities[key] or {}).text_colour then return SMODS.Rarities[key].text_colour end
     if (SMODS.Stickers[key] or {}).text_colour then return SMODS.Stickers[key].text_colour end

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -3420,3 +3420,28 @@ end
 SMODS.custom_debuff_handling = {
     'j_shoot_the_moon', 'j_baron', 'j_reserved_parking', 'j_raised_fist'
 }
+
+function SMODS.get_badge_text_colour(key, type, center, card)
+    if (center or {}).badge_text_colour then
+        if (card or {}).debuff then return end
+        return center.badge_text_colour
+    end
+    if type == 'Joker' and center then
+        if (card or {}).debuff then return end
+        local rarity = ({"Common", "Uncommon", "Rare", "Legendary"})[center.rarity] or center.rarity
+        return SMODS.Rarities[rarity] and SMODS.Rarities[rarity].text_colour
+    end
+    if type and SMODS.ConsumableTypes[type] then
+        if (card or {}).debuff then return end
+        return SMODS.ConsumableTypes[type].text_colour
+    end
+    if not key then return end
+    if (SMODS.Rarities[key] or {}).text_colour then return SMODS.Rarities[key].text_colour end
+    if (SMODS.Stickers[key] or {}).text_colour then return SMODS.Stickers[key].text_colour end
+    for _, v in ipairs(G.P_CENTER_POOLS.Edition) do
+        if v.key:sub(3) == key and v.text_colour then return v.text_colour end
+    end
+    for k, v in pairs(SMODS.Seals) do
+        if k:lower()..'_seal' == key and v.text_colour then return v.text_colour end
+    end
+end


### PR DESCRIPTION
* Allows most (all?) card/modifier objects to specify a `text_colour` for their badge which was previously only possible by ConsumableTypes
* Centers also have a `badge_colour`/`badge_text_colour` which will replace the colours for whatever card type badge they have. This is useful for Enhancements/Boosters but can also be used to replace the Rarity/ConsumableType badge on an individual object if one needs to.
* ConsumableTypes (and everything added in the PR) now use the default white colour for the badge when debuffed instead of `text_colour`
* Badges now use the vanilla default G.C.WHITE instead of G.C.UI.TEXT_LIGHT for badges. I think they are the same though but just in case something else changes one but not the other
* Added an early return to get_badge_colour() so it doesn't run every loop every time it needs to get a badge's colour if it already exists. This could probably just return if G.BADGE_COL exists at all but I didn't know if that would break something.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
