### PR TITLE
Fix AnimatedSprite size in mods menu

### DIFF
--- a/src/ui.lua
+++ b/src/ui.lua
@@ -1014,7 +1014,7 @@ function buildModtag(mod)
     tag_sprite.stop_hover = function(_self) _self.hovering = false; Node.stop_hover(_self); _self.hover_tilt = 0 end
     tag_sprite.update = function (self, dt)
         if not self.rescaled then
-            if type(tag_sprite.rescale) == "function" then tag_sprite:rescale() end
+            if type(self.rescale) == "function" then self:rescale() end
             self.rescaled = true
         end
     end

--- a/src/ui.lua
+++ b/src/ui.lua
@@ -1012,6 +1012,12 @@ function buildModtag(mod)
         G.FUNCS["openModUI_" .. mod.id](self)
     end
     tag_sprite.stop_hover = function(_self) _self.hovering = false; Node.stop_hover(_self); _self.hover_tilt = 0 end
+    tag_sprite.update = function (self, dt)
+        if not self.rescaled then
+            if type(tag_sprite.rescale) == "function" then tag_sprite:rescale() end
+            self.rescaled = true
+        end
+    end
 
     tag_sprite:juice_up()
 


### PR DESCRIPTION
It runs `rescale` on the sprite but since it doesn't work if done on creation (I'm assuming it has to do with the UI elements resizing it) it's done via an `update` function. I thought that would be better than adding a bunch of events to the queue.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
