### PR TITLE
Update card_draw.lua

### DIFF
--- a/src/card_draw.lua
+++ b/src/card_draw.lua
@@ -8,6 +8,8 @@ function SMODS.CanvasSprite:init(args)
     self.canvasScale = 10
     self.text = ""
     self.text_offset = {x = 0, y = 0}
+	self.text_h_align = 'center'
+	self.text_v_align = 'middle'
     for k, v in pairs(args) do self[k] = v end
     self.canvas = love.graphics.newCanvas(self.canvasW * self.canvasScale, self.canvasH * self.canvasScale)
     self.font = (SMODS.Fonts[self.text_font] or G.FONTS[self.text_font] or G.FONTS[1]).FONT
@@ -373,7 +375,7 @@ SMODS.DrawStep {
     key = 'canvas_text',
     order = 45,
     func = function(self, layer)
-        if self.canvas_text then
+        if self.canvas_text and (self.config.center.discovered or self.bypass_discovery_center) then
             for _, sprite in ipairs(self.canvas_text[1] and self.canvas_text or {self.canvas_text}) do
                 love.graphics.push()
                 love.graphics.origin()
@@ -386,7 +388,8 @@ SMODS.DrawStep {
                             (0 + sprite.text_offset.y) * sprite.canvasScale,
                             0,
                             scale_fac, scale_fac,
-                            text:getWidth()/2, text:getHeight()/2
+							sprite.text_h_align == 'left' and 0 or (sprite.text_h_align == 'right' and text:getWidth() or text:getWidth()/2),
+							sprite.text_v_align == 'top' and 0 or (sprite.text_v_align == 'bottom' and text:getHeight() or text:getHeight()/2)
                         })
                     sprite.canvas:renderTo(love.graphics.draw,
                         text,


### PR DESCRIPTION
Bug fix: canvas text was drawn even when card was undiscovered.

New functionality: easy text alignment: rather then creating a new table for text_transform whenever the text changes, this way you can simply set text_h_align and text_v_align once.

text_h_align can be 'left', 'center' (default behaviour) or 'right' text_v_align can be 'top', 'middle' (default behaviour) or 'bottom'



## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
