### PR TITLE
fix smods duplication detection

### DIFF
--- a/src/preflight/loader.lua
+++ b/src/preflight/loader.lua
@@ -289,7 +289,7 @@ function loadMods(modsDirectory)
             elseif filename:lower():match('%.json') and depth > 1 then
                 local json_str = NFS.read(file_path)
                 local parsed, mod = pcall(JSON.decode, json_str)
-                if mod and mod.name and mod.name:find('Steamodded') then print('[SMODS DUPE] SET smods_dupe='..directory..' from file='..file_path..' SMODS.path='..tostring(SMODS.path)); smods_dupe = directory end
+                if mod and mod.name and mod.name:find('Steamodded') then smods_dupe = directory end
                 local valid = true
                 local err
                 if not parsed then

--- a/src/preflight/loader.lua
+++ b/src/preflight/loader.lua
@@ -231,7 +231,7 @@ function loadMods(modsDirectory)
 
     -- Function to process each directory (including subdirectories) with depth tracking
     local function processDirectory(directory, depth, flags)
-        if depth > 3 or directory..'/' == SMODS.path then
+        if depth > 3 or SMODS.path:sub(-#(directory..'/')) == directory..'/' then
             return
         end
 
@@ -289,7 +289,7 @@ function loadMods(modsDirectory)
             elseif filename:lower():match('%.json') and depth > 1 then
                 local json_str = NFS.read(file_path)
                 local parsed, mod = pcall(JSON.decode, json_str)
-                if mod and mod.name and mod.name:find('Steamodded') then smods_dupe = directory end
+                if mod and mod.name and mod.name:find('Steamodded') then print('[SMODS DUPE] SET smods_dupe='..directory..' from file='..file_path..' SMODS.path='..tostring(SMODS.path)); smods_dupe = directory end
                 local valid = true
                 local err
                 if not parsed then


### PR DESCRIPTION
Smods detected itself as dupe, relative vs. absolute paths was the issue here.

Example log with the debug log removed in 69005ebb077d480e84f671a0552e84c1af89229b:

```
INFO - [G] Mods	smods	1
INFO - [G] [SMODS DUPE] SET smods_dupe=Mods/smods from file=Mods/smods/manifest.json SMODS.path=/Users/nnmrts/Library/Application Support/Balatro/Mods/smods/
```

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
