### PR TITLE
Fix: Update Blind's description with `set_text` (Fixes #1233) and properly update name with loc_vars

### DIFF
--- a/lovely/blind.toml
+++ b/lovely/blind.toml
@@ -386,10 +386,14 @@ end
 [[patches]]
 [patches.pattern]
 target = 'functions/UI_definitions.lua'
-pattern = "local text_table = loc_target"
+pattern = '''
+local loc_name = localize{type = 'name_text', key = blind_choice.config.key, set = 'Blind'}
+local text_table = loc_target
+'''
 match_indent = true
 position = 'at'
 payload = '''
+local loc_name = localize{type = 'name_text', key = target.key or blind_choice.config.key, set = target.set or 'Blind'}
 local text_table = G.localization.descriptions[target.set][target.key].text_parsed
 '''
 
@@ -397,7 +401,10 @@ local text_table = G.localization.descriptions[target.set][target.key].text_pars
 [[patches]]
 [patches.pattern]
 target = 'functions/UI_definitions.lua'
-pattern = '''local loc_target = localize{type = 'raw_descriptions', key = blind.key, set = 'Blind', vars = vars or blind.vars}'''
+pattern = '''
+local loc_target = localize{type = 'raw_descriptions', key = blind.key, set = 'Blind', vars = vars or blind.vars}
+local loc_name = localize{type = 'name_text', key = blind.key, set = 'Blind'}
+'''
 match_indent = true
 position = 'at'
 payload = '''
@@ -410,7 +417,8 @@ if blind.collection_loc_vars and type(blind.collection_loc_vars) == 'function' t
     target.scale = res.scale
     target.text_colour = res.text_colour
 end
-local loc_target = G.localization.descriptions[target.set][target.key].text_parsed'''
+local loc_target = G.localization.descriptions[target.set][target.key].text_parsed
+local loc_name = localize{type = 'name_text', key = target.key or blind.key, set = target.set or 'Blind'}'''
 
 [[patches]]
 [patches.pattern]
@@ -422,6 +430,36 @@ match_indent = true
 position = 'at'
 payload = '''
 ability_text[#ability_text + 1] = {n=G.UIT.R, config={align = "cm"}, nodes=SMODS.localize_box(v, {default_col = target.text_colour or G.C.WHITE, shadow = true, vars = target.vars, scale = target.scale})}
+'''
+
+# create_UIBox_round_scores_row()
+[[patches]]
+[patches.pattern]
+target = 'functions/UI_definitions.lua'
+pattern = '''
+local blind_choice = {config = G.GAME.blind.config.blind or G.P_BLINDS.bl_small}
+'''
+match_indent = true
+position = 'after'
+payload = '''
+local target = {type = 'name_text', key = blind_choice.config.key, set = 'Blind'}
+if blind_choice.config.loc_vars and type(blind_choice.config.loc_vars) == 'function' then
+    local res = blind_choice.config:loc_vars() or {}
+    target.key = res.key or target.key
+    target.set = res.set or target.set
+end
+'''
+
+[[patches]]
+[patches.pattern]
+target = 'functions/UI_definitions.lua'
+pattern = '''
+{n=G.UIT.O, config={object = DynaText({string = localize(target), colours = {G.C.WHITE},shadow = true, float = true,maxw = 2.2, scale = 0.45})}}
+'''
+match_indent = true
+position = 'at'
+payload = '''
+{n=G.UIT.O, config={object = DynaText({string = localize{type ='name_text', key = blind_choice.config.key, set = 'Blind'}, colours = {G.C.WHITE},shadow = true, float = true,maxw = 2.2, scale = 0.45})}}
 '''
 
 # get_new_boss()

--- a/lovely/blind.toml
+++ b/lovely/blind.toml
@@ -454,12 +454,12 @@ end
 [patches.pattern]
 target = 'functions/UI_definitions.lua'
 pattern = '''
-{n=G.UIT.O, config={object = DynaText({string = localize(target), colours = {G.C.WHITE},shadow = true, float = true,maxw = 2.2, scale = 0.45})}}
+{n=G.UIT.O, config={object = DynaText({string = localize{type ='name_text', key = blind_choice.config.key, set = 'Blind'}, colours = {G.C.WHITE},shadow = true, float = true,maxw = 2.2, scale = 0.45})}}
 '''
 match_indent = true
 position = 'at'
 payload = '''
-{n=G.UIT.O, config={object = DynaText({string = localize{type ='name_text', key = blind_choice.config.key, set = 'Blind'}, colours = {G.C.WHITE},shadow = true, float = true,maxw = 2.2, scale = 0.45})}}
+{n=G.UIT.O, config={object = DynaText({string = localize(target), colours = {G.C.WHITE},shadow = true, float = true,maxw = 2.2, scale = 0.45})}}
 '''
 
 # get_new_boss()

--- a/lovely/blind_ui.toml
+++ b/lovely/blind_ui.toml
@@ -75,6 +75,7 @@ position = 'before'
 payload = '''
 EMPTY(self.loc_debuff_lines)
 if G.localization.descriptions[target.set][target.key] then
+    self.update_loc_debuff_lines = true
     for k, v in ipairs(G.localization.descriptions[target.set][target.key].text_parsed) do
         self.loc_debuff_lines[k] = v
     end

--- a/lovely/blind_ui.toml
+++ b/lovely/blind_ui.toml
@@ -76,6 +76,7 @@ payload = '''
 EMPTY(self.loc_debuff_lines)
 if G.localization.descriptions[target.set][target.key] then
     self.update_loc_debuff_lines = true
+    self.loc_name = self.name == '' and self.name or localize{type ='name_text', key = target.key, set = target.set}
     for k, v in ipairs(G.localization.descriptions[target.set][target.key].text_parsed) do
         self.loc_debuff_lines[k] = v
     end

--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -17,7 +17,14 @@ G.FUNCS.HUD_blind_debuff = function(e)
 		local excess_height = (0.3 + padding)*(num_lines - 5)
 		padding = padding - excess_height / (num_lines + 1)
 	end
-	e.config.padding = padding
+    e.config.padding = padding
+    if G.GAME.blind.update_loc_debuff_lines then
+		for i = 1, #e.children do
+			e.children[i]:remove()
+			e.children[i] = nil
+		end
+		G.GAME.blind.update_loc_debuff_lines = nil
+	end
 	if num_lines > #e.children then
         for i = #e.children + 1, num_lines do
 			local node_def 


### PR DESCRIPTION
Allows `blind:set_text()` to work properly again after #1199. This still doesn't allow the same functionality as before as you could change `G.GAME.blind.loc_debuff_lines` directly for the text to be updated but I think it's a good compromise.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
