### PR TITLE
`main_start`/`end` support for multiboxes

### DIFF
--- a/lovely/multi_box_descriptions.toml
+++ b/lovely/multi_box_descriptions.toml
@@ -73,6 +73,8 @@ local multi_boxes = {}
 if AUT.multi_box then
     for i, box in ipairs(AUT.multi_box) do
         box.background_colour = box.background_colour or AUT.box_colours and AUT.box_colours[i+1] or nil
+        if AUT.box_starts and AUT.box_starts[i] then table.insert(box, 1, AUT.box_starts[i]) end
+        if AUT.box_ends and AUT.box_ends[i] then table.insert(box, AUT.box_ends[i]) end
         multi_boxes[#multi_boxes+1] = desc_from_rows(box)
     end
 end

--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -1219,8 +1219,10 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
                 target.set = res.set or target.set
                 target.scale = res.scale
                 target.text_colour = res.text_colour
-                full_UI_table.box_starts = res.box_starts
-                full_UI_table.box_ends = res.box_ends
+                if desc_nodes == full_UI_table.main then
+                    full_UI_table.box_starts = res.box_starts
+                    full_UI_table.box_ends = res.box_ends
+                end
             end
 
             if desc_nodes == full_UI_table.main and not full_UI_table.name then
@@ -2984,8 +2986,10 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
                 target.set = res.set or target.set
                 target.scale = res.scale
                 target.text_colour = res.text_colour
-                full_UI_table.box_starts = res.box_starts
-                full_UI_table.box_ends = res.box_ends
+                if desc_nodes == full_UI_table.main then
+                    full_UI_table.box_starts = res.box_starts
+                    full_UI_table.box_ends = res.box_ends
+                end
             end
             if desc_nodes == full_UI_table.main and not full_UI_table.name then
                 full_UI_table.name = localize { type = 'name', set = target.set, key = res.name_key or target.key, nodes = full_UI_table.name, vars = res.name_vars or res.vars or {} }

--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -1219,6 +1219,8 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
                 target.set = res.set or target.set
                 target.scale = res.scale
                 target.text_colour = res.text_colour
+                full_UI_table.box_starts = res.box_starts
+                full_UI_table.box_ends = res.box_ends
             end
 
             if desc_nodes == full_UI_table.main and not full_UI_table.name then
@@ -2982,6 +2984,8 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
                 target.set = res.set or target.set
                 target.scale = res.scale
                 target.text_colour = res.text_colour
+                full_UI_table.box_starts = res.box_starts
+                full_UI_table.box_ends = res.box_ends
             end
             if desc_nodes == full_UI_table.main and not full_UI_table.name then
                 full_UI_table.name = localize { type = 'name', set = target.set, key = res.name_key or target.key, nodes = full_UI_table.name, vars = res.name_vars or res.vars or {} }


### PR DESCRIPTION
Adds `box_starts` and `box_ends` returns to `loc_vars` to support `main_start`/`end` on centers and tag's multiboxes.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
