### PR TITLE
fix scoring calculation operator text not being set when re-entering a run

### DIFF
--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2776,6 +2776,7 @@ function Game:start_run(args)
         trigger = 'immediate',
         func = function()
             SMODS.refresh_score_UI_list()
+            G.HUD:get_UIE_by_ID('hand_operator_container').UIBox:recalculate()
             return true
         end
     }))


### PR DESCRIPTION
noticed this when i was fucking around with scoring calculations earlier. i had set the scoring calc to exponent, and when re-entering the run the ui was the default multiply ui, but the current calc was still exponent

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [X] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [X] I didn't modify api's or I've updated lsp definitions.
- [X] I didn't make new lovely files or all new lovely files have appropriate priority.
