### PR TITLE
Feat: Add ``Card:can_sell()`` API method

### DIFF
--- a/lovely/better_calc.toml
+++ b/lovely/better_calc.toml
@@ -1879,7 +1879,7 @@ if v ~= eligible_card and (not v.ability.eternal) then v:start_dissolve(nil, _fi
 payload = '''
 if v ~= eligible_card and (not SMODS.is_eternal(v, self)) then v.getting_sliced = true; v:start_dissolve(nil, _first_dissolve);_first_dissolve = true end
 '''
-# Card:can_sell()
+# Card:can_sell(), Add can_sell API method
 [[patches]]
 [patches.pattern]
 target = 'card.lua'
@@ -1890,6 +1890,12 @@ not self.ability.eternal then
 '''
 payload = '''
 not SMODS.is_eternal(self, {from_sell = true}) then
+
+local obj = self.config.center
+if self.ability.set ~= "Enhanced" and obj.can_sell and type(obj.can_sell) == 'function' then
+	local o, t = obj:can_sell(self, context)
+	if o or t then return o, t end
+end
 '''
 
 # Adds tag_added context

--- a/lovely/better_calc.toml
+++ b/lovely/better_calc.toml
@@ -1894,7 +1894,7 @@ not SMODS.is_eternal(self, {from_sell = true}) then
 local obj = self.config.center
 if self.ability.set ~= "Enhanced" and obj.can_sell and type(obj.can_sell) == 'function' then
 	local o, t = obj:can_sell(self, context)
-	if o or t then return o, t end
+	if o ~= nil or t ~= nil then return o, t end
 end
 '''
 

--- a/lovely/better_calc.toml
+++ b/lovely/better_calc.toml
@@ -1893,8 +1893,7 @@ not SMODS.is_eternal(self, {from_sell = true}) then
 
 local obj = self.config.center
 if self.ability.set ~= "Enhanced" and obj.can_sell and type(obj.can_sell) == 'function' then
-	local o, t = obj:can_sell(self, context)
-	if o ~= nil or t ~= nil then return o, t end
+	return obj:can_sell(self, context)
 end
 '''
 

--- a/lsp_def/classes/consumable.lua
+++ b/lsp_def/classes/consumable.lua
@@ -25,7 +25,7 @@
 ---@field can_use? fun(self: SMODS.Consumable|table, card: Card|table): boolean? Return `true` if the consumable is allowed to be used. 
 ---@field keep_on_use? fun(self: SMODS.Consumable|table, card: Card|table): boolean? Return `true` if the consumable should stay after use.
 ---@field calc_scaling? fun(self: SMODS.Consumable|table, card: Card|table, other_card: Card|table, scaling_value: number, scalar_value: number, args: table): table? Called by `SMODS.scale_card`. Allows detection and modification of cards when scaling values. The return may include a `scaling_value` or `scalar_value` field to modify those values or any standard calculation return.
----@field can_sell? fun(self: SMODS.Consumable|table, context: unknown?):boolean? Allows configuring if the card is allowed to be sold. (Context is not used in vanilla and it's not the same as `calculate`)
+---@field can_sell? fun(self: SMODS.Consumable|table, card: Card|table, context: unknown?):boolean? Allows configuring if the card is allowed to be sold. (Context is not used in vanilla and it's not the same as `calculate`)
 ---@overload fun(self: SMODS.Consumable): SMODS.Consumable
 SMODS.Consumable = setmetatable({}, {
     __call = function(self)

--- a/lsp_def/classes/consumable.lua
+++ b/lsp_def/classes/consumable.lua
@@ -25,7 +25,7 @@
 ---@field can_use? fun(self: SMODS.Consumable|table, card: Card|table): boolean? Return `true` if the consumable is allowed to be used. 
 ---@field keep_on_use? fun(self: SMODS.Consumable|table, card: Card|table): boolean? Return `true` if the consumable should stay after use.
 ---@field calc_scaling? fun(self: SMODS.Consumable|table, card: Card|table, other_card: Card|table, scaling_value: number, scalar_value: number, args: table): table? Called by `SMODS.scale_card`. Allows detection and modification of cards when scaling values. The return may include a `scaling_value` or `scalar_value` field to modify those values or any standard calculation return.
----@field can_sell? fun(self: SMODS.Consumable|table, context: unknown?):boolean? Allows configuring if the card is allowed to be sold. 
+---@field can_sell? fun(self: SMODS.Consumable|table, context: unknown?):boolean? Allows configuring if the card is allowed to be sold. (Context is not used in vanilla and it's not the same as `calculate`)
 ---@overload fun(self: SMODS.Consumable): SMODS.Consumable
 SMODS.Consumable = setmetatable({}, {
     __call = function(self)

--- a/lsp_def/classes/consumable.lua
+++ b/lsp_def/classes/consumable.lua
@@ -25,6 +25,7 @@
 ---@field can_use? fun(self: SMODS.Consumable|table, card: Card|table): boolean? Return `true` if the consumable is allowed to be used. 
 ---@field keep_on_use? fun(self: SMODS.Consumable|table, card: Card|table): boolean? Return `true` if the consumable should stay after use.
 ---@field calc_scaling? fun(self: SMODS.Consumable|table, card: Card|table, other_card: Card|table, scaling_value: number, scalar_value: number, args: table): table? Called by `SMODS.scale_card`. Allows detection and modification of cards when scaling values. The return may include a `scaling_value` or `scalar_value` field to modify those values or any standard calculation return.
+---@field can_sell? fun(self: SMODS.Consumable|table, context: unknown?):boolean? Allows configuring if the card is allowed to be sold. 
 ---@overload fun(self: SMODS.Consumable): SMODS.Consumable
 SMODS.Consumable = setmetatable({}, {
     __call = function(self)

--- a/lsp_def/classes/joker.lua
+++ b/lsp_def/classes/joker.lua
@@ -18,7 +18,7 @@
 ---@field get_obj? fun(self: SMODS.Joker|table, key: string): SMODS.Joker|table? Returns an object if one matches the `key`. 
 ---@field calc_dollar_bonus? fun(self: SMODS.Joker|table, card: Card|table): nil|number Calculates reward money. 
 ---@field calc_scaling? fun(self: SMODS.Joker|table, card: Card|table, other_card: Card|table, scaling_value: number, scalar_value: number, args: table): table? Called by `SMODS.scale_card`. Allows detection and modification of cards when scaling values. The return may include a `scaling_value` or `scalar_value` field to modify those values or any standard calculation return.
----@field can_sell? fun(self: SMODS.Joker|table, context: unknown?):boolean? Allows configuring if the card is allowed to be sold. 
+---@field can_sell? fun(self: SMODS.Joker|table, context: unknown?):boolean? Allows configuring if the card is allowed to be sold. (Context is not used in vanilla and it's not the same as `calculate`)
 ---@field new? fun(self, name, slug, config, spritePos, loc_txt, rarity, cost, unlocked, discovered,blueprint_compat, eternal_compat, effect, atlas, soul_pos): any DEPRECATED. DO NOT USE
 ---@overload fun(self: SMODS.Joker): SMODS.Joker
 SMODS.Joker = setmetatable({}, {

--- a/lsp_def/classes/joker.lua
+++ b/lsp_def/classes/joker.lua
@@ -18,7 +18,7 @@
 ---@field get_obj? fun(self: SMODS.Joker|table, key: string): SMODS.Joker|table? Returns an object if one matches the `key`. 
 ---@field calc_dollar_bonus? fun(self: SMODS.Joker|table, card: Card|table): nil|number Calculates reward money. 
 ---@field calc_scaling? fun(self: SMODS.Joker|table, card: Card|table, other_card: Card|table, scaling_value: number, scalar_value: number, args: table): table? Called by `SMODS.scale_card`. Allows detection and modification of cards when scaling values. The return may include a `scaling_value` or `scalar_value` field to modify those values or any standard calculation return.
----@field can_sell? fun(self: SMODS.Joker|table, context: unknown?):boolean? Allows configuring if the card is allowed to be sold. (Context is not used in vanilla and it's not the same as `calculate`)
+---@field can_sell? fun(self: SMODS.Joker|table, card: Card|table, context: unknown?):boolean? Allows configuring if the card is allowed to be sold. (Context is not used in vanilla and it's not the same as `calculate`)
 ---@field new? fun(self, name, slug, config, spritePos, loc_txt, rarity, cost, unlocked, discovered,blueprint_compat, eternal_compat, effect, atlas, soul_pos): any DEPRECATED. DO NOT USE
 ---@overload fun(self: SMODS.Joker): SMODS.Joker
 SMODS.Joker = setmetatable({}, {

--- a/lsp_def/classes/joker.lua
+++ b/lsp_def/classes/joker.lua
@@ -18,6 +18,7 @@
 ---@field get_obj? fun(self: SMODS.Joker|table, key: string): SMODS.Joker|table? Returns an object if one matches the `key`. 
 ---@field calc_dollar_bonus? fun(self: SMODS.Joker|table, card: Card|table): nil|number Calculates reward money. 
 ---@field calc_scaling? fun(self: SMODS.Joker|table, card: Card|table, other_card: Card|table, scaling_value: number, scalar_value: number, args: table): table? Called by `SMODS.scale_card`. Allows detection and modification of cards when scaling values. The return may include a `scaling_value` or `scalar_value` field to modify those values or any standard calculation return.
+---@field can_sell? fun(self: SMODS.Joker|table, context: unknown?):boolean? Allows configuring if the card is allowed to be sold. 
 ---@field new? fun(self, name, slug, config, spritePos, loc_txt, rarity, cost, unlocked, discovered,blueprint_compat, eternal_compat, effect, atlas, soul_pos): any DEPRECATED. DO NOT USE
 ---@overload fun(self: SMODS.Joker): SMODS.Joker
 SMODS.Joker = setmetatable({}, {


### PR DESCRIPTION
Identical to other API method patches - But from what I can see, looks like it needs to be in better_calc.toml? As the area where the API method needs to be directly follows an eternal check and the next thing after that is a return.

May need to be moved to center.toml



## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [X] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
