### PR TITLE
Adjust Chaos the Clown

### DIFF
--- a/lovely/shop.toml
+++ b/lovely/shop.toml
@@ -183,7 +183,7 @@ pattern = '''
 G.GAME.current_round.free_rerolls = G.GAME.current_round.free_rerolls + 1
 '''
 payload = '''
-SMODS.change_free_rerolls(1)
+SMODS.change_free_rerolls(self.ability.extra or 1)
 '''
 [[patches]]
 [patches.pattern]
@@ -194,7 +194,7 @@ pattern = '''
 G.GAME.current_round.free_rerolls = G.GAME.current_round.free_rerolls - 1
 '''
 payload = '''
-SMODS.change_free_rerolls(-1)
+SMODS.change_free_rerolls(-(self.ability.extra or 1))
 '''
 
 ## Shop Card Area Width


### PR DESCRIPTION
Makes Chaos the Clown actually use its extra value instead of just being a flat 1; This improves flexibility if a mod wanted to say, scale its reroll count using ``scale_card`` as part of a mechanic effect or some other interaction.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [X] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
