### PR TITLE
`disable_shine` for boosters, vouchers, and spectrals

### DIFF
--- a/lsp_def/classes/booster.lua
+++ b/lsp_def/classes/booster.lua
@@ -8,7 +8,8 @@
 ---@field kind? string Groups pack types together. For example, this can be used in `get_pack()` to generate a booster pack of a specific type. 
 ---@field weight? number Weight of the booster pack. 
 ---@field select_card? string|{[string]: string} Key to the CardArea (e.x. `G[SMODS.Booster.select_card]`). Consumables inside this booster pack will be "selected" and emplaced into a CardArea instead of used. As a table, each key-value pair is a card set as key and CardArea string as values.  
----@field select_exclusions? string[] List of card sets to exclude from being "Selected". 
+---@field select_exclusions? string[] List of card sets to exclude from being "Selected".
+---@field disable_shine? boolean If true, disables the default shine shader.
 ---@field __call? fun(self: SMODS.Booster|table, o: SMODS.Booster|table): nil|table|SMODS.Booster
 ---@field extend? fun(self: SMODS.Booster|table, o: SMODS.Booster|table): table Primary method of creating a class. 
 ---@field check_duplicate_register? fun(self: SMODS.Booster|table): boolean? Ensures objects already registered will not register. 

--- a/lsp_def/classes/consumable.lua
+++ b/lsp_def/classes/consumable.lua
@@ -6,7 +6,8 @@
 ---@field soul_set? string Key to the ConsumableType set this consumable can replace. Requires `hidden` to be true.
 ---@field soul_rate? number Chance this card replaces a consumable. Requires `hidden` to be true.
 ---@field type? SMODS.ConsumableType|table ConsumableType this center belongs to. 
----@field legendaries? (SMODS.Consumable|table)[] All injected "legendary" consumables. 
+---@field legendaries? (SMODS.Consumable|table)[] All injected "legendary" consumables.
+---@field disable_shine? boolean If true, disables the default shine shader (for Spectrals).
 ---@field __call? fun(self: SMODS.Consumable|table, o: SMODS.Consumable|table): nil|table|SMODS.Consumable
 ---@field extend? fun(self: SMODS.Consumable|table, o: SMODS.Consumable|table): table Primary method of creating a class. 
 ---@field check_duplicate_register? fun(self: SMODS.Consumable|table): boolean? Ensures objects already registered will not register. 

--- a/lsp_def/classes/voucher.lua
+++ b/lsp_def/classes/voucher.lua
@@ -2,7 +2,8 @@
 
 ---@class SMODS.Voucher: SMODS.Center
 ---@field super? SMODS.Center|table Parent class. 
----@field requires? string[] Array of keys to other voucher. This voucher will not appear if those are not redeemed.  
+---@field requires? string[] Array of keys to other voucher. This voucher will not appear if those are not redeemed.
+---@field disable_shine? boolean If true, disables the default shine shader.
 ---@field __call? fun(self: SMODS.Voucher|table, o: SMODS.Voucher|table): nil|table|SMODS.Voucher
 ---@field extend? fun(self: SMODS.Voucher|table, o: SMODS.Voucher|table): table Primary method of creating a class. 
 ---@field check_duplicate_register? fun(self: SMODS.Voucher|table): boolean? Ensures objects already registered will not register. 

--- a/src/card_draw.lua
+++ b/src/card_draw.lua
@@ -286,11 +286,11 @@ SMODS.DrawStep {
     order = 10,
     func = function(self)
         if (self.ability.set == 'Voucher' or self.config.center.demo) and (self.ability.name ~= 'Antimatter' or not (self.config.center.discovered or self.bypass_discovery_center)) then
-            if self:should_draw_base_shader() then
+            if self:should_draw_base_shader() and not self.config.center.disable_shine then
                 self.children.center:draw_shader('voucher', nil, self.ARGS.send_to_shader)
             end
         end
-        if (self.ability.set == 'Booster' or self.ability.set == 'Spectral') and self:should_draw_base_shader() then
+        if (self.ability.set == 'Booster' or self.ability.set == 'Spectral') and self:should_draw_base_shader() and not self.config.center.disable_shine then
             self.children.center:draw_shader('booster', nil, self.ARGS.send_to_shader)
         end
     end,


### PR DESCRIPTION
This is a simple change to the card_type_shader DrawStep that allows for easy disabling of the shine shader for Booster, Voucher, and Spectral objects. Simply add `disable_shine = true` to any of these objects to disable

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
