### PR TITLE
pass args.level_up to args.func in SMODS.upgrade_poker_hands

### DIFF
--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -775,7 +775,7 @@ function SMODS.is_active_blind(key, ignore_disabled) end
 ---@return boolean
 function SMODS.challenge_is_unlocked(challenge, k) end
 
----@param args table|{hands?: table, parameters?: table, level_up?: number|boolean, func?: fun(base: number, hand: string, param: string), instant?: boolean, StatusText?: boolean|string|table|fun(hand: string, parameter: string)}
+---@param args table|{hands?: table, parameters?: table, level_up?: number|boolean, func?: fun(base: number, hand: string, param: string, level_up?: number|boolean), instant?: boolean, StatusText?: boolean|string|table|fun(hand: string, parameter: string)}
 --- This functions handles upgrading poker hands in more complex ways. You can define
 --- a custom `func` to modify the values in specific ways. `hands` and `parameters` can
 --- be limited to specific ones, or default to using all of `G.GAME.hands` and `SMODS.Scoring_Parameters`.

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -3386,7 +3386,7 @@ function SMODS.upgrade_poker_hands(args)
         for i, parameter in ipairs(args.parameters) do
             if G.GAME.hands[hand][parameter] then
                 context.old_parameters[parameter] = G.GAME.hands[hand][parameter]
-                G.GAME.hands[hand][parameter] = args.func(G.GAME.hands[hand][parameter], hand, parameter)
+                G.GAME.hands[hand][parameter] = args.func(G.GAME.hands[hand][parameter], hand, parameter, args.level_up)
                 context.new_parameters[parameter] = G.GAME.hands[hand][parameter]
                 if not instant then
                     local StatusText = true


### PR DESCRIPTION
Per discussion in the Potato Patch discord server, this passes the `level_up` value in `SMODS.upgrade_poker_hands` to the optional custom function, allowing for that custom function to properly interact with the amount of levels given to the hand.

Theoretical use case: someone has a modded joker that doubles all planet level-ups, as well as a modded planet that always adds +50 Chips and +10 Mult to a random hand. The modded joker is implemented by hooking `SMODS.upgrade_poker_hands` and simply doubling `args.level_up` if the joker is present, and then the modded planet can use `SMODS.upgrade_poker_hands` with a custom function to do its thing while still allowing the joker to interact with it and properly double both the increase in level number and the increases in the parameters.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [X] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [X] I didn't modify api's or I've updated lsp definitions.
- [X] I didn't make new lovely files or all new lovely files have appropriate priority.
