### PR TITLE
feat: add conditionals for cycling dynatext content

### DIFF
--- a/lovely/dynatext_conditionals.toml
+++ b/lovely/dynatext_conditionals.toml
@@ -44,3 +44,21 @@ end
 '''
 match_indent = true
 
+# Check condition for the initial string
+[[patches]]
+[patches.pattern]
+target = 'engine/text.lua'
+pattern = '''for k, v in ipairs(self.strings) do'''
+position = 'before'
+payload = '''
+if first_pass and type(self.strings[self.focused_string]) == 'table' and 
+type(self.strings[self.focused_string].condition) == 'function' and not self.strings[self.focused_string].condition() then
+	while true do
+		self.focused_string = (self.config.random_element and math.random(1, #self.strings)) or self.focused_string ==  #self.strings and 1 or self.focused_string+1
+		if type(self.strings[self.focused_string]) ~= 'table' or not self.strings[self.focused_string].condition then break
+		elseif self.strings[self.focused_string].condition() then break end
+	end
+end
+
+'''
+match_indent = true


### PR DESCRIPTION
Adds the ability to limit when certain content can appear in a cycling DynaText

### Example
```lua
DynaText({
  string = {
    "Did you know ... ",
    {string = "You're rich!", condition = function() return G.GAME.dollars > 50 end},
    {string = "You're poor!", condition = function() return G.GAME.dollars <= 50 end}
  }
  -- other code
})
```

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
