### PR TITLE
Ability to specify scale args for custom round eval rows

### DIFF
--- a/lovely/better_calc.toml
+++ b/lovely/better_calc.toml
@@ -851,7 +851,7 @@ elseif string.find(config.name, 'joker') then
 '''
 payload = '''
 elseif config.name == 'custom' then
-    if config.number then table.insert(left_text, {n=G.UIT.T, config={text = config.number, scale = 0.8*scale, colour = config.number_colour or G.C.FILTER, shadow = true, juice = true}}) end
+    if config.number then table.insert(left_text, {n=G.UIT.T, config={text = config.number, scale = config.number_scale or 0.8*scale, colour = config.number_colour or G.C.FILTER, shadow = true, juice = true}}) end
     table.insert(left_text, {n=G.UIT.O, config={object = DynaText({string = {" "..config.text}, colours = {config.text_colour or G.C.UI.TEXT_LIGHT}, shadow = true, pop_in = 0, scale = config.text_scale or 0.4*scale, silent = true})}})
 '''
 


### PR DESCRIPTION
Adds parsing for ``config.number_scale`` and ``config.text_scale`` vars in ``add_round_eval_row`` calls where ``config.name`` is ``'custom'``, offers mod authors better flexibility over custom round eval row calls.

Useful if you want a row that's a little larger than the default scales of ``0.8*0.9`` and ``0.4*0.9`` respectively.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [X] I didn't make new lovely files or all new lovely files have appropriate priority.
