### PR TITLE
stakes don't increment their own order anymore

### DIFF
--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -703,8 +703,8 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
             if self.above_stake and G.P_STAKES[self.above_stake] then
                 self.order = G.P_STAKES[self.above_stake].order + 1
             end
-            for _, v in pairs(G.P_STAKES) do
-                if v.order >= self.order then
+            for i, v in pairs(G.P_STAKES) do
+                if i ~= self.key and v.order >= self.order then
                     v.order = v.order + 1
                 end
             end


### PR DESCRIPTION
This is a teeny tiny PR to fix an interaction with `above_stake`: during the stake inject process, it would iterate over `G.P_STAKES` to ensure that if it was being set to some order that wasn't just the end of the list, all the other stakes in the list would get bumped up one to compensate. However, the stake was already added to `G.P_STAKES` at that time, so it would also increment its own order, and the stake order would get extremely messy. This should make `above_stake` function as intended once again.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [X] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [X] I didn't modify api's or I've updated lsp definitions.
- [X] I didn't make new lovely files or all new lovely files have appropriate priority.
