### PR TITLE
Added some Attributes

### DIFF
--- a/src/game_objects/attributes.lua
+++ b/src/game_objects/attributes.lua
@@ -451,6 +451,10 @@ SMODS.Attribute({
 })
 
 SMODS.Attribute({
+    key = 'stickers'
+})
+
+SMODS.Attribute({
     key = 'tag',
     keys = { 'j_diet_cola' }
 })
@@ -503,13 +507,23 @@ SMODS.Attribute({
 
 SMODS.Attribute({
     key = 'consumeable',
-    alias = {'consumable'},
     keys = {
         'j_perkeo', 'j_astronomer', 'j_constellation', 'j_satellite', 'j_8_ball', 'j_superposition', 
         'j_vagabond', 'j_hallucination', 'j_fortune_teller', 'j_cartomancer', 'j_sixth_sense', 'j_seance',
     }
 })
+
 SMODS.Attribute({
     key = 'consumeable_slot',
-    alias = {'consumable_slot'},
+})
+
+SMODS.Attribute({
+    key = 'debuff'
+})
+
+SMODS.Attribute({
+    key = 'position'
+    keys = {
+        'j_blueprint', 'j_ceremonial', 'j_brainstorm', 'j_hanging_chad', 'j_photograph',
+    }
 })

--- a/src/game_objects/attributes.lua
+++ b/src/game_objects/attributes.lua
@@ -501,12 +501,6 @@ SMODS.Attribute({
     }
 })
 
-SMODS.Attribute {
-    key = "destroy_self",
-    keys = {
-    "j_mr_bones", 'j_gros_michel', 'j_cavendish', 'j_ice_cream', 'j_ramen', 'j_turtle_bean', 'j_popcorn', 'j_selzer',
-    },
-}
 SMODS.Attribute({
     key = 'consumeable',
     alias = {'consumable'},

--- a/src/game_objects/attributes.lua
+++ b/src/game_objects/attributes.lua
@@ -500,3 +500,22 @@ SMODS.Attribute({
         'j_hiker'
     }
 })
+
+SMODS.Attribute {
+    key = "destroy_self",
+    keys = {
+    "j_mr_bones", 'j_gros_michel', 'j_cavendish', 'j_ice_cream', 'j_ramen', 'j_turtle_bean', 'j_popcorn', 'j_selzer',
+    },
+}
+SMODS.Attribute({
+    key = 'consumeable',
+    alias = {'consumable'},
+    keys = {
+        'j_perkeo', 'j_astronomer', 'j_constellation', 'j_satellite', 'j_8_ball', 'j_superposition', 
+        'j_vagabond', 'j_hallucination', 'j_fortune_teller', 'j_cartomancer', 'j_sixth_sense', 'j_seance',
+    }
+})
+SMODS.Attribute({
+    key = 'consumeable_slot',
+    alias = {'consumable_slot'},
+})

--- a/src/game_objects/attributes.lua
+++ b/src/game_objects/attributes.lua
@@ -506,7 +506,7 @@ SMODS.Attribute({
 })
 
 SMODS.Attribute({
-    key = 'consumeable',
+    key = 'consumable',
     keys = {
         'j_perkeo', 'j_astronomer', 'j_constellation', 'j_satellite', 'j_8_ball', 'j_superposition', 
         'j_vagabond', 'j_hallucination', 'j_fortune_teller', 'j_cartomancer', 'j_sixth_sense', 'j_seance',
@@ -514,7 +514,7 @@ SMODS.Attribute({
 })
 
 SMODS.Attribute({
-    key = 'consumeable_slot',
+    key = 'consumable_slot',
 })
 
 SMODS.Attribute({


### PR DESCRIPTION
added a general "consumable" attribute for jokers that interact with consumables in general, like perkeo or a potential modded joker that creates any consumeable
added a "consumable_slot" attribute because "joker_slot" exists
added "stickers" because "editions", "seals", and "enhancements" exist
added "position" for jokers that mind certain card positions
added "debuff" for jokers that debuff cards or gain something when debuffed
## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [X] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [X] I didn't modify api's or I've updated lsp definitions.
- [X] I didn't make new lovely files or all new lovely files have appropriate priority.

Wiki PR: https://github.com/Steamodded/Wiki/pull/106
