### PR TITLE
split Card:set_cost for convenient overrides

### DIFF
--- a/lovely/center.toml
+++ b/lovely/center.toml
@@ -684,3 +684,52 @@ remove_all(self.children)
 payload = '''
 if self.canvas_text then SMODS.clean_up_canvas_text(self) end
 '''
+
+# Card:set_cost()
+# Split Card:set_cost into Card:set_cost_value and Card:set_sell_value
+[[patches]]
+[patches.pattern]
+target = 'card.lua'
+match_indent = false
+position = 'at'
+pattern = '''
+    if self.area and self.ability.couponed and (self.area == G.shop_jokers or self.area == G.shop_booster) then self.cost = 0 end
+    self.sell_cost_label = self.facing == 'back' and '?' or self.sell_cost
+end
+'''
+payload = '''
+end
+'''
+[[patches]]
+[patches.pattern]
+target = 'card.lua'
+match_indent = false
+position = 'after'
+pattern = '''
+function Card:set_cost()
+    self.extra_cost = 0 + G.GAME.inflation
+'''
+payload = '''
+
+    self:set_cost_value()
+    self:set_sell_value()
+
+    if self.area and self.ability.couponed and (self.area == G.shop_jokers or self.area == G.shop_booster) then self.cost = 0 end
+    self.sell_cost_label = self.facing == 'back' and '?' or self.sell_cost
+end
+
+function Card:set_cost_value()
+'''
+[[patches]]
+[patches.pattern]
+target = 'card.lua'
+match_indent = false
+position = 'after'
+pattern = '''
+    if self.ability.rental then self.cost = 1 end
+'''
+payload = '''
+end
+
+function Card:set_sell_value()
+'''


### PR DESCRIPTION
splits `Card:set_cost()` into `Card:set_cost_value()` and `Card:set_sell_value()`, so that these individual behaviors can be overridden without needing to use lovely patches. all lines of code for vanilla behavior are still present and are still run in their original order, so any existing patches mods have made will continue to work

this is a follow-up to my [set_cost context PR](https://github.com/Steamodded/smods/pull/1114), since that never got merged (for reasons that i agree with). i'll be closing that PR in a moment as i think this is a better way to do the same thing

apologies if the location of the patch isn't ideal, it's very hard for me to tell where the correct place to put patches is lol

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
