### PR TITLE
Fix dropdowns causing unnecessary recalculates

### DIFF
--- a/lsp_def/ui.lua
+++ b/lsp_def/ui.lua
@@ -388,7 +388,7 @@ function G.FUNCS.scrollbar(e) end
 ---@field id? string Assigns the given id to the config table of the root of the button UIBox if set.
 ---@field option_align? string Aligns the text of the dropdown options. Works just like aligning regular UI nodes. Default is "cl".
 ---@field close_on_select? boolean If true, the dropdown menu will automatically close when an option is selected or unselected.
----@field display_choice_func? fun(option: string): string? If defined, changes the displayed text for a choice to the returned value of this function. `option` is 
+---@field display_choice_func? fun(option: string): string? If defined, changes the displayed text for a choice to the returned value of this function. `option` is the current option selected from the `options` table.
 
 ---Returns a button that creates a dropdown selection menu when clicked on.
 ---@param args DropdownSelectArgs

--- a/src/ui.lua
+++ b/src/ui.lua
@@ -2948,7 +2948,7 @@ function SMODS.GUI.dropdown_select(args)
                                         },
                                         colours = { args.text_colour or G.C.UI.TEXT_LIGHT },
                                         scale = args.scale,
-                                        non_recalc = true,
+                                        non_recalc = type(args.minw) == "number",
                                         shadow = true,
                                         silent = true,
                                     })

--- a/src/ui.lua
+++ b/src/ui.lua
@@ -2905,10 +2905,6 @@ function SMODS.GUI.dropdown_select(args)
     end
     args.dropdown_bg_colour = args.dropdown_bg_colour or lighten(G.C.BLACK, 0.2)
     args.selected_colour = args.selected_colour or G.C.BLACK
-    args.display_choice_func = args.display_choice_func or function(option)
-        return option
-    end
-    local table_ref = args.ref_table
 	local arrow = SMODS.create_sprite(0, 0, args.scale * 0.75, args.scale * 0.75, "dropdown_arrow", { x = 0, y = 0 })
     return {
         n = args.ui_type or G.UIT.R,
@@ -2937,19 +2933,25 @@ function SMODS.GUI.dropdown_select(args)
                         },
                         nodes = {
                             {
-                                n = G.UIT.T,
+                                n = G.UIT.O,
                                 config = {
-                                    ref_table = setmetatable({}, {
-                                        __index = function(_, k)
-                                            if k == args.ref_value then
-                                                return args.display_choice_func(table_ref[k])
-                                            end
-                                            return table_ref[k]
-                                        end
-                                    }),
-                                    ref_value = args.ref_value,
-                                    colour = args.text_colour or G.C.UI.TEXT_LIGHT,
-                                    scale = args.scale,
+                                    object = DynaText({
+                                        string = {
+                                            {
+                                                ref_table = args.display_choice_func and setmetatable({}, {
+                                                    __index = function(_, _)
+                                                        return args.display_choice_func(args.ref_table[args.ref_value])
+                                                    end
+                                                }) or args.ref_table,
+                                                ref_value = args.ref_value,
+                                            }
+                                        },
+                                        colours = { args.text_colour or G.C.UI.TEXT_LIGHT },
+                                        scale = args.scale,
+                                        non_recalc = true,
+                                        shadow = true,
+                                        silent = true,
+                                    })
                                 },
                             },
                         }
@@ -3031,18 +3033,6 @@ function G.FUNCS.dropdown_select(e)
     if args.close_on_select then
         G.FUNCS.toggle_dropdown_menu(e.config.dropdown_button)
     end
-    local text = args.display_choice_func(args.ref_table[args.ref_value])
-    local parent = e.config.dropdown_button.children[1].children[1]
-    if parent.config and parent.config.text and not parent.config.text_drawable then
-        parent.config.lang = parent.config.lang or G.LANG
-        parent.config.text_drawable = love.graphics.newText((parent.config.font or parent.config.lang.font).FONT, {G.C.WHITE,parent.config.text})
-    end
-    if text ~= parent.config.prev_value then
-        parent.config.text = text
-        parent.config.text_drawable:set(parent.config.text)
-        if not parent.config.prev_value or (parent.config.prev_value and string.len(parent.config.prev_value) ~= string.len(parent.config.text)) then parent.UIBox:recalculate() end
-        parent.config.prev_value = text
-    end
 end
 
 function G.FUNCS.update_dropdown_select(e)
@@ -3089,7 +3079,7 @@ function SMODS.GUI.create_UIBox_dropdown_menu(args, parent_width, parent)
                             n = G.UIT.T,
                             config = {
                                 scale = args.dropdown_scale or 0.4,
-                                text = args.display_choice_func(opt),
+                                text = args.display_choice_func and args.display_choice_func(opt) or opt,
                                 colour = args.dropdown_text_colour or G.C.UI.TEXT_LIGHT
                             },
                         },


### PR DESCRIPTION
This fixes a bug with #1253 where the currently selected option updating its text would force the UIBox it's inside of to recalculate, causing UI issues when the dropdown is used in a collection menu for instance.

Edit: I had to add back in the recalc for dropdowns without a minw for the main dropdown box, in order to preserve the UI adapting to the size of the current option. It still should generally be preferred to make a dropdown with a minw defined, but omitting it had never been disallowed.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
