### PR TITLE
`soul_atlas`: Separate atlas for center's floating sprite

### DIFF
--- a/lsp_def/classes/center.lua
+++ b/lsp_def/classes/center.lua
@@ -5,6 +5,7 @@
 ---@field super? SMODS.GameObject|table Parent class. 
 ---@field atlas? string Key to the center's atlas. 
 ---@field pos? table|{x: integer, y: integer} Position of the center's sprite. 
+---@field soul_atlas? string Key to the center's soul atlas. 
 ---@field soul_pos? table|{x: integer, y: integer, draw?: fun(card: Card|table, scale_mod?: number, rotate_mod?: number)} Position of the "soul" sprite. Separate front layer sprite that hovers over the card. 
 ---@field unlocked? boolean Sets the unlock state of the center. 
 ---@field discovered? boolean Sets the discovery state of the center. 

--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -74,7 +74,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
         local atlas_cfg = obj.prefix_config.atlas
         if atlas_cfg ~= false then
             if type(atlas_cfg) ~= 'table' then atlas_cfg = {} end
-            for _, v in ipairs({ 'atlas', 'hc_atlas', 'lc_atlas', 'hc_ui_atlas', 'lc_ui_atlas', 'sticker_atlas' }) do
+            for _, v in ipairs({ 'atlas', 'hc_atlas', 'lc_atlas', 'hc_ui_atlas', 'lc_ui_atlas', 'soul_atlas', 'hc_soul_atlas', 'lc_soul_atlas', 'sticker_atlas' }) do
                 if rawget(obj, v) then SMODS.modify_key(obj, mod and mod.prefix, atlas_cfg, v) end
             end
         end

--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -1206,6 +1206,9 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
                     end
                 end
             end
+            if self.soul_atlas and not self.soul_pos then
+                self.soul_pos = { x = 0, y = 0 }
+            end
         end,
         delete = function(self)
             G.P_CENTERS[self.key] = nil

--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -1861,7 +1861,7 @@ function Card:set_sprites(_center, _front)
 
         if _center.soul_pos then
 			if self.children.floating_sprite then self.children.floating_sprite:remove() end
-			local atlas_key = _center[G.SETTINGS.colourblind_option and 'hc_atlas' or 'lc_atlas'] or _center.atlas or _center.set
+            local atlas_key = _center[G.SETTINGS.colourblind_option and 'hc_soul_atlas' or 'lc_soul_atlas'] or _center.soul_atlas or _center[G.SETTINGS.colourblind_option and 'hc_atlas' or 'lc_atlas'] or _center.atlas or _center.set
             self.children.floating_sprite = SMODS.create_sprite(self.T.x, self.T.y, self.T.w, self.T.h, atlas_key, self.config.center.soul_pos)
             self.children.floating_sprite.role.draw_major = self
             self.children.floating_sprite.states.hover.can = false

--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -1859,10 +1859,10 @@ function Card:set_sprites(_center, _front)
             end
         end
 
-        if _center.soul_pos then
+        if _center.soul_pos or _center[G.SETTINGS.colourblind_option and 'hc_soul_atlas' or 'lc_soul_atlas'] or _center.soul_atlas then
 			if self.children.floating_sprite then self.children.floating_sprite:remove() end
             local atlas_key = _center[G.SETTINGS.colourblind_option and 'hc_soul_atlas' or 'lc_soul_atlas'] or _center.soul_atlas or _center[G.SETTINGS.colourblind_option and 'hc_atlas' or 'lc_atlas'] or _center.atlas or _center.set
-            self.children.floating_sprite = SMODS.create_sprite(self.T.x, self.T.y, self.T.w, self.T.h, atlas_key, self.config.center.soul_pos)
+            self.children.floating_sprite = SMODS.create_sprite(self.T.x, self.T.y, self.T.w, self.T.h, atlas_key, _center.soul_pos or { x = 0, y = 0 })
             self.children.floating_sprite.role.draw_major = self
             self.children.floating_sprite.states.hover.can = false
             self.children.floating_sprite.states.click.can = false


### PR DESCRIPTION
This PR adds ability to specify atlas used for creating card's `floating_sprite` aka "soul sprite" via `soul_atlas` property in `SMODS.Center` class.
Same as for center's sprite, `hc_soul_atlas` and `lc_soul_atlas` can be used for high/low contrast atlases respectively.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
