### PR TITLE
fix: resolve nil-indexing crashes in deck_preview UI

### DIFF
--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -806,7 +806,7 @@ function G.UIDEF.deck_preview(args)
 
 	for k, v in ipairs(suit_map) do
 		if not hidden_suits[v] then
-			local deckskin = SMODS.DeckSkins[G.SETTINGS.CUSTOM_DECK.Collabs[v]]
+			local deckskin = SMODS.DeckSkins[G.SETTINGS.CUSTOM_DECK.Collabs[v]] or {}
 			local palette = (deckskin or {}).palette_map and (deckskin.palette_map[G.SETTINGS.colour_palettes[v] or ""] or ((deckskin or {}).palettes or {})[1]) or {}
 			local t_s
 			if palette and palette.suit_icon and palette.suit_icon.atlas then

--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -808,6 +808,7 @@ function G.UIDEF.deck_preview(args)
 		if not hidden_suits[v] then
 			local deckskin = SMODS.DeckSkins[G.SETTINGS.CUSTOM_DECK.Collabs[v]]
 			local palette = deckskin and (deckskin.palette_map and deckskin.palette_map[G.SETTINGS.colour_palettes[v] or ""] or (deckskin.palettes or {})[1]) or {}
+			local t_s
 			if palette and palette.suit_icon and palette.suit_icon.atlas then
 				local _x = (v == 'Spades' and 3) or (v == 'Hearts' and 0) or (v == 'Clubs' and 2) or (v == 'Diamonds' and 1)
 				local atlas_key = palette.suit_icon.atlas or 'ui_1'

--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -733,7 +733,7 @@ function G.UIDEF.deck_preview(args)
 				if v.base.suit == kk and not v_ns then suit_counts[kk] = suit_counts[kk] + 1 end
 				if v:is_suit(kk) then mod_suit_counts[kk] = mod_suit_counts[kk] + 1 end
 			end
-			if v.base.suit and SUITS[v.base.suit] and SUITS[v.base.suit][v.base.value] and not v_nr and not v_ns then
+			if (SUITS[v.base.suit] or {})[v.base.value] and not v_nr and not v_ns then
 				table.insert(SUITS[v.base.suit][v.base.value], v)
 			end
 			if not v_nr then
@@ -795,7 +795,7 @@ function G.UIDEF.deck_preview(args)
 				local _colour = #SUITS[suit][rank] > 0 and flip_col or G.C.UI.TRANSPARENT_LIGHT
 
 				local _col = {n = G.UIT.C, config = {align = "cm", padding = 0.05, minw = _minw + 0.098, minh = _minh }, nodes = {
-					{n = G.UIT.T, config = {text = '' .. (SUITS[suit] and SUITS[suit][rank] and #SUITS[suit][rank] or 0), colour = _colour, scale = _tscale, shadow = true, lang = G.LANGUAGES['en-us'] } },}}
+					{n = G.UIT.T, config = {text = '' .. #((SUITS[suit] or {})[rank] or {}), colour = _colour, scale = _tscale, shadow = true, lang = G.LANGUAGES['en-us'] } },}}
 				if not hidden_ranks[rank] then table.insert(_row, _col) end
 			end
 			table.insert(deck_tables,
@@ -807,7 +807,7 @@ function G.UIDEF.deck_preview(args)
 	for k, v in ipairs(suit_map) do
 		if not hidden_suits[v] then
 			local deckskin = SMODS.DeckSkins[G.SETTINGS.CUSTOM_DECK.Collabs[v]]
-			local palette = deckskin and (deckskin.palette_map and deckskin.palette_map[G.SETTINGS.colour_palettes[v] or ""] or (deckskin.palettes or {})[1]) or {}
+			local palette = (deckskin or {}).palette_map and (deckskin.palette_map[G.SETTINGS.colour_palettes[v] or ""] or ((deckskin or {}).palettes or {})[1]) or {}
 			local t_s
 			if palette and palette.suit_icon and palette.suit_icon.atlas then
 				local _x = (v == 'Spades' and 3) or (v == 'Hearts' and 0) or (v == 'Clubs' and 2) or (v == 'Diamonds' and 1)

--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -733,7 +733,7 @@ function G.UIDEF.deck_preview(args)
 				if v.base.suit == kk and not v_ns then suit_counts[kk] = suit_counts[kk] + 1 end
 				if v:is_suit(kk) then mod_suit_counts[kk] = mod_suit_counts[kk] + 1 end
 			end
-			if v.base.suit and SUITS[v.base.suit][v.base.value] and not v_nr and not v_ns then
+			if v.base.suit and SUITS[v.base.suit] and SUITS[v.base.suit][v.base.value] and not v_nr and not v_ns then
 				table.insert(SUITS[v.base.suit][v.base.value], v)
 			end
 			if not v_nr then

--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -795,7 +795,7 @@ function G.UIDEF.deck_preview(args)
 				local _colour = #SUITS[suit][rank] > 0 and flip_col or G.C.UI.TRANSPARENT_LIGHT
 
 				local _col = {n = G.UIT.C, config = {align = "cm", padding = 0.05, minw = _minw + 0.098, minh = _minh }, nodes = {
-					{n = G.UIT.T, config = {text = '' .. #SUITS[suit][rank], colour = _colour, scale = _tscale, shadow = true, lang = G.LANGUAGES['en-us'] } },}}
+					{n = G.UIT.T, config = {text = '' .. (SUITS[suit] and SUITS[suit][rank] and #SUITS[suit][rank] or 0), colour = _colour, scale = _tscale, shadow = true, lang = G.LANGUAGES['en-us'] } },}}
 				if not hidden_ranks[rank] then table.insert(_row, _col) end
 			end
 			table.insert(deck_tables,
@@ -807,8 +807,7 @@ function G.UIDEF.deck_preview(args)
 	for k, v in ipairs(suit_map) do
 		if not hidden_suits[v] then
 			local deckskin = SMODS.DeckSkins[G.SETTINGS.CUSTOM_DECK.Collabs[v]]
-			local palette = deckskin.palette_map and deckskin.palette_map[G.SETTINGS.colour_palettes[v] or ''] or (deckskin.palettes or {})[1]
-			local t_s
+			local palette = deckskin and (deckskin.palette_map and deckskin.palette_map[G.SETTINGS.colour_palettes[v] or ""] or (deckskin.palettes or {})[1]) or {}
 			if palette and palette.suit_icon and palette.suit_icon.atlas then
 				local _x = (v == 'Spades' and 3) or (v == 'Hearts' and 0) or (v == 'Clubs' and 2) or (v == 'Diamonds' and 1)
 				local atlas_key = palette.suit_icon.atlas or 'ui_1'

--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -807,7 +807,7 @@ function G.UIDEF.deck_preview(args)
 	for k, v in ipairs(suit_map) do
 		if not hidden_suits[v] then
 			local deckskin = SMODS.DeckSkins[G.SETTINGS.CUSTOM_DECK.Collabs[v]] or {}
-			local palette = (deckskin.palette_map or {})[G.SETTINGS.colour_palettes[v] or ""] or (deckskin.palettes or {})[1])
+			local palette = (deckskin.palette_map or {})[G.SETTINGS.colour_palettes[v] or ""] or (deckskin.palettes or {})[1]
 			local t_s
 			if palette and palette.suit_icon and palette.suit_icon.atlas then
 				local _x = (v == 'Spades' and 3) or (v == 'Hearts' and 0) or (v == 'Clubs' and 2) or (v == 'Diamonds' and 1)

--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -733,7 +733,7 @@ function G.UIDEF.deck_preview(args)
 				if v.base.suit == kk and not v_ns then suit_counts[kk] = suit_counts[kk] + 1 end
 				if v:is_suit(kk) then mod_suit_counts[kk] = mod_suit_counts[kk] + 1 end
 			end
-			if SUITS[v.base.suit][v.base.value] and not v_nr and not v_ns then
+			if v.base.suit and SUITS[v.base.suit][v.base.value] and not v_nr and not v_ns then
 				table.insert(SUITS[v.base.suit][v.base.value], v)
 			end
 			if not v_nr then

--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -807,7 +807,7 @@ function G.UIDEF.deck_preview(args)
 	for k, v in ipairs(suit_map) do
 		if not hidden_suits[v] then
 			local deckskin = SMODS.DeckSkins[G.SETTINGS.CUSTOM_DECK.Collabs[v]] or {}
-			local palette = (deckskin or {}).palette_map and (deckskin.palette_map[G.SETTINGS.colour_palettes[v] or ""] or ((deckskin or {}).palettes or {})[1]) or {}
+			local palette = (deckskin.palette_map or {})[G.SETTINGS.colour_palettes[v] or ""] or (deckskin.palettes or {})[1])
 			local t_s
 			if palette and palette.suit_icon and palette.suit_icon.atlas then
 				local _x = (v == 'Spades' and 3) or (v == 'Hearts' and 0) or (v == 'Clubs' and 2) or (v == 'Diamonds' and 1)


### PR DESCRIPTION
Adds three critical safety checks to G.UIDEF.deck_preview in src/overrides.lua to prevent "attempt to index a nil value" crashes during modded runs.

Changes:
   1. Logic Fix (Line ~736): Added checks for v.base.suit and its initialization in the SUITS table before indexing. This prevents crashes when encountering non-standard card data.
   2. UI Text Fix (Line ~798): Added a nil-safe check when displaying card counts per rank (SUITS[suit][rank]). This ensures the UI doesn't crash if a specific suit/rank combination isn't initialized.
   3. Palette Fix (Line ~810): Added a nil-check for deckskin before accessing palette_map. This prevents a crash if a suit is mapped to a custom deck skin that is missing or uninitialized.

These fixes significantly improve the stability of the Deck Preview UI in environments where mods (like Cryptid) introduce exotic card properties.
  
## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [X] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [X] I didn't modify api's or I've updated lsp definitions.
- [X] I didn't make new lovely files or all new lovely files have appropriate priority.
