### PR TITLE
Optimize quantum enhancements's `set_ability`

### DIFF
--- a/lovely/atlas.toml
+++ b/lovely/atlas.toml
@@ -46,10 +46,8 @@ pattern = '''
 local X, Y, W, H = self.T.x, self.T.y, self.T.w, self.T.h
 '''
 payload = '''
-if delay_sprites ~= 'quantum' then
-    for key, _ in pairs(self.T) do
-        self.T[key] = self.original_T[key]
-    end
+for key, _ in pairs(self.T) do
+    self.T[key] = self.original_T[key]
 end
 '''
 

--- a/lovely/center.toml
+++ b/lovely/center.toml
@@ -41,29 +41,6 @@ match_indent = true
 [patches.pattern]
 target = 'card.lua'
 match_indent = true
-position = 'after'
-pattern = '''
-if delay_sprites then 
-'''
-payload = '''
- if delay_sprites then
-'''
-[[patches]]
-[patches.pattern]
-target = 'card.lua'
-match_indent = true
-position = 'before'
-pattern = '''
-else
-    self:set_sprites(center)
-'''
-payload = '''
-end
-'''
-[[patches]]
-[patches.pattern]
-target = 'card.lua'
-match_indent = true
 position = 'at'
 pattern = '''
 self:set_sprites(center)

--- a/lovely/center.toml
+++ b/lovely/center.toml
@@ -46,7 +46,7 @@ pattern = '''
 if delay_sprites then 
 '''
 payload = '''
- if delay_sprites ~= 'quantum' then
+ if delay_sprites then
 '''
 [[patches]]
 [patches.pattern]

--- a/lovely/enhancement.toml
+++ b/lovely/enhancement.toml
@@ -326,5 +326,5 @@ match_indent = true
 target = 'card.lua'
 pattern = 'if not initial then G.GAME.blind:debuff_card(self) end'
 position = 'at'
-payload = 'if not initial and delay_sprites ~= "quantum" and G.GAME.blind then G.GAME.blind:debuff_card(self) end'
+payload = 'if not initial and G.GAME.blind then G.GAME.blind:debuff_card(self) end'
 match_indent = true

--- a/lovely/fixes.toml
+++ b/lovely/fixes.toml
@@ -166,7 +166,6 @@ pattern = "self.config.center = center"
 position = 'at'
 match_indent = true
 payload = '''
-if delay_sprites == 'quantum' then self.from_quantum = true end
 local was_added_to_deck = false
 if self.added_to_deck and old_center and not self.debuff then
     self:remove_from_deck()
@@ -189,7 +188,7 @@ payload = '''
 if was_added_to_deck and not self.debuff then
     self:add_to_deck()
 end
-self.from_quantum = nil'''
+'''
 
 
 ## set_ability() transfers over old fields

--- a/lovely/fixes.toml
+++ b/lovely/fixes.toml
@@ -220,14 +220,7 @@ self.ability.extra_slots_used = self.ability.extra_slots_used + (center.config.e
 
 
 -- reset keys do not persist on ability change
-local reset_keys = {'name', 'effect', 'set', 'extra', 'played_this_ante', 'perma_debuff'}
-for _, mod in ipairs(SMODS.mod_list) do
-    if mod.set_ability_reset_keys then
-        local keys = mod.set_ability_reset_keys()
-        for _, v in pairs(keys) do table.insert(reset_keys, v) end
-    end
-end
-for _, k in ipairs(reset_keys) do
+for _, k in ipairs(SMODS.get_ability_reset_keys(self) or {}) do
     self.ability[k] = new_ability[k]
 end
 '''

--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -2711,7 +2711,7 @@ function add_tag(_tag)
 	add_tag_ref(_tag)
 end
 
-function Card:quantum_set_ability(center)
+function Card:quantum_set_ability(center, reset_keys)
     SMODS.enh_cache:write(self, nil)
 
     if self.ability then
@@ -2796,13 +2796,6 @@ function Card:quantum_set_ability(center)
     self.ability.extra_slots_used = self.ability.extra_slots_used + (center.config.extra_slots_used or 0)
 
     -- reset keys do not persist on ability change
-    local reset_keys = {'name', 'effect', 'set', 'extra', 'played_this_ante', 'perma_debuff'}
-    for _, mod in ipairs(SMODS.mod_list) do
-        if mod.set_ability_reset_keys then
-            local keys = mod.set_ability_reset_keys()
-            for _, v in pairs(keys) do table.insert(reset_keys, v) end
-        end
-    end
     for _, k in ipairs(reset_keys) do
         self.ability[k] = new_ability[k]
     end
@@ -2850,19 +2843,7 @@ function Card:quantum_set_ability(center)
         self.ability.loyalty_remaining = self.ability.extra.every
     end
 
-    self.base_cost = center.cost or 1
-
     self.ability.hands_played_at_create = G.GAME and G.GAME.hands_played or 0
-
-    self.label = center.label or self.config.card and self.config.card.label or self.ability.set
-    if self.ability.set == 'Joker' then self.label = self.ability.name end
-    if self.ability.set == 'Edition' then self.label = self.ability.name end
-    if self.ability.consumeable then self.label = self.ability.name end
-    if self.ability.set == 'Voucher' then self.label = self.ability.name end
-    if self.ability.set == 'Booster' then
-        self.label = self.ability.name
-        self.mouse_damping = 1.5
-    end
 
     local obj = self.config.center
     if obj.set_ability and type(obj.set_ability) == 'function' then

--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -2692,6 +2692,7 @@ end
 
 local set_ability = Card.set_ability
 function Card:set_ability(center, initial, delay_sprites)
+    if delay_sprites == "quantum" then return self:quantum_set_ability(center) end
 	local old_center = self.config.center
 	set_ability(self, center, initial, delay_sprites)
 	if not initial and (G.STATE ~= G.STATES.SMODS_BOOSTER_OPENED and G.STATE ~= G.STATES.SHOP and not G.SETTINGS.paused or G.TAROT_INTERRUPT) then
@@ -2711,7 +2712,7 @@ function add_tag(_tag)
 	add_tag_ref(_tag)
 end
 
-function Card:quantum_set_ability(center, reset_keys)
+function Card:quantum_set_ability(center)
     SMODS.enh_cache:write(self, nil)
 
     if self.ability then
@@ -2797,8 +2798,9 @@ function Card:quantum_set_ability(center, reset_keys)
     self.ability.card_limit = self.ability.card_limit + (center.config.card_limit or 0)
     self.ability.extra_slots_used = self.ability.extra_slots_used + (center.config.extra_slots_used or 0)
 
+
     -- reset keys do not persist on ability change
-    for _, k in ipairs(reset_keys) do
+    for _, k in ipairs(SMODS.get_ability_reset_keys(self) or {}) do
         self.ability[k] = new_ability[k]
     end
 

--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -2711,11 +2711,163 @@ function add_tag(_tag)
 	add_tag_ref(_tag)
 end
 
--- Fix visual glitch in deck select
-local g_funcs_change_viewed_back_ref = G.FUNCS.change_viewed_back
-G.FUNCS.change_viewed_back = function(...)
-	for _, card in pairs(G.sticker_card.area.cards) do
-		card.original_T = copy_table(card.T)
-	end
-	return g_funcs_change_viewed_back_ref(...)
+function Card:quantum_set_ability(center)
+    SMODS.enh_cache:write(self, nil)
+
+    if self.ability then
+        self.ability.card_limit = self.ability.card_limit - (self.config.center.config.card_limit or 0)
+        self.ability.extra_slots_used = self.ability.extra_slots_used - (self.config.center.config.extra_slots_used or 0)
+    end
+
+    local old_center = self.config.center
+    self.from_quantum = true
+    if type(center) == 'string' then
+        assert(G.P_CENTERS[center], ("Could not find center \"%s\""):format(center))
+        center = G.P_CENTERS[center]
+    end
+    self.config.center = center
+    if self.config.center.key then
+        self.config.center_key = self.config.center.key
+    else
+        for k, v in pairs(G.P_CENTERS) do
+            if center == v then self.config.center_key = k end
+        end
+    end
+
+    if self.ability and old_center and old_center.config.bonus then
+        self.ability.bonus = self.ability.bonus - old_center.config.bonus
+    end
+    
+    local new_ability = {
+        name = center.name,
+        effect = center.effect,
+        set = center.set,
+        mult = center.config.mult or 0,
+        h_mult = center.config.h_mult or 0,
+        h_x_mult = center.config.h_x_mult or 0,
+        h_dollars = center.config.h_dollars or 0,
+        p_dollars = center.config.p_dollars or 0,
+        t_mult = center.config.t_mult or 0,
+        t_chips = center.config.t_chips or 0,
+        x_mult = center.config.Xmult or center.config.x_mult or 1,
+        h_chips = center.config.h_chips or 0,
+        x_chips = center.config.x_chips or 1,
+        h_x_chips = center.config.h_x_chips or 1,
+        repetitions = center.config.repetitions or 0,
+        h_size = center.config.h_size or 0,
+        d_size = center.config.d_size or 0,
+        extra = copy_table(center.config.extra) or nil,
+        extra_value = 0,
+        type = center.config.type or '',
+        order = center.order or nil,
+        forced_selection = self.ability and self.ability.forced_selection or nil,
+        perma_bonus = self.ability and self.ability.perma_bonus or 0,
+        perma_x_chips = self.ability and self.ability.perma_x_chips or 0,
+        perma_mult = self.ability and self.ability.perma_mult or 0,
+        perma_x_mult = self.ability and self.ability.perma_x_mult or 0,
+        perma_h_chips = self.ability and self.ability.perma_h_chips or 0,
+        perma_h_x_chips = self.ability and self.ability.perma_h_x_chips or 0,
+        perma_h_mult = self.ability and self.ability.perma_h_mult or 0,
+        perma_h_x_mult = self.ability and self.ability.perma_h_x_mult or 0,
+        perma_p_dollars = self.ability and self.ability.perma_p_dollars or 0,
+        perma_h_dollars = self.ability and self.ability.perma_h_dollars or 0,
+        perma_repetitions = self.ability and self.ability.perma_repetitions or 0,
+        card_limit = self.ability and self.ability.card_limit or 0,
+        extra_slots_used = self.ability and self.ability.extra_slots_used or 0,
+        perma_score = self.ability and self.ability.perma_score or 0,
+        perma_h_score = self.ability and self.ability.perma_h_score or 0,
+        perma_x_score = self.ability and self.ability.perma_x_score or 0,
+        perma_h_x_score = self.ability and self.ability.perma_h_x_score or 0,
+        perma_blind_size = self.ability and self.ability.perma_blind_size or 0,
+        perma_h_blind_size = self.ability and self.ability.perma_h_blind_size or 0,
+        perma_x_blind_size = self.ability and self.ability.perma_x_blind_size or 0,
+        perma_h_x_blind_size = self.ability and self.ability.perma_h_x_blind_size or 0,
+    }
+    self.ability = self.ability or {}
+    new_ability.extra_value = nil
+    new_ability.debuff_sources = {}
+    self.ability.extra_value = self.ability.extra_value or 0
+    for k, v in pairs(new_ability) do
+        self.ability[k] = v
+    end
+
+    -- handles card_limit/extra_slots_used changes
+    self.ability.card_limit = self.ability.card_limit + (center.config.card_limit or 0)
+    self.ability.extra_slots_used = self.ability.extra_slots_used + (center.config.extra_slots_used or 0)
+
+    -- reset keys do not persist on ability change
+    local reset_keys = {'name', 'effect', 'set', 'extra', 'played_this_ante', 'perma_debuff'}
+    for _, mod in ipairs(SMODS.mod_list) do
+        if mod.set_ability_reset_keys then
+            local keys = mod.set_ability_reset_keys()
+            for _, v in pairs(keys) do table.insert(reset_keys, v) end
+        end
+    end
+    for _, k in ipairs(reset_keys) do
+        self.ability[k] = new_ability[k]
+    end
+
+    self.ability.bonus = (self.ability.bonus or 0) + (center.config.bonus or 0)
+    if not self.ability.name then self.ability.name = center.key end
+    for k, v in pairs(center.config) do
+        if k ~= 'bonus' then
+            if type(v) == 'table' then
+                self.ability[k] = copy_table(v)
+            else
+                self.ability[k] = v
+            end
+        end
+    end
+
+    if center.consumeable then 
+        self.ability.consumeable = center.config
+    end
+
+    if self.ability.name == "Invisible Joker" then 
+        self.ability.invis_rounds = 0
+    end
+    if self.ability.name == 'To Do List' then
+        local _poker_hands = {}
+        for k, v in pairs(G.GAME.hands) do
+            if SMODS.is_poker_hand_visible(k) then _poker_hands[#_poker_hands+1] = k end
+        end
+        local old_hand = self.ability.to_do_poker_hand
+        self.ability.to_do_poker_hand = nil
+
+        while not self.ability.to_do_poker_hand do
+            self.ability.to_do_poker_hand = pseudorandom_element(_poker_hands, pseudoseed((self.area and self.area.config.type == 'title') and 'false_to_do' or 'to_do'))
+            if self.ability.to_do_poker_hand == old_hand then self.ability.to_do_poker_hand = nil end
+        end
+    end
+    if self.ability.name == 'Caino' then 
+        self.ability.caino_xmult = 1
+    end
+    if self.ability.name == 'Yorick' then 
+        self.ability.yorick_discards = self.ability.extra.discards
+    end
+    if self.ability.name == 'Loyalty Card' then 
+        self.ability.burnt_hand = 0
+        self.ability.loyalty_remaining = self.ability.extra.every
+    end
+
+    self.base_cost = center.cost or 1
+
+    self.ability.hands_played_at_create = G.GAME and G.GAME.hands_played or 0
+
+    self.label = center.label or self.config.card and self.config.card.label or self.ability.set
+    if self.ability.set == 'Joker' then self.label = self.ability.name end
+    if self.ability.set == 'Edition' then self.label = self.ability.name end
+    if self.ability.consumeable then self.label = self.ability.name end
+    if self.ability.set == 'Voucher' then self.label = self.ability.name end
+    if self.ability.set == 'Booster' then
+        self.label = self.ability.name
+        self.mouse_damping = 1.5
+    end
+
+    local obj = self.config.center
+    if obj.set_ability and type(obj.set_ability) == 'function' then
+        obj:set_ability(self, false, nil)
+    end
+
+    self.from_quantum = nil
 end

--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -2737,52 +2737,54 @@ function Card:quantum_set_ability(center, reset_keys)
     if self.ability and old_center and old_center.config.bonus then
         self.ability.bonus = self.ability.bonus - old_center.config.bonus
     end
+
+    self.ARGS.smods_quantum_ability = self.ARGS.smods_quantum_ability or {}
+    local new_ability = self.ARGS.smods_quantum_ability
+
+    new_ability.name = center.name
+    new_ability.effect = center.effect
+    new_ability.set = center.set
+    new_ability.mult = center.config.mult or 0
+    new_ability.h_mult = center.config.h_mult or 0
+    new_ability.h_x_mult = center.config.h_x_mult or 0
+    new_ability.h_dollars = center.config.h_dollars or 0
+    new_ability.p_dollars = center.config.p_dollars or 0
+    new_ability.t_mult = center.config.t_mult or 0
+    new_ability.t_chips = center.config.t_chips or 0
+    new_ability.x_mult = center.config.Xmult or center.config.x_mult or 1
+    new_ability.h_chips = center.config.h_chips or 0
+    new_ability.x_chips = center.config.x_chips or 1
+    new_ability.h_x_chips = center.config.h_x_chips or 1
+    new_ability.repetitions = center.config.repetitions or 0
+    new_ability.h_size = center.config.h_size or 0
+    new_ability.d_size = center.config.d_size or 0
+    new_ability.extra = copy_table(center.config.extra) or nil
+    new_ability.extra_value = 0
+    new_ability.type = center.config.type or ''
+    new_ability.order = center.order or nil
+    new_ability.forced_selection = self.ability and self.ability.forced_selection or nil
+    new_ability.perma_bonus = self.ability and self.ability.perma_bonus or 0
+    new_ability.perma_x_chips = self.ability and self.ability.perma_x_chips or 0
+    new_ability.perma_mult = self.ability and self.ability.perma_mult or 0
+    new_ability.perma_x_mult = self.ability and self.ability.perma_x_mult or 0
+    new_ability.perma_h_chips = self.ability and self.ability.perma_h_chips or 0
+    new_ability.perma_h_x_chips = self.ability and self.ability.perma_h_x_chips or 0
+    new_ability.perma_h_mult = self.ability and self.ability.perma_h_mult or 0
+    new_ability.perma_h_x_mult = self.ability and self.ability.perma_h_x_mult or 0
+    new_ability.perma_p_dollars = self.ability and self.ability.perma_p_dollars or 0
+    new_ability.perma_h_dollars = self.ability and self.ability.perma_h_dollars or 0
+    new_ability.perma_repetitions = self.ability and self.ability.perma_repetitions or 0
+    new_ability.card_limit = self.ability and self.ability.card_limit or 0
+    new_ability.extra_slots_used = self.ability and self.ability.extra_slots_used or 0
+    new_ability.perma_score = self.ability and self.ability.perma_score or 0
+    new_ability.perma_h_score = self.ability and self.ability.perma_h_score or 0
+    new_ability.perma_x_score = self.ability and self.ability.perma_x_score or 0
+    new_ability.perma_h_x_score = self.ability and self.ability.perma_h_x_score or 0
+    new_ability.perma_blind_size = self.ability and self.ability.perma_blind_size or 0
+    new_ability.perma_h_blind_size = self.ability and self.ability.perma_h_blind_size or 0
+    new_ability.perma_x_blind_size = self.ability and self.ability.perma_x_blind_size or 0
+    new_ability.perma_h_x_blind_size = self.ability and self.ability.perma_h_x_blind_size or 0
     
-    local new_ability = {
-        name = center.name,
-        effect = center.effect,
-        set = center.set,
-        mult = center.config.mult or 0,
-        h_mult = center.config.h_mult or 0,
-        h_x_mult = center.config.h_x_mult or 0,
-        h_dollars = center.config.h_dollars or 0,
-        p_dollars = center.config.p_dollars or 0,
-        t_mult = center.config.t_mult or 0,
-        t_chips = center.config.t_chips or 0,
-        x_mult = center.config.Xmult or center.config.x_mult or 1,
-        h_chips = center.config.h_chips or 0,
-        x_chips = center.config.x_chips or 1,
-        h_x_chips = center.config.h_x_chips or 1,
-        repetitions = center.config.repetitions or 0,
-        h_size = center.config.h_size or 0,
-        d_size = center.config.d_size or 0,
-        extra = copy_table(center.config.extra) or nil,
-        extra_value = 0,
-        type = center.config.type or '',
-        order = center.order or nil,
-        forced_selection = self.ability and self.ability.forced_selection or nil,
-        perma_bonus = self.ability and self.ability.perma_bonus or 0,
-        perma_x_chips = self.ability and self.ability.perma_x_chips or 0,
-        perma_mult = self.ability and self.ability.perma_mult or 0,
-        perma_x_mult = self.ability and self.ability.perma_x_mult or 0,
-        perma_h_chips = self.ability and self.ability.perma_h_chips or 0,
-        perma_h_x_chips = self.ability and self.ability.perma_h_x_chips or 0,
-        perma_h_mult = self.ability and self.ability.perma_h_mult or 0,
-        perma_h_x_mult = self.ability and self.ability.perma_h_x_mult or 0,
-        perma_p_dollars = self.ability and self.ability.perma_p_dollars or 0,
-        perma_h_dollars = self.ability and self.ability.perma_h_dollars or 0,
-        perma_repetitions = self.ability and self.ability.perma_repetitions or 0,
-        card_limit = self.ability and self.ability.card_limit or 0,
-        extra_slots_used = self.ability and self.ability.extra_slots_used or 0,
-        perma_score = self.ability and self.ability.perma_score or 0,
-        perma_h_score = self.ability and self.ability.perma_h_score or 0,
-        perma_x_score = self.ability and self.ability.perma_x_score or 0,
-        perma_h_x_score = self.ability and self.ability.perma_h_x_score or 0,
-        perma_blind_size = self.ability and self.ability.perma_blind_size or 0,
-        perma_h_blind_size = self.ability and self.ability.perma_h_blind_size or 0,
-        perma_x_blind_size = self.ability and self.ability.perma_x_blind_size or 0,
-        perma_h_x_blind_size = self.ability and self.ability.perma_h_x_blind_size or 0,
-    }
     self.ability = self.ability or {}
     new_ability.extra_value = nil
     new_ability.debuff_sources = {}
@@ -2850,5 +2852,6 @@ function Card:quantum_set_ability(center, reset_keys)
         obj:set_ability(self, false, nil)
     end
 
+    EMPTY(new_ability)
     self.from_quantum = nil
 end

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -1096,8 +1096,17 @@ function SMODS.calculate_quantum_enhancements(card, effects, context)
         end
     end
     table.sort(extra_enhancements_list, function(a, b) return G.P_CENTERS[a].order < G.P_CENTERS[b].order end)
+
+    local reset_keys = {'name', 'effect', 'set', 'extra', 'played_this_ante', 'perma_debuff'}
+    for _, mod in ipairs(SMODS.mod_list) do
+        if mod.set_ability_reset_keys then
+            local keys = mod.set_ability_reset_keys()
+            for _, v in pairs(keys) do table.insert(reset_keys, v) end
+        end
+    end
+
     for _, k in ipairs(extra_enhancements_list) do
-        card:quantum_set_ability(G.P_CENTERS[k])
+        card:quantum_set_ability(G.P_CENTERS[k], reset_keys)
         card.ability.extra_enhancement = k
         local eval = eval_card(card, context)
         table.insert(effects, eval)

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -1076,6 +1076,17 @@ function SMODS.shatters(card)
     end
 end
 
+function SMODS.get_ability_reset_keys(card)
+    local reset_keys = {'name', 'effect', 'set', 'extra', 'played_this_ante', 'perma_debuff'}
+    for _, mod in ipairs(SMODS.mod_list) do
+        if mod.set_ability_reset_keys then
+            local keys = mod.set_ability_reset_keys()
+            for _, v in pairs(keys) do table.insert(reset_keys, v) end
+        end
+    end
+    return reset_keys
+end
+
 function SMODS.calculate_quantum_enhancements(card, effects, context)
     if not SMODS.optional_features.quantum_enhancements then return end
     if context.extra_enhancement or context.check_enhancement or SMODS.extra_enhancement_calc_in_progress then return end
@@ -1097,16 +1108,8 @@ function SMODS.calculate_quantum_enhancements(card, effects, context)
     end
     table.sort(extra_enhancements_list, function(a, b) return G.P_CENTERS[a].order < G.P_CENTERS[b].order end)
 
-    local reset_keys = {'name', 'effect', 'set', 'extra', 'played_this_ante', 'perma_debuff'}
-    for _, mod in ipairs(SMODS.mod_list) do
-        if mod.set_ability_reset_keys then
-            local keys = mod.set_ability_reset_keys()
-            for _, v in pairs(keys) do table.insert(reset_keys, v) end
-        end
-    end
-
     for _, k in ipairs(extra_enhancements_list) do
-        card:quantum_set_ability(G.P_CENTERS[k], reset_keys)
+        card:quantum_set_ability(G.P_CENTERS[k])
         card.ability.extra_enhancement = k
         local eval = eval_card(card, context)
         table.insert(effects, eval)

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -1097,7 +1097,7 @@ function SMODS.calculate_quantum_enhancements(card, effects, context)
     end
     table.sort(extra_enhancements_list, function(a, b) return G.P_CENTERS[a].order < G.P_CENTERS[b].order end)
     for _, k in ipairs(extra_enhancements_list) do
-        card:set_ability(G.P_CENTERS[k], nil, 'quantum')
+        card:quantum_set_ability(G.P_CENTERS[k])
         card.ability.extra_enhancement = k
         local eval = eval_card(card, context)
         table.insert(effects, eval)


### PR DESCRIPTION
This PR targeted to optimize quantum enhancements by providing `Card.quantum_set_ability` function, which works mostly the same as `Card.set_ability` but without any kind of resizing or sprite manipulations.

As a result, calculating time for 80 steel cards in hand + 2 jokers with quantum effect was decreased from 8 seconds to 3 seconds. Additionally, it significantly decreases a lag during selecting cards in hand + hovering them.

Sadly, because by patching `Card:set_ability` will be difficult to exclude all side effects, new method was used, which leads to some noticeable changes from previous implementation:
- all hooks and patches targeted to `Card:set_ability` will not be reflected in `Card.quantum_set_ability`
- if during `SMODS.Center.set_ability` some changes to card outside of `ability` table is made, they will persist. Modders can check `card.from_quantum` to account for this behaviour.
-  `SMODS.calculate_context({setting_ability = true})` will not be called between switching quantum enhancements. Maybe it's a good thing?

## Additional Info:
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.