### PR TITLE
Expand `no_collection`  field

### DIFF
--- a/lsp_def/classes/center.lua
+++ b/lsp_def/classes/center.lua
@@ -9,7 +9,7 @@
 ---@field soul_pos? table|{x: integer, y: integer, draw?: fun(card: Card|table, scale_mod?: number, rotate_mod?: number)} Position of the "soul" sprite. Separate front layer sprite that hovers over the card. 
 ---@field unlocked? boolean Sets the unlock state of the center. 
 ---@field discovered? boolean Sets the discovery state of the center. 
----@field no_collection? boolean Sets whether the card shows up in the collections menu. 
+---@field no_collection? boolean|fun():boolean Sets whether the card shows up in the collections menu. 
 ---@field loc_txt? table|{name: string|string[], text: string[]|string[][]} Contains strings used for displaying text related to this object. 
 ---@field pools? string[] Array of keys to ObjectTypes this center will be added to.
 ---@field cost? number Sell cost of this center. 

--- a/lsp_def/classes/game_object.lua
+++ b/lsp_def/classes/game_object.lua
@@ -15,7 +15,7 @@
 ---@field prefix_config? boolean|table Controls how prefixes are applied. By default, class_prefix and mod_prefix are applied to all registered objects. 
 ---@field required_params? string[] Array of parameters required for objects created by this class. 
 ---@field set? string Important for objects wanting to follow vanilla logic that depends on `set`. For classes, this is used for logging purposes. 
----@field no_collection? boolean Sets whether the object is allowed to show up in collections.
+---@field no_collection? boolean|fun():boolean Sets whether the object is allowed to show up in collections.
 ---@field config? table Cards/Objects representing your center will copy default values from `config` into it's `ability` table. Custom values can be stored within `extra`. 
 ---@field __call? fun(self: SMODS.GameObject|table, o: SMODS.GameObject|table): nil|table|SMODS.GameObject
 ---@field extend? fun(self: SMODS.GameObject|table, o: SMODS.GameObject|table): table Primary method of creating a class. 

--- a/lsp_def/classes/poker_hand.lua
+++ b/lsp_def/classes/poker_hand.lua
@@ -13,7 +13,7 @@
 ---@field visible? boolean|fun(self:SMODS.PokerHand|table): boolean? Sets hand visibility in the poker hands menu. If `false`, poker hand is shown only after being played once.  A function allows more precise control over hand visibility in the poker hands menu.  
 ---@field above_hand? PokerHands|string Key to a poker hand. Used to order this poker hand above specified poker hand. 
 ---@field order_offset? number Adds this value to poker hand's mult and chips to offset ordering. 
----@field no_collection? boolean Sets whether the poker hand shows up in the collections menu. 
+---@field no_collection? boolean|fun():boolean Sets whether the poker hand shows up in the collections menu. 
 ---@field __call? fun(self: SMODS.PokerHand|table, o: SMODS.PokerHand|table): nil|table|SMODS.PokerHand
 ---@field extend? fun(self: SMODS.PokerHand|table, o: SMODS.PokerHand|table): table Primary method of creating a class. 
 ---@field check_duplicate_register? fun(self: SMODS.PokerHand|table): boolean? Ensures objects already registered will not register. 

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -1155,7 +1155,7 @@ SMODS.collection_pool = function(_base_pool)
     local is_array = _base_pool[1]
     local ipairs = is_array and ipairs or pairs
     for _, v in ipairs(_base_pool) do
-        if (not G.ACTIVE_MOD_UI or v.mod == G.ACTIVE_MOD_UI) and not v.no_collection then
+        if (not G.ACTIVE_MOD_UI or v.mod == G.ACTIVE_MOD_UI) and (not v.no_collection or (type(v.no_collection) == "function" and not v.no_collection())) then
             pool[#pool+1] = v
         end
     end


### PR DESCRIPTION
Allows `no_collection` field to be a function returning boolean, for more precise control over whether an object may be shown in the collection.
## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [X] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [X] I didn't modify api's or I've updated lsp definitions.
- [X] I didn't make new lovely files or all new lovely files have appropriate priority.
