### PR TITLE
Mobile patches

### DIFF
--- a/lovely/mobile_patches.toml
+++ b/lovely/mobile_patches.toml
@@ -78,7 +78,6 @@ payload = """
 match_indent = true
 times = 1
 
-# Remove noise factor from CRT shader
 
 [[patches]]
 [patches.pattern]
@@ -88,6 +87,8 @@ position = "at"
 payload = "mediump vec4 effect( mediump vec4 colour, Image texture, mediump vec2 texture_coords, mediump vec2 screen_coords )"
 match_indent = true
 times = 1
+
+# Remove noise factor from CRT shader
 
 [[patches]]
 [patches.pattern]

--- a/lovely/mobile_patches.toml
+++ b/lovely/mobile_patches.toml
@@ -1,0 +1,98 @@
+[manifest]
+version = "1.0.0"
+dump_lua = true
+priority = -10
+
+# Internal config options for mobile
+[[patches]]
+[patches.pattern]
+target = "globals.lua"
+pattern = "if love.system.getOS() == 'OS X' then"
+position = "before"
+payload = '''
+if love.system.getOS() == 'Android' or love.system.getOS() == 'iOS' then
+	self.F_SAVE_TIMER = 5
+	self.F_DISCORD = true
+	self.F_NO_ACHIEVEMENTS = true
+	self.F_CRASH_REPORTS = false
+	self.F_SOUND_THREAD = true
+	self.F_VIDEO_SETTINGS = false
+	self.F_ENGLISH_ONLY = false
+	self.F_QUIT_BUTTON = false
+    self.F_MOBILE_UI = true
+end
+'''
+match_indent = true
+times = 1
+
+# highdpi mode
+[[patches]]
+[patches.pattern]
+target = "functions/button_callbacks.lua"
+pattern = "highdpi = (love.system.getOS() == 'OS X')"
+position = "at"
+payload = "highdpi = (love.system.getOS() == 'OS X' or love.system.getOS() == 'Android' or love.system.getOS() == 'iOS')"
+match_indent = true
+times = 1
+
+# landscape orientation
+[[patches]]
+[patches.pattern]
+target = "functions/button_callbacks.lua"
+pattern = "resizable = true,"
+position = "at"
+payload = "resizable = not (love.system.getOS() == 'Android' or love.system.getOS() == 'iOS'),"
+match_indent = true
+times = 1
+
+[[patches]]
+[patches.pattern]
+target = "main.lua"
+pattern = "local os = love.system.getOS()"
+position = "after"
+payload = "if os == 'Android' or os == 'iOS' then love.window.updateMode(2, 1) end"
+match_indent = true
+times = 1
+
+# make the on-screen keyboard work on touch controls
+[[patches]]
+[patches.pattern]
+target = "functions/button_callbacks.lua"
+pattern = "if G.CONTROLLER.text_input_hook == e and G.CONTROLLER.HID.controller then"
+position = "at"
+payload = 'if G.CONTROLLER.text_input_hook == e and (G.CONTROLLER.HID.controller or G.CONTROLLER.HID.touch) then'
+match_indent = true
+times = 1
+
+# fix flame shader
+[[patches]]
+[patches.pattern]
+target = 'flame.fs'
+pattern = "#endif"
+position = "after"
+payload = """
+#ifdef GL_ES
+    precision MY_HIGHP_OR_MEDIUMP float;
+#endif
+"""
+match_indent = true
+times = 1
+
+# Remove noise factor from CRT shader
+
+[[patches]]
+[patches.pattern]
+target = 'flame.fs'
+pattern = 'vec4 effect*'
+position = "at"
+payload = "mediump vec4 effect( mediump vec4 colour, Image texture, mediump vec2 texture_coords, mediump vec2 screen_coords )"
+match_indent = true
+times = 1
+
+[[patches]]
+[patches.pattern]
+target = 'CRT.fs'
+pattern = '*noise_fac*'
+position = "at"
+payload = ""
+match_indent = true

--- a/lovely/shaders.toml
+++ b/lovely/shaders.toml
@@ -26,3 +26,12 @@ pattern = '''self.config = config'''
 position = "after"
 payload = '''self.shaders = config.shaders'''
 match_indent = true
+
+# delegate CRT shader to SMODS.ScreenShader
+[[patches]]
+[patches.pattern]
+target = "game.lua"
+pattern = 'if (not G.recording_mode or G.video_control )and true then'
+position = 'at'
+payload = 'if false then'
+match_indent = true

--- a/lovely/shaders.toml
+++ b/lovely/shaders.toml
@@ -29,9 +29,8 @@ match_indent = true
 
 # delegate CRT shader to SMODS.ScreenShader
 [[patches]]
-[patches.pattern]
+[patches.regex]
 target = "game.lua"
-pattern = 'if (not G.recording_mode or G.video_control )and true then'
+pattern = 'G.SETTINGS.GRAPHICS.crt =(.*\n)*\s*G.SETTINGS.GRAPHICS.crt =.*'
 position = 'at'
-payload = 'if false then'
-match_indent = true
+payload = ''

--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -3427,7 +3427,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
                 ['feather_fac'] = 0.01,
                 ['bloom_fac'] = G.SETTINGS.GRAPHICS.bloom - 1,
                 ['time'] = 400 + G.TIMERS.REAL,
-                ['noise_fac'] = 0.001*crt/100,
+                -- ['noise_fac'] = 0.001*crt/100, -- removed for mobile compat
                 ['crt_intensity'] = 0.16*crt/100,
                 ['glitch_intensity'] = 0,
                 ['scanlines'] = G.CANVAS:getPixelHeight()*0.75/G.CANV_SCALE,
@@ -3437,6 +3437,7 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
             }
         end,
         order = 0, -- not necessary, but explicitly set in this example for clarity
+        should_apply = function(self) return not G.recording_mode or G.video_control end,
     }
 
     -------------------------------------------------------------------------------------------------

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -3773,7 +3773,7 @@ end
 
 -- Used for SMODS.ScreenShader, just to save lines re-creating canvases when relevant
 function SMODS.create_canvas()
-    local w, h = love.graphics.getPixelWidth(), love.graphics.getPixelHeight()
+    local w, h = G.CANVAS:getDimensions()
     local canvas = love.graphics.newCanvas(w, h, { type = '2d', readable = true })
     canvas:setFilter('linear', 'linear')
     return canvas


### PR DESCRIPTION
- Incorporate changes from [Mobile Patches](https://github.com/WilsontheWolf/MobilePatches):
  - Fix the flame shader (updated to lovely patches)
  - Properly set global flags on mobile
  - Enable high DPI mode on mobile
  - Force landscape mode on mobile
  - Enable the on-screen keyboard for touch control
- Remove `noise_fac` from the CRT shader. This has no visual effect due to the factor used being too small.
  - This fixes part of the screen going black on some Android devices without the invasive change of disabling the shader altogether.
- Remove a duplicate application of the CRT shader as it is already handled by `SMODS.ScreenShader` and may cause issues if modified.
## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
