### PR TITLE
SMODS.scale_card scalar_factor

### DIFF
--- a/lovely/scaling.toml
+++ b/lovely/scaling.toml
@@ -27,9 +27,7 @@ SMODS.scale_card(self, {
     ref_value = "mult",
     scalar_table = sliced_card,
     scalar_value = "sell_cost",
-    operation = function(ref_table, ref_value, initial, scaling)
-        ref_table[ref_value] = initial + 2*scaling
-    end,
+    scalar_factor = 2,
     scaling_message = {
         message = localize{type = 'variable', key = 'a_mult', vars = {self.ability.mult+2*sliced_card.sell_cost}},
         colour = G.C.RED,
@@ -492,11 +490,9 @@ SMODS.scale_card(self, {
     ref_table = self.ability,
     ref_value = "x_mult",
     scalar_value = "extra",
+    scalar_factor = #enhanced,
     message_key = 'a_xmult',
-    message_colour = G.C.MULT,
-    operation = function(ref_table, ref_value, initial, scaling)
-        ref_table[ref_value] = initial + scaling*#enhanced
-    end
+    message_colour = G.C.MULT
 })
 return nil, true
 '''
@@ -516,10 +512,8 @@ SMODS.scale_card(self, {
     ref_table = self.ability,
     ref_value = "x_mult",
     scalar_value = "extra",
-    message_key = 'a_xmult',
-    operation = function(ref_table, ref_value, initial, scaling)
-        ref_table[ref_value] = initial + scaling*#context.cards
-    end
+    scalar_factor = #context.cards,
+    message_key = 'a_xmult'
 })
 '''
 
@@ -672,9 +666,7 @@ SMODS.scale_card(self, {
     ref_table = self.ability,
     ref_value = 'caino_xmult',
     scalar_value = 'extra',
-    operation = function(ref_table, ref_value, initial, change)
-        ref_table[ref_value] = initial + face_cards*change
-    end,
+    scalar_factor = face_cards,
     message_key = 'a_xmult'
 })
 return nil, true
@@ -700,9 +692,7 @@ SMODS.scale_card(self, {
     ref_table = self.ability,
     ref_value = 'x_mult',
     scalar_value = 'extra',
-    operation = function(ref_table, ref_value, initial, change)
-        ref_table[ref_value] = initial + glass_cards*change
-    end,
+    scalar_factor = glass_cards,
     message_key = 'a_xmult'
 })
 '''

--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -718,9 +718,10 @@ function SMODS.is_poker_hand_visible(handname) end
 function SMODS.is_eternal(card, trigger) end
 
 ---@param card Card|table
----@param args? table|{ref_table: table, ref_value: string, scalar_value: string, scalar_table: table?, operation: '+'|'X'|'-'|string|fun(ref_table: table, ref_value: string, initial: number, change: number)?, block_overrides: {value: boolean?, scalar: boolean?, message: boolean?}?, scaling_message: table?, message_key: string?, message_colour: table?, message_delay: number?, no_message: boolean?}
---- Tells Jokers that this card is scaling allowing for scaling detection
---- Args must contain `ref_table`, `ref_value`, and `scalar_value`. It may optionally contain `scalar_table`, used in place of `ref_table` for the `scalar_value`, and `operation` to designate the scaling operation, which defaults to `"+"`
+---@param args? table|{ref_table: table, ref_value: string, scalar_value: string?, scalar_table: table?, scalar_factor:number?, operation: '+'|'X'|'-'|string|fun(ref_table: table, ref_value: string, initial: number, change: number)?, block_overrides: {value: boolean?, scalar: boolean?, message: boolean?}?, scaling_message: table?, message_key: string?, message_colour: table?, message_delay: number?, no_message: boolean?}
+--- Tells Jokers that this card is scaling allowing for scaling detection.
+--- Args must contain `ref_table` and `ref_value`. If `scalar_value` is not defined, it is automatically created.
+--- It may also optionally contain `scalar_table`, used in place of `ref_table` for the `scalar_value`, and `operation` to designate the scaling operation, which defaults to `"+"`
 function SMODS.scale_card(card, args) end
 
 ---@param prototype_obj SMODS.GameObject|table

--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -719,9 +719,11 @@ function SMODS.is_eternal(card, trigger) end
 
 ---@param card Card|table
 ---@param args? table|{ref_table: table, ref_value: string, scalar_value: string?, scalar_table: table?, scalar_factor:number?, operation: '+'|'X'|'-'|string|fun(ref_table: table, ref_value: string, initial: number, change: number)?, block_overrides: {value: boolean?, scalar: boolean?, message: boolean?}?, scaling_message: table?, message_key: string?, message_colour: table?, message_delay: number?, no_message: boolean?}
+---@return number, number
 --- Tells Jokers that this card is scaling allowing for scaling detection.
 --- Args must contain `ref_table` and `ref_value`. If `scalar_value` is not defined, it is automatically created.
 --- It may also optionally contain `scalar_table`, used in place of `ref_table` for the `scalar_value`, and `operation` to designate the scaling operation, which defaults to `"+"`
+--- Returns the final scaled value, and what it had been scaled by
 function SMODS.scale_card(card, args) end
 
 ---@param prototype_obj SMODS.GameObject|table

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -3076,7 +3076,12 @@ function SMODS.scale_card(card, args)
     args.ref_table = args.ref_table or card.ability.extra
     args.scalar_table = args.scalar_table or args.ref_table
     local initial = args.ref_table[args.ref_value]
+    if not args.scalar_value then
+        args.scalar_value = "SMODS_scalar_"..args.ref_value
+        args.scalar_table[args.scalar_value] = 1
+    end
     local scalar_value = args.scalar_table[args.scalar_value]
+    local scalar_factor = args.scalar_factor or 1
     if args.operation == '-' and scalar_value < 0 then scalar_value = scalar_value * -1 end
     local scaling_message = args.scaling_message
     local scaling_responses = {}
@@ -3110,17 +3115,17 @@ function SMODS.scale_card(card, args)
     end
 
     if type(args.operation) == 'function' then
-        args.operation(args.ref_table, args.ref_value, initial, scalar_value)
+        args.operation(args.ref_table, args.ref_value, initial, scalar_value * scalar_factor)
     elseif args.operation == 'X' then
-        SMODS.multiplicative_scaling(args.ref_table, args.ref_value, initial, scalar_value)
+        SMODS.multiplicative_scaling(args.ref_table, args.ref_value, initial, scalar_value * scalar_factor)
     elseif args.operation == '-' then
-        SMODS.additive_scaling(args.ref_table, args.ref_value, initial, -1 * scalar_value)
+        SMODS.additive_scaling(args.ref_table, args.ref_value, initial, -1 * scalar_value * scalar_factor)
     else
-        SMODS.additive_scaling(args.ref_table, args.ref_value, initial, scalar_value)
+        SMODS.additive_scaling(args.ref_table, args.ref_value, initial, scalar_value * scalar_factor)
     end
 
     scaling_message = scaling_message or {
-        message = localize(args.message_key and {type='variable',key=args.message_key,vars={args.message_key =='a_xmult' and args.ref_table[args.ref_value] or scalar_value}} or 'k_upgrade_ex'),
+        message = localize(args.message_key and {type='variable',key=args.message_key,vars={args.message_key =='a_xmult' and args.ref_table[args.ref_value] or scalar_value * scalar_factor}} or 'k_upgrade_ex'),
         colour = args.message_colour or G.C.FILTER,
         delay = args.message_delay,
     }

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -3135,6 +3135,7 @@ function SMODS.scale_card(card, args)
     for _, ret in ipairs(scaling_responses) do
         SMODS.calculate_effect(ret, ret.source)
     end
+    return args.ref_table[args.ref_value], scalar_value * scalar_factor
 end
 
 function SMODS.additive_scaling(ref_table, ref_value, initial, modifier)


### PR DESCRIPTION
this makes three changes to `SMODS.scale_card`, which makes it easier to use outside of the most basic cases:
- `args.scalar_factor` can be provided, which will be multiplied with the `scalar_value` in the _operation_ functions specifically (as well as the localized variable). this allows for conveniently recreating the behavior of scaling a card by a multiple of something, which is currently only possible by making a custom operation
- if no `args.scalar_value` is provided, SMODS will automatically make one with a value of 1. the intent of this feature is: combined with the `scalar_factor` argument, you can scale a card by an arbitrary value easily, while still internally using a scalar_value to allow for manipulation from other objects
- `SMODS.scale_card` now returns the final scaled value, and what it was scaled by, to allow jokers themselves to respond / utilize the changed values

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
