### PR TITLE
context.area in context.create_shop_card

### DIFF
--- a/lovely/shop.toml
+++ b/lovely/shop.toml
@@ -263,7 +263,7 @@ local card = create_card(v.type, area, nil, nil, nil, nil, nil, 'sho')
 position = 'at'
 payload = '''
 local args = {set = v.type, area = area, key_append = 'sho'}
-local flags = SMODS.calculate_context({create_shop_card = true, set = v.type})
+local flags = SMODS.calculate_context({create_shop_card = true, set = v.type, area = area})
 local create_flags = SMODS.merge_defaults(flags.shop_create_flags or {}, args)
 local card = SMODS.create_card(create_flags)
 SMODS.calculate_context({modify_shop_card = true, card = card})

--- a/src/utils/weights.lua
+++ b/src/utils/weights.lua
@@ -365,7 +365,7 @@ function SMODS.create_shop_card(area)
     }
     card_args.key = SMODS.poll_object({type = card_args.type, append = 'sho'})
 
-    local flags = SMODS.calculate_context({create_shop_card = true, set = card_args.type, key = card_args.key})
+    local flags = SMODS.calculate_context({create_shop_card = true, set = card_args.type, key = card_args.key, area = card_args.area})
 
     local card = SMODS.create_card(SMODS.merge_defaults(flags.shop_create_flags or {}, card_args))
 


### PR DESCRIPTION
Adds context.area to context.create_shop_card calls, to match how the game calls the `Tag:apply_to_run` function

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
