### PR TITLE
fix: booster select not accoutning for extra_slots_used

### DIFF
--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2455,8 +2455,9 @@ end
 G.FUNCS.can_select_from_booster = function(e)
     local card = e.config.ref_table
     local area = booster_obj and card:selectable_from_pack(booster_obj)
-    local edition_card_limit = card.ability.card_limit
-    if area and #G[area].cards < G[area].config.card_limit + edition_card_limit then
+    local edition_card_limit = card.ability.card_limit - card.ability.extra_slots_used
+    local card_slots_extra = card.ability.extra_slots_used
+    if area and #G[area].cards + card_slots_extra < G[area].config.card_limit + edition_card_limit then
         e.config.colour = G.C.GREEN
         e.config.button = 'use_card'
     else

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2456,8 +2456,7 @@ G.FUNCS.can_select_from_booster = function(e)
     local card = e.config.ref_table
     local area = booster_obj and card:selectable_from_pack(booster_obj)
     local edition_card_limit = card.ability.card_limit - card.ability.extra_slots_used
-    local card_slots_extra = card.ability.extra_slots_used
-    if area and #G[area].cards + card_slots_extra < G[area].config.card_limit + edition_card_limit then
+    if area and #G[area].cards < G[area].config.card_limit + edition_card_limit then
         e.config.colour = G.C.GREEN
         e.config.button = 'use_card'
     else


### PR DESCRIPTION

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
