### PR TITLE
Button Config - Manipulate what buttons shouldn't appear on a card

### DIFF
--- a/lovely/buttons.toml
+++ b/lovely/buttons.toml
@@ -1,0 +1,86 @@
+[manifest]
+version = "1.0.0"
+dump_lua = true
+priority = -10
+
+# Buy and Use in shop config
+[[patches]]
+[patches.pattern]
+target = 'functions/UI_definitions.lua'
+pattern = '''
+if card.ability.consumeable then --and card:can_use_consumeable(true, true)
+'''
+position = 'at'
+payload = '''
+if card.ability.consumeable --and card:can_use_consumeable(true, true)
+    and (not card.config.center.button_config or card.config.center.button_config.buy_and_use ~= false)
+    and (not SMODS.ConsumableTypes[card.ability.set] or not SMODS.ConsumableTypes[card.ability.set].button_config or SMODS.ConsumableTypes[card.ability.set].button_config.buy_and_use ~= false ) then
+'''
+match_indent = true
+
+# Use and Sell Config
+[[patches]]
+[patches.pattern]
+target = "functions/UI_definitions.lua"
+pattern = '''
+local t = {
+  n=G.UIT.ROOT, config = {padding = 0, colour = G.C.CLEAR}, nodes={
+    {n=G.UIT.C, config={padding = 0.15, align = 'cl'}, nodes={
+      {n=G.UIT.R, config={align = 'cl'}, nodes={
+        sell
+      }},
+      {n=G.UIT.R, config={align = 'cl'}, nodes={
+        use
+      }},
+    }},
+}}
+'''
+position = "before"
+payload = '''
+if (card.config.center.button_config and type(card.config.center.button_config) == 'table')
+    or (SMODS.ConsumableTypes[card.ability.set] and SMODS.ConsumableTypes[card.ability.set].button_config and type(SMODS.ConsumableTypes[card.ability.set].button_config) == 'table') then
+    local button_config = card.config.center.button_config or SMODS.ConsumableTypes[card.ability.set].button_config
+    print(button_config)
+    return {
+    n=G.UIT.ROOT, config = {padding = 0, colour = G.C.CLEAR}, nodes={
+        {n=G.UIT.C, config={padding = 0.15, align = 'cl'}, nodes={
+        button_config.sell ~= false and {n=G.UIT.R, config={align = 'cl'}, nodes={
+            sell
+        }} or nil,
+        button_config.use ~= false and {n=G.UIT.R, config={align = 'cl'}, nodes={
+            use
+        }} or nil,
+        }},
+    }}
+end
+'''
+match_indent = true
+
+# Controller support
+[[patches]]
+[patches.pattern]
+target = 'functions/UI_definitions.lua'
+pattern = '''
+return base_background
+'''
+position = 'before'
+payload = '''
+if (card.config.center.button_config and type(card.config.center.button_config) == 'table')
+    or (SMODS.ConsumableTypes[card.ability.set] and SMODS.ConsumableTypes[card.ability.set].button_config and type(SMODS.ConsumableTypes[card.ability.set].button_config) == 'table') then
+    local button_config = card.config.center.button_config or SMODS.ConsumableTypes[card.ability.set].button_config
+    print(button_config)
+
+    for k, v in button_config do
+        if not v and base_attach.children[k] then
+            base_attach.children[k] = nil
+        end
+    end
+
+    base_attach.children.buy = G.UIDEF.card_focus_button{
+      card = card, parent = base_attach, type = 'buy',
+      func = 'can_buy', button = 'buy_from_shop', card_width = card_width, buy_and_use = buy_and_use
+    }
+end
+
+'''
+match_indent = true

--- a/lovely/buttons.toml
+++ b/lovely/buttons.toml
@@ -69,7 +69,7 @@ if (card.config.center.button_config and type(card.config.center.button_config) 
     or (SMODS.ConsumableTypes[card.ability.set] and SMODS.ConsumableTypes[card.ability.set].button_config and type(SMODS.ConsumableTypes[card.ability.set].button_config) == 'table') then
     local button_config = card.config.center.button_config or SMODS.ConsumableTypes[card.ability.set].button_config
 
-    for k, v in button_config do
+    for k, v in pairs(button_config) do
         if not v and base_attach.children[k] then
             base_attach.children[k] = nil
         end

--- a/lovely/buttons.toml
+++ b/lovely/buttons.toml
@@ -39,8 +39,8 @@ position = "before"
 payload = '''
 if (card.config.center.button_config and type(card.config.center.button_config) == 'table')
     or (SMODS.ConsumableTypes[card.ability.set] and SMODS.ConsumableTypes[card.ability.set].button_config and type(SMODS.ConsumableTypes[card.ability.set].button_config) == 'table') then
+    
     local button_config = card.config.center.button_config or SMODS.ConsumableTypes[card.ability.set].button_config
-    print(button_config)
     return {
     n=G.UIT.ROOT, config = {padding = 0, colour = G.C.CLEAR}, nodes={
         {n=G.UIT.C, config={padding = 0.15, align = 'cl'}, nodes={
@@ -68,7 +68,6 @@ payload = '''
 if (card.config.center.button_config and type(card.config.center.button_config) == 'table')
     or (SMODS.ConsumableTypes[card.ability.set] and SMODS.ConsumableTypes[card.ability.set].button_config and type(SMODS.ConsumableTypes[card.ability.set].button_config) == 'table') then
     local button_config = card.config.center.button_config or SMODS.ConsumableTypes[card.ability.set].button_config
-    print(button_config)
 
     for k, v in button_config do
         if not v and base_attach.children[k] then

--- a/lovely/buttons.toml
+++ b/lovely/buttons.toml
@@ -70,7 +70,7 @@ if (card.config.center.button_config and type(card.config.center.button_config) 
     local button_config = card.config.center.button_config or SMODS.ConsumableTypes[card.ability.set].button_config
 
     for k, v in pairs(button_config) do
-        if not v and base_attach.children[k] then
+        if v == false and base_attach.children[k] then
             base_attach.children[k] = nil
         end
     end


### PR DESCRIPTION
Allows defining a `button_config` table on card or ConsumableType objects that allow for manipulation of what buttons shouldn't appear on a card, primarily used for suppressing `buy_and_use`, `use`, and `sell` (for whatever sick individual might wanna do that for whatever reason)

Example:
```
button_config = {
   use = false -- Suppresses Use button on this card/card with this ConsumableType
}
```

You do not need to define a field as true for buttons to appear

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
