### PR TITLE
SMODS.create_card now supports scale.w and scale.h

### DIFF
--- a/lovely/center.toml
+++ b/lovely/center.toml
@@ -716,22 +716,8 @@ target = 'functions/common_events.lua'
 match_indent = false
 position = 'at'
 pattern = '''    
-function create_card(_type, area, legendary, _rarity, skip_materialize, soulable, forced_key, key_append)
-'''
-payload = '''
-function create_card(_type, area, legendary, _rarity, skip_materialize, soulable, forced_key, key_append, scale)
-local scale = scale or {w = 1, h = 1}
-'''
-
-# create_card now supports card scale
-[[patches]]
-[patches.pattern]
-target = 'functions/common_events.lua'
-match_indent = false
-position = 'at'
-pattern = '''    
 local card = Card(area.T.x + area.T.w/2, area.T.y, G.CARD_W, G.CARD_H, front, center,
 '''
 payload = '''
-local card = Card(area.T.x + area.T.w/2, area.T.y, G.CARD_W*scale.w, G.CARD_H*scale.h, front, center,
+local card = Card(area.T.x + area.T.w/2, area.T.y, G.CARD_W*SMODS.create_card_scale.w, G.CARD_H*SMODS.create_card_scale.h, front, center,
 '''

--- a/lovely/center.toml
+++ b/lovely/center.toml
@@ -722,17 +722,3 @@ payload = '''
 SMODS.create_card_scale = SMODS.create_card_scale or {w = 1, h = 1}
 local card = Card(area.T.x + area.T.w/2, area.T.y, G.CARD_W*SMODS.create_card_scale.w, G.CARD_H*SMODS.create_card_scale.h, front, center,
 '''
-
-# create_card now supports card scale
-[[patches]]
-[patches.pattern]
-target = 'functions/common_events.lua'
-match_indent = false
-position = 'at'
-pattern = '''    
-local card = Card(area.T.x + area.T.w/2, area.T.y, G.CARD_W, G.CARD_H, front, center,
-'''
-payload = '''
-SMODS.create_card_scale = SMODS.create_card_scale or {w = 1, h = 1}
-local card = Card(area.T.x + area.T.w/2, area.T.y, G.CARD_W*SMODS.create_card_scale.w, G.CARD_H*SMODS.create_card_scale.h, front, center,
-'''

--- a/lovely/center.toml
+++ b/lovely/center.toml
@@ -708,3 +708,30 @@ end
 
 function Card:set_sell_value()
 '''
+
+# create_card now supports card scale
+[[patches]]
+[patches.pattern]
+target = 'functions/common_events.lua'
+match_indent = false
+position = 'at'
+pattern = '''    
+function create_card(_type, area, legendary, _rarity, skip_materialize, soulable, forced_key, key_append)
+'''
+payload = '''
+function create_card(_type, area, legendary, _rarity, skip_materialize, soulable, forced_key, key_append, scale)
+local scale = scale or {w = 1, h = 1}
+'''
+
+# create_card now supports card scale
+[[patches]]
+[patches.pattern]
+target = 'functions/common_events.lua'
+match_indent = false
+position = 'at'
+pattern = '''    
+local card = Card(area.T.x + area.T.w/2, area.T.y, G.CARD_W, G.CARD_H, front, center,
+'''
+payload = '''
+local card = Card(area.T.x + area.T.w/2, area.T.y, G.CARD_W*scale.w, G.CARD_H*scale.h, front, center,
+'''

--- a/lovely/center.toml
+++ b/lovely/center.toml
@@ -719,5 +719,20 @@ pattern = '''
 local card = Card(area.T.x + area.T.w/2, area.T.y, G.CARD_W, G.CARD_H, front, center,
 '''
 payload = '''
+SMODS.create_card_scale = SMODS.create_card_scale or {w = 1, h = 1}
+local card = Card(area.T.x + area.T.w/2, area.T.y, G.CARD_W*SMODS.create_card_scale.w, G.CARD_H*SMODS.create_card_scale.h, front, center,
+'''
+
+# create_card now supports card scale
+[[patches]]
+[patches.pattern]
+target = 'functions/common_events.lua'
+match_indent = false
+position = 'at'
+pattern = '''    
+local card = Card(area.T.x + area.T.w/2, area.T.y, G.CARD_W, G.CARD_H, front, center,
+'''
+payload = '''
+SMODS.create_card_scale = SMODS.create_card_scale or {w = 1, h = 1}
 local card = Card(area.T.x + area.T.w/2, area.T.y, G.CARD_W*SMODS.create_card_scale.w, G.CARD_H*SMODS.create_card_scale.h, front, center,
 '''

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -412,7 +412,8 @@ function SMODS.create_card(t)
     SMODS.bypass_create_card_discovery_center = t.bypass_discovery_center
     SMODS.set_create_card_front = G.P_CARDS[t.front]
     SMODS.create_card_allow_duplicates = t.allow_duplicates
-    local _card = create_card(t.set, t.area, t.legendary, t.rarity, t.skip_materialize, t.soulable, t.key, t.key_append, t.scale)
+    SMODS.create_card_scale = t.scale or {w = 1, h = 1}
+    local _card = create_card(t.set, t.area, t.legendary, t.rarity, t.skip_materialize, t.soulable, t.key, t.key_append)
     SMODS.bypass_create_card_edition = nil
     SMODS.bypass_create_card_discover = nil
     SMODS.bypass_create_card_discovery_center = nil

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -412,7 +412,7 @@ function SMODS.create_card(t)
     SMODS.bypass_create_card_discovery_center = t.bypass_discovery_center
     SMODS.set_create_card_front = G.P_CARDS[t.front]
     SMODS.create_card_allow_duplicates = t.allow_duplicates
-    SMODS.create_card_scale = t.scale or {w = 1, h = 1}
+    SMODS.create_card_scale = t.scale
     local _card = create_card(t.set, t.area, t.legendary, t.rarity, t.skip_materialize, t.soulable, t.key, t.key_append)
     SMODS.bypass_create_card_edition = nil
     SMODS.bypass_create_card_discover = nil

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -412,7 +412,7 @@ function SMODS.create_card(t)
     SMODS.bypass_create_card_discovery_center = t.bypass_discovery_center
     SMODS.set_create_card_front = G.P_CARDS[t.front]
     SMODS.create_card_allow_duplicates = t.allow_duplicates
-    SMODS.create_card_scale = t.scale
+    SMODS.create_card_scale = t.scale and { w = t.scale.w or 1, h = t.scale.h or 1 }
     local _card = create_card(t.set, t.area, t.legendary, t.rarity, t.skip_materialize, t.soulable, t.key, t.key_append)
     SMODS.create_card_scale = nil
     SMODS.bypass_create_card_edition = nil

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -412,7 +412,7 @@ function SMODS.create_card(t)
     SMODS.bypass_create_card_discovery_center = t.bypass_discovery_center
     SMODS.set_create_card_front = G.P_CARDS[t.front]
     SMODS.create_card_allow_duplicates = t.allow_duplicates
-    local _card = create_card(t.set, t.area, t.legendary, t.rarity, t.skip_materialize, t.soulable, t.key, t.key_append)
+    local _card = create_card(t.set, t.area, t.legendary, t.rarity, t.skip_materialize, t.soulable, t.key, t.key_append, t.scale)
     SMODS.bypass_create_card_edition = nil
     SMODS.bypass_create_card_discover = nil
     SMODS.bypass_create_card_discovery_center = nil

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -414,6 +414,7 @@ function SMODS.create_card(t)
     SMODS.create_card_allow_duplicates = t.allow_duplicates
     SMODS.create_card_scale = t.scale
     local _card = create_card(t.set, t.area, t.legendary, t.rarity, t.skip_materialize, t.soulable, t.key, t.key_append)
+    SMODS.create_card_scale = nil
     SMODS.bypass_create_card_edition = nil
     SMODS.bypass_create_card_discover = nil
     SMODS.bypass_create_card_discovery_center = nil


### PR DESCRIPTION
I have added the ability for SMODS.create_card to create a card with a specific scale as well! I added a few lovely patches to common_events.lua to give create_card another parameter (is that what its called) and later use it when creating a card using Card(). This is done by including a new "scale" key in the input table for SMODS.create_card, which should be a table with w and h scaling for width and height

for example, to create a Booster pack with its typical scaling, it would be:
`SMODS.create_card({set = 'Booster', scale = {w = 1.27, h = 1.27}}`

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
