### PR TITLE
SUI: SMODS/Simple UI framework

### DIFF
--- a/lovely/sui.toml
+++ b/lovely/sui.toml
@@ -1,0 +1,42 @@
+[manifest]
+version = "1.0.0"
+dump_lua = true
+priority = 0
+
+# Intercept created UIE
+[[patches]]
+[patches.pattern]
+target = "engine/ui.lua"
+pattern = '''local UIE = UIElement(parent, self, node.n, node.config)'''
+position = "at"
+payload = '''
+node = SMODS.SUI.process_node_render(node)
+local UIE = UIElement(parent, self, node.n, node.config)
+UIE.input_node = node
+'''
+match_indent = true
+
+# Mark a point where UIE is fully created
+[[patches]]
+[patches.pattern]
+target = "engine/ui.lua"
+pattern = '''self.static_rotation = true'''
+position = "after"
+payload = '''
+SMODS.SUI.UIE_INIT = true
+'''
+match_indent = true
+
+# Init element
+[[patches]]
+[patches.pattern]
+target = "engine/ui.lua"
+pattern = '''self.layered_parallax = self.layered_parallax or {x=0, y=0}'''
+position = "after"
+payload = '''
+if SMODS.SUI.UIE_INIT then
+    SMODS.SUI.UIE_INIT = nil
+    SMODS.SUI.process_element_created(self)
+end
+'''
+match_indent = true

--- a/lovely/sui.toml
+++ b/lovely/sui.toml
@@ -10,7 +10,7 @@ target = "engine/ui.lua"
 pattern = '''local UIE = UIElement(parent, self, node.n, node.config)'''
 position = "at"
 payload = '''
-node = SMODS.SUI.process_node_render(node)
+node = SMODS.SUI and SMODS.SUI.process_node_render(node) or node
 local UIE = UIElement(parent, self, node.n, node.config)
 UIE.input_node = node
 '''
@@ -20,10 +20,10 @@ match_indent = true
 [[patches]]
 [patches.pattern]
 target = "engine/ui.lua"
-pattern = '''self.static_rotation = true'''
+pattern = '''Moveable.init(self,{T = _T})'''
 position = "after"
 payload = '''
-SMODS.SUI.UIE_INIT = true
+self.sui_init_request = SMODS.SUI
 '''
 match_indent = true
 
@@ -34,8 +34,8 @@ target = "engine/ui.lua"
 pattern = '''self.layered_parallax = self.layered_parallax or {x=0, y=0}'''
 position = "after"
 payload = '''
-if SMODS.SUI.UIE_INIT then
-    SMODS.SUI.UIE_INIT = nil
+if self.sui_init_request then
+    self.sui_init_request = nil
     SMODS.SUI.process_element_created(self)
 end
 '''

--- a/src/core.lua
+++ b/src/core.lua
@@ -3,6 +3,7 @@ for _, path in ipairs {
     "src/ui.lua",
     "src/index.lua",
     "src/utils.lua",
+    "src/sui.lua",
     "src/overrides.lua",
     "src/game_object.lua",
     "src/compat_0_9_8.lua",

--- a/src/sui.lua
+++ b/src/sui.lua
@@ -42,10 +42,9 @@ function SMODS.SUI.input_type(i)
 end
 function SMODS.SUI.attach_hooks(target, hooks)
 	if not target or not hooks then
-		return
+		return target
 	end
-	for _, func_key in pairs(hooks) do
-		local new_func = hooks[func_key]
+	for func_key, new_func in pairs(hooks) do
 		local old_func = target[func_key] or function() end
 		target[func_key] = function(self, ...)
 			return new_func(self, old_func, ...)

--- a/src/sui.lua
+++ b/src/sui.lua
@@ -274,6 +274,7 @@ function SMODS.SUI.Node:init(n, ...)
 	self.s_config = {}
 	self.s_hooks = {}
 end
+function SMODS.SUI.Node:s_init() end
 function SMODS.SUI.Node:setup() end
 function SMODS.SUI.Node:__call(...)
 	if self.n then
@@ -289,6 +290,18 @@ end
 
 function SMODS.SUI.Node:process_config(key, value)
 	SMODS.SUI.config_merge(self, key, value)
+end
+function SMODS.SUI.Node:pre_process_nodes(index, value)
+	-- Filter booleans to make conditional UI easier
+	if value == true or value == false then
+		return
+    -- If table is array of elements, process all elements in it separately
+	elseif type(value) == "table" and table.maxn(value) > 0 then
+        return value
+    -- Pass other arguments as-is
+	else
+		return { value }
+	end
 end
 function SMODS.SUI.Node:process_node(index, value)
 	SMODS.SUI.node_merge(self, index, value)
@@ -322,7 +335,7 @@ function SMODS.SUI.Node:process_input(input)
 		return
 	end
 
-	local children_to_insert = {}
+	local nodes_to_insert = {}
 	if input.config then
 		for k, v in pairs(input.config) do
 			self:process_config(k, v)
@@ -330,32 +343,28 @@ function SMODS.SUI.Node:process_input(input)
 	end
 	if input.nodes then
 		for k, v in pairs(input.nodes) do
-			children_to_insert[#children_to_insert + 1] = v
+			nodes_to_insert[#nodes_to_insert + 1] = v
 		end
 	end
 	for k, v in pairs(input) do
 		if SMODS.SUI.special_config_keys[k] then
 		elseif type(k) == "number" then
-			children_to_insert[#children_to_insert + 1] = v
+			nodes_to_insert[#nodes_to_insert + 1] = v
 		else
 			self:process_config(k, v)
 		end
 	end
 
-	local child_index = 0
-	for _, v in ipairs(children_to_insert) do
-		if type(v) == "table" and #v > 0 then
-			for _, node in pairs(v) do
-				child_index = child_index + 1
-				self:process_node(child_index, node)
+    self:post_process_input(input)
+
+	for i, v in ipairs(nodes_to_insert) do
+		local pre_processed_nodes = self:pre_process_nodes(i, v)
+		if pre_processed_nodes then
+			for _, node in pairs(pre_processed_nodes) do
+				self:process_node(i, node)
 			end
-		else
-			child_index = child_index + 1
-			self:process_node(child_index, v)
 		end
 	end
-
-	self:post_process_input(input)
 end
 function SMODS.SUI.Node:process_inputs(...)
 	for _, input in ipairs({ ... }) do
@@ -386,13 +395,13 @@ function SMODS.SUI.Node:render()
 		for word in string.gmatch(self.s_class, "%S+") do
 			if classes[word] then
 				at_least_one_match = true
-                if type(classes[word]) == "function" then
-                    classes[word](self)
-                else
-                    for k, v in pairs(classes[word]) do
-                        self:process_config(k, v)
-                    end
-                end
+				if type(classes[word]) == "function" then
+					classes[word](self)
+				else
+					for k, v in pairs(classes[word]) do
+						self:process_config(k, v)
+					end
+				end
 			end
 		end
 

--- a/src/sui.lua
+++ b/src/sui.lua
@@ -52,6 +52,9 @@ function SMODS.SUI.attach_hooks(target, hooks)
 	end
 	return target
 end
+function SMODS.SUI.is_column_type(n)
+	return n == G.UIT.C or n == G.UIT.B or n == G.UIT.T or n == G.UIT.O
+end
 
 -- Storages for keys which needs to be resolved by iterating dictionaries
 
@@ -144,15 +147,15 @@ function SMODS.SUI.extended_process_node(node, index, v)
 	end
 	if input_type == "node" then
 		if node.s_config.rc_fix_target == nil then
-			if v.n == G.UIT.C or v.n == G.UIT.O then
+			if SMODS.SUI.is_column_type(v.n) then
 				node.s_config.rc_fix_target = "C"
 			elseif v.n == G.UIT.R then
 				node.s_config.rc_fix_target = "R"
 			end
 			SMODS.SUI.Node.process_node(node, index, v)
-		elseif node.s_config.rc_fix_target == "C" and v.n == G.UIT.R then
+		elseif node.s_config.rc_fix_target == "C" and not SMODS.SUI.is_column_type(v.n) then
 			SMODS.SUI.Node.process_node(node, index, SUI.C({ v }))
-		elseif node.s_config.rc_fix_target == "R'" and (v.n == G.UIT.C or v.n == G.UIT.O) then
+		elseif node.s_config.rc_fix_target == "R'" and SMODS.SUI.is_column_type(v.n) then
 			SMODS.SUI.Node.process_node(node, index, SUI.R({ v }))
 		else
 			SMODS.SUI.Node.process_node(node, index, v)
@@ -493,20 +496,6 @@ SUI.CLEAR_ROOT = SUI.ROOT:extend({
 		self:process_inputs({ colour = G.C.CLEAR })
 	end,
 })
--- SUI.ROOT with default align = "cm"
-SUI.CENTER_ROOT = SUI.ROOT:extend({
-	setup = function(self, ...)
-		SUI.ROOT.setup(self, ...)
-		self:process_inputs({ align = "cm" })
-	end,
-})
--- SUI.ROOT with default colour G.C.CLEAR instead of G.C.BLACK, and with default align = "cm"
-SUI.CLEAR_CENTER_ROOT = SUI.ROOT:extend({
-	setup = function(self, ...)
-		SUI.ROOT.setup(self, ...)
-		self:process_inputs({ colour = G.C.CLEAR, align = "cm" })
-	end,
-})
 -- SUI.C with default align = "cm"
 SUI.CENTER_C = SUI.C:extend({
 	setup = function(self, ...)
@@ -519,35 +508,5 @@ SUI.CENTER_R = SUI.R:extend({
 	setup = function(self, ...)
 		SUI.R.setup(self, ...)
 		self:process_inputs({ align = "cm" })
-	end,
-})
-
--- Custom elements
-
--- SUI.LOC_TEXT: easy way to render text via SMODS.localize_box
-SUI.LOC_TEXT = SUI.C:extend({
-	process_config = function(self, k, v)
-		if k == "loc_box_config" or k == "row_config" then
-			self.s_config[k] = SMODS.merge_defaults(v or {}, self.s_config[k] or {})
-		else
-			SUI.C.process_config(self, k, v)
-		end
-	end,
-	process_node = function(self, k, v)
-		local input_type = SMODS.SUI.input_type(v)
-		if input_type == "node" or input_type == "moveable" then
-			SUI.C.process_node(self, k, v)
-		else
-			local line = input_type == "string" and loc_parse_string(v) or v
-			local box_config = SMODS.merge_defaults(self.s_config.loc_box_config or {}, {
-				vars = {},
-				default_col = G.C.UI.TEXT_LIGHT,
-			})
-			SUI.C.process_node(
-				self,
-				k,
-				SUI.R({ config = self.s_config.row_config, nodes = SMODS.localize_box(line, box_config) })
-			)
-		end
 	end,
 })

--- a/src/sui.lua
+++ b/src/sui.lua
@@ -14,9 +14,12 @@ SMODS.SUI.special_config_keys = {
 
 -- Utilities
 
+-- Formats number from range 0-1 to HEX component 00-FF
 function SMODS.SUI.to_hex(v)
 	return string.format("%02X", math.floor(v * 255 + 0.5))
 end
+-- Formats colour from format `{ r, g, b, a }` to `#RRGGBB`.
+-- If `a` is less than 1, format to `#RRGGBBAA` instead.
 function SMODS.SUI.colour_to_hex(colour)
 	colour = colour or { 0, 0, 0, 0 }
 
@@ -28,18 +31,20 @@ function SMODS.SUI.colour_to_hex(colour)
 
 	return hex
 end
-function SMODS.SUI.input_type(i)
-	local itype = type(i)
+-- Extended Lua's `type()` function to check is passed input is `Moveable` or can be treated as node definition.
+function SMODS.SUI.input_type(input)
+	local itype = type(input)
 	if itype == "table" then
-		if Object.is(i, Moveable) then
+		if Object.is(input, Moveable) then
 			return "moveable"
 		end
-		if i.n then
+		if input.n then
 			return "node"
 		end
 	end
 	return itype or "nil"
 end
+-- Easy way to attach multiple hooks to table in bulk. In hook function passed as first argument, all other arguments goes after it.
 function SMODS.SUI.attach_hooks(target, hooks)
 	if not target or not hooks then
 		return target
@@ -52,6 +57,7 @@ function SMODS.SUI.attach_hooks(target, hooks)
 	end
 	return target
 end
+-- Checks is element's type considered as column element.
 function SMODS.SUI.is_column_type(n)
 	return n == G.UIT.C or n == G.UIT.B or n == G.UIT.T or n == G.UIT.O
 end
@@ -61,7 +67,7 @@ end
 SMODS.SUI.UIT_STORAGE = {
 	buffer = {},
 	fallback_to_unknown = false,
-	get_tables = function()
+	get_tables = function(self)
 		return {
 			[""] = G.UIT,
 		}
@@ -72,7 +78,7 @@ SMODS.SUI.DEBUG_UIT_STORAGE = {
 	fallback_to_unknown = true,
 	unknown_next_index = 1,
 	unknown_prefix = "?UIT",
-	get_tables = function()
+	get_tables = function(self)
 		return {
 			[""] = G.UIT,
 		}
@@ -83,7 +89,7 @@ SMODS.SUI.DEBUG_CLASS_STORAGE = {
 	fallback_to_unknown = true,
 	unknown_next_index = 1,
 	unknown_prefix = "?Class",
-	get_tables = function()
+	get_tables = function(self)
 		return {
 			[""] = _G,
 			["SMODS."] = SMODS,
@@ -99,10 +105,10 @@ function SMODS.SUI.create_storage(storage)
 			return storage.buffer[input]
 		end
 		-- Process all tables looking for input
-		for _k, _v in pairs(storage.get_tables()) do
-			for k, v in pairs(_v) do
-				if v == input then
-					local result_key = _k .. k
+		for table_key, table_value in pairs(storage:get_tables()) do
+			for key, value in pairs(table_value) do
+				if value == input then
+					local result_key = table_key .. key
 					storage.buffer[input] = result_key
 					return result_key
 				end
@@ -133,32 +139,37 @@ SMODS.SUI.get_debug_object_class_name = SMODS.SUI.create_storage(SMODS.SUI.DEBUG
 function SMODS.SUI.config_merge(node, key, value)
 	node.config[key] = value
 end
-function SMODS.SUI.node_merge(node, index, value)
-	node.nodes[table.maxn(node.nodes) + 1] = value
+function SMODS.SUI.node_merge(node, index, child)
+	node.nodes[table.maxn(node.nodes) + 1] = child
 end
-function SMODS.SUI.extended_process_node(node, index, v)
-	local input_type = SMODS.SUI.input_type(v)
+function SMODS.SUI.extended_process_node(node, index, child)
+	local input_type = SMODS.SUI.input_type(child)
+
+	-- Wrap Moveable into G.UIT.O
 	if input_type == "moveable" then
-		v = SUI.O({ v })
+		child = SUI.O({ child })
 		input_type = "node"
+	-- Wrap string and numbers in G.UIT.T
 	elseif input_type == "string" or input_type == "number" then
-		v = SUI.T({ colour = G.C.UI.TEXT_LIGHT, scale = 0.32, v })
+		child = SUI.T({ colour = G.C.UI.TEXT_LIGHT, scale = 0.32, text = child })
 		input_type = "node"
 	end
 	if input_type == "node" then
-		if node.s_config.rc_fix_target == nil then
-			if SMODS.SUI.is_column_type(v.n) then
+		-- Perform R/C fix: element behave unpredictably when R/C elements are mixed inside one parent.
+		-- if target not specified, first element's type will used as target.
+		if node.s_config.rc_fix_target == nil or node.s_config.rc_fix_target == true then
+			if SMODS.SUI.is_column_type(child.n) then
 				node.s_config.rc_fix_target = "C"
-			elseif v.n == G.UIT.R then
+			elseif child.n == G.UIT.R then
 				node.s_config.rc_fix_target = "R"
 			end
-			SMODS.SUI.Node.process_node(node, index, v)
-		elseif node.s_config.rc_fix_target == "C" and not SMODS.SUI.is_column_type(v.n) then
-			SMODS.SUI.Node.process_node(node, index, SUI.C({ v }))
-		elseif node.s_config.rc_fix_target == "R'" and SMODS.SUI.is_column_type(v.n) then
-			SMODS.SUI.Node.process_node(node, index, SUI.R({ v }))
+			SMODS.SUI.Node.process_node(node, index, child)
+		elseif node.s_config.rc_fix_target == "C" and not SMODS.SUI.is_column_type(child.n) then
+			SMODS.SUI.Node.process_node(node, index, SUI.C({ align = node.s_config.rc_fix_align, child }))
+		elseif node.s_config.rc_fix_target == "R" and SMODS.SUI.is_column_type(child.n) then
+			SMODS.SUI.Node.process_node(node, index, SUI.R({ align = node.s_config.rc_fix_align, child }))
 		else
-			SMODS.SUI.Node.process_node(node, index, v)
+			SMODS.SUI.Node.process_node(node, index, child)
 		end
 	end
 end
@@ -166,9 +177,11 @@ function SMODS.SUI.process_node_render(node)
 	return node.render and node:render() or node
 end
 function SMODS.SUI.process_element_created(element)
-	SMODS.SUI.attach_hooks(element, element.input_node.s_hooks)
-	if element.input_node.s_init then
-		element.input_node.s_init(element)
+	if element.input_node then
+		SMODS.SUI.attach_hooks(element, element.input_node.s_hooks)
+		if element.input_node.s_init then
+			element.input_node.s_init(element)
+		end
 	end
 end
 
@@ -177,11 +190,11 @@ end
 function SMODS.SUI.get_topology(node, options, indent)
 	options = options or {}
 	indent = indent or ""
-	if node.render then
-		node = node:render()
-	end
-	local formatted_class_name = ""
+	node = SMODS.SUI.process_node_render(node)
 	node.config = node.config or {}
+
+	-- Resolve class name & id and format element in tree as `n#id.class1.class2`
+	local formatted_class_name = ""
 	if node.s_config and node.s_config.class then
 		for word in string.gmatch(node.s_config.class, "%S+") do
 			formatted_class_name = formatted_class_name .. "." .. word
@@ -191,22 +204,29 @@ function SMODS.SUI.get_topology(node, options, indent)
 	if node.config.id then
 		formatted_id = "#" .. node.config.id
 	end
+
+	-- Resolve element topology info
 	local topology_info
 	if not node.topology then
 		local uit = SMODS.SUI.get_debug_uit_key(node.n)
 		topology_info = (SUI[uit] or SMODS.SUI.Node).topology(node)
 	else
-		topology_info = node:topology()
+		topology_info = node:topology(options)
 	end
+
 	local formatted_n = topology_info.n
 	local element_line = string.format("%s<%s%s%s", indent, formatted_n, formatted_id, formatted_class_name)
+
+	-- Resolve attributes to display and format them as `attr_1=value_1 attr_2=value_2`
 	local additional_attributes = ""
-	for _, v in pairs(topology_info.attributes or {}) do
-		additional_attributes = additional_attributes .. v .. " "
+	for k, v in pairs(topology_info.attributes or {}) do
+		additional_attributes = additional_attributes .. k .. "=" .. v .. " "
 	end
 	if additional_attributes ~= "" then
 		element_line = element_line .. " " .. additional_attributes
 	end
+
+	-- Format children if present
 	local with_children = false
 	for _, subnode in pairs(topology_info.nodes or {}) do
 		if not with_children then
@@ -215,11 +235,14 @@ function SMODS.SUI.get_topology(node, options, indent)
 		end
 		element_line = element_line .. "\n" .. SMODS.SUI.get_topology(subnode, options, indent .. "    ")
 	end
+
+	-- Close element
 	if with_children then
 		element_line = element_line .. "\n" .. string.format("%s</%s>", indent or "", formatted_n)
 	else
 		element_line = element_line .. " />"
 	end
+
 	return element_line
 end
 function SMODS.SUI.print_topology(node, options)
@@ -271,13 +294,12 @@ function SMODS.SUI.Node:process_node(index, value)
 end
 function SMODS.SUI.Node:pre_process_input(input)
 	local input_type = SMODS.SUI.input_type(input)
-	if input_type ~= "table" and input_type ~= "nil" then
-		input = { input }
-		input_type = "table"
-	end
 	if input_type == "table" then
 		return input
+	elseif input_type ~= "nil" then
+		return { input }
 	end
+	return nil
 end
 function SMODS.SUI.Node:post_process_input(input)
 	if input.s_config then
@@ -338,6 +360,7 @@ function SMODS.SUI.Node:process_inputs(...)
 end
 
 function SMODS.SUI.Node:render()
+	-- Propagate CSS stylesheet element uses
 	if self.s_config.css ~= nil then
 		for _, child in ipairs(self.nodes) do
 			if not child.s_config then
@@ -348,22 +371,32 @@ function SMODS.SUI.Node:render()
 			end
 		end
 	end
+
+	-- Apply CSS classes
 	if self.s_config.class then
-		local classes = self.s_config.css or SMODS.SUI.CSS or {}
-		local classname = self.s_config.class
+		local classes = self.s_config.css or SMODS.SUI.CSS
 		local old_config = self.config
+		local at_least_one_match = false
 		self.config = {}
-		for word in string.gmatch(classname, "%S+") do
+
+		for word in string.gmatch(self.s_config.class, "%S+") do
 			if classes[word] then
+				at_least_one_match = true
 				for k, v in pairs(classes[word]) do
 					self:process_config(k, v)
 				end
 			end
 		end
-		for k, v in pairs(old_config) do
-			self:process_config(k, v)
+
+		if at_least_one_match then
+			for k, v in pairs(old_config) do
+				self:process_config(k, v)
+			end
+		else
+			self.config = old_config
 		end
 	end
+
 	return {
 		n = self.n,
 		config = self.config,
@@ -375,7 +408,7 @@ function SMODS.SUI.Node:render()
 		s_init = self.s_init,
 	}
 end
-function SMODS.SUI.Node:topology()
+function SMODS.SUI.Node:topology(options)
 	self.config = self.config or {}
 	return {
 		n = SMODS.SUI.get_debug_uit_key(self.n),
@@ -385,14 +418,14 @@ function SMODS.SUI.Node:topology()
 		s_config = self.s_config or {},
 
 		attributes = {
-			align = self.config.align and string.format('align="%s"', self.config.align),
-			colour = self.config.colour and string.format("colour=%s", SMODS.SUI.colour_to_hex(self.config.colour)),
-			w = self.config.w and string.format("w=%.2f", self.config.w),
-			minw = self.config.minw and string.format("minw=%.2f", self.config.minw),
-			maxw = self.config.maxw and string.format("maxw=%.2f", self.config.maxw),
-			h = self.config.w and string.format("h=%.2f", self.config.h),
-			minh = self.config.minh and string.format("minh=%.2f", self.config.minh),
-			maxh = self.config.maxh and string.format("maxh=%.2f", self.config.maxh),
+			align = self.config.align and string.format('"%s"', self.config.align),
+			colour = self.config.colour and string.format("%s", SMODS.SUI.colour_to_hex(self.config.colour)),
+			w = self.config.w and string.format("%.2f", self.config.w),
+			minw = self.config.minw and string.format("%.2f", self.config.minw),
+			maxw = self.config.maxw and string.format("%.2f", self.config.maxw),
+			h = self.config.w and string.format("%.2f", self.config.h),
+			minh = self.config.minh and string.format("%.2f", self.config.minh),
+			maxh = self.config.maxh and string.format("%.2f", self.config.maxh),
 		},
 	}
 end
@@ -410,17 +443,16 @@ end
 SUI = setmetatable({
 	padding = G.UIT.padding,
 }, {
-	__call = function(t, ...)
+	__call = function(sui, ...)
 		local args = { ... }
 		local uit
 
 		local arg = args[1]
 		if type(arg) == "table" then
+			-- Try to resolve arg.n as n
 			uit = arg.n and (G.UIT[arg.n] and arg.n or SMODS.SUI.get_uit_key(arg.n)) or nil
-			if uit then
-				arg.n = nil
-			end
 		elseif arg then
+			-- Try to resolve arg itself as n
 			uit = G.UIT[arg] and arg or SMODS.SUI.get_uit_key(arg)
 			if uit then
 				table.remove(args, 1)
@@ -428,66 +460,61 @@ SUI = setmetatable({
 		end
 
 		if uit then
-			return t[uit](unpack(args))
+			return sui[uit](unpack(args))
 		end
 		error("Not found node type for SMODS.SUI node")
 	end,
-	__index = function(t, k)
-		if G.UIT[k] then
-			t[k] = SMODS.SUI.extend_uit(G.UIT[k])
-			return t[k]
+	__index = function(sui, n)
+		if G.UIT[n] then
+			sui[n] = SMODS.SUI.extend_uit(G.UIT[n])
+			return sui[n]
 		end
-		error("Not found node type for SMODS.SUI node: " .. tostring(k))
+		error("Not found node type for SMODS.SUI node: " .. tostring(n))
 	end,
 })
 
 -- Vanilla node elements and their extensions
 
--- G.UIT.B - just a box without any child elements
+-- `G.UIT.B` - just a box without any child elements
 SUI.B = SMODS.SUI.extend_uit(G.UIT.B, {
-	process_node = function(self, node, index, v) end,
+	process_node = function(self, index, child) end,
 })
 
--- G.UIT.ROOT - starting element of each UIBox
+-- `G.UIT.ROOT` - starting element of each UIBox
 -- Fixes R/C inside, covers text into T, objects into O
 SUI.ROOT = SMODS.SUI.extend_uit(G.UIT.ROOT, {
 	process_node = SMODS.SUI.extended_process_node,
 })
 
--- G.UIT.C - column element
+-- `G.UIT.C` - column element
 -- Fixes R/C inside, covers text into T, objects into O
 SUI.C = SMODS.SUI.extend_uit(G.UIT.C, {
 	process_node = SMODS.SUI.extended_process_node,
 })
 
--- G.UIT.R - row element
+-- `G.UIT.R` - row element
 -- Fixes R/C inside, covers text into T, objects into O
 SUI.R = SMODS.SUI.extend_uit(G.UIT.R, {
 	process_node = SMODS.SUI.extended_process_node,
 })
 
--- G.UIT.O - object element
--- can have only 1 child - object to render; all other removes old and place new
+-- `G.UIT.O` - object element
+-- Can have only 1 child - object to render; all other removes old and place new
 SUI.O = SMODS.SUI.extend_uit(G.UIT.O, {
-	process_node = function(self, index, v)
+	process_node = function(self, index, child)
 		if self.config.object then
 			self.config.object:remove()
 		end
-		self.config.object = v
+		self.config.object = child
 	end,
-	topology = function(self)
-		local old_topology = SMODS.SUI.Node.topology(self)
+	topology = function(self, options)
+		local old_topology = SMODS.SUI.Node.topology(self, options)
 		local meta = self.config.object and getmetatable(self.config.object)
-		old_topology.attributes.object = "object={"
-			.. (meta and SMODS.SUI.get_debug_object_class_name(meta) or "nil")
-			.. "}"
+		old_topology.attributes.object = "{" .. (meta and SMODS.SUI.get_debug_object_class_name(meta) or "nil") .. "}"
 		return old_topology
 	end,
 	render = function(self)
 		local r = SMODS.SUI.Node.render(self)
-		if type(r.config.object_func) == "function" and not r.config.object then
-			r.config.object = r.config.object_func(self)
-		end
 		if not r.config.object then
 			r.config.object = Moveable()
 		end
@@ -495,23 +522,41 @@ SUI.O = SMODS.SUI.extend_uit(G.UIT.O, {
 	end,
 })
 
+-- `G.UIT.T` - text element
+-- Can have only 1 child - text to render; replaces old text with new one
+SUI.T = SMODS.SUI.extend_uit(G.UIT.T, {
+	process_node = function(self, index, child)
+		self.config.text = child
+	end,
+	topology = function(self, options)
+		local old_topology = SMODS.SUI.Node.topology(self, options)
+		old_topology.attributes.text = self.config.text
+		if self.config.ref_table and self.config.ref_value then
+			old_topology.attributes.text = tostring(self.config.ref_table[self.config.ref_value])
+		end
+		old_topology.attributes.text = old_topology.attributes.text or "[UI ERROR]"
+		old_topology.attributes.scale = self.config.scale and string.format("%.2f", self.config.scale) or "nil"
+		return old_topology
+	end,
+})
+
 -- Useful shortcuts for vanilla elements
 
--- SUI.ROOT with default colour G.C.CLEAR instead of G.C.BLACK
+-- `SUI.ROOT` with default colour `G.C.CLEAR` instead of `G.C.BLACK`
 SUI.CLEAR_ROOT = SUI.ROOT:extend({
 	setup = function(self, ...)
 		SUI.ROOT.setup(self, ...)
 		self:process_input({ colour = G.C.CLEAR })
 	end,
 })
--- SUI.C with default align = "cm"
+-- `SUI.C` with default `align = "cm"`
 SUI.CENTER_C = SUI.C:extend({
 	setup = function(self, ...)
 		SUI.C.setup(self, ...)
 		self:process_input({ align = "cm" })
 	end,
 })
--- SUI.R with default align = "cm"
+-- `SUI.R` with default `align = "cm"`
 SUI.CENTER_R = SUI.R:extend({
 	setup = function(self, ...)
 		SUI.R.setup(self, ...)

--- a/src/sui.lua
+++ b/src/sui.lua
@@ -266,6 +266,19 @@ end
 function SMODS.SUI.Node:process_config(key, value)
 	SMODS.SUI.config_merge(self, key, value)
 end
+function SMODS.SUI.Node:process_node(index, value)
+	SMODS.SUI.node_merge(self, index, value)
+end
+function SMODS.SUI.Node:pre_process_input(input)
+	local input_type = SMODS.SUI.input_type(input)
+	if input_type ~= "table" and input_type ~= "nil" then
+		input = { input }
+		input_type = "table"
+	end
+	if input_type == "table" then
+		return input
+	end
+end
 function SMODS.SUI.Node:post_process_input(input)
 	if input.s_config then
 		self.s_config = SMODS.merge_defaults(input.s_config or {}, self.s_config or {}) or {}
@@ -277,51 +290,46 @@ function SMODS.SUI.Node:post_process_input(input)
 		self.s_init = input.s_init
 	end
 end
-function SMODS.SUI.Node:process_node(index, value)
-	SMODS.SUI.node_merge(self, index, value)
-end
 function SMODS.SUI.Node:process_input(input)
-	local input_type = SMODS.SUI.input_type(input)
-	if input_type ~= "table" and input_type ~= "nil" then
-		input = { input }
-		input_type = "table"
+	input = self:pre_process_input(input)
+	if not input then
+		return
 	end
-	if input_type == "table" then
-		local children_to_insert = {}
-		if input.config then
-			for k, v in pairs(input.config) do
-				self:process_config(k, v)
-			end
-		end
-		if input.nodes then
-			for k, v in pairs(input.nodes) do
-				children_to_insert[#children_to_insert + 1] = v
-			end
-		end
-		for k, v in pairs(input) do
-			if SMODS.SUI.special_config_keys[k] then
-			elseif type(k) == "number" then
-				children_to_insert[#children_to_insert + 1] = v
-			else
-				self:process_config(k, v)
-			end
-		end
 
-		self:post_process_config(input)
+	local children_to_insert = {}
+	if input.config then
+		for k, v in pairs(input.config) do
+			self:process_config(k, v)
+		end
+	end
+	if input.nodes then
+		for k, v in pairs(input.nodes) do
+			children_to_insert[#children_to_insert + 1] = v
+		end
+	end
+	for k, v in pairs(input) do
+		if SMODS.SUI.special_config_keys[k] then
+		elseif type(k) == "number" then
+			children_to_insert[#children_to_insert + 1] = v
+		else
+			self:process_config(k, v)
+		end
+	end
 
-		local child_index = 0
-		for _, v in ipairs(children_to_insert) do
-			if type(v) == "table" and #v > 0 then
-				for _, node in pairs(v) do
-					child_index = child_index + 1
-					self:process_node(child_index, node)
-				end
-			else
+	local child_index = 0
+	for _, v in ipairs(children_to_insert) do
+		if type(v) == "table" and #v > 0 then
+			for _, node in pairs(v) do
 				child_index = child_index + 1
-				self:process_node(child_index, v)
+				self:process_node(child_index, node)
 			end
+		else
+			child_index = child_index + 1
+			self:process_node(child_index, v)
 		end
 	end
+
+	self:post_process_input(input)
 end
 function SMODS.SUI.Node:process_inputs(...)
 	for _, input in ipairs({ ... }) do
@@ -493,20 +501,20 @@ SUI.O = SMODS.SUI.extend_uit(G.UIT.O, {
 SUI.CLEAR_ROOT = SUI.ROOT:extend({
 	setup = function(self, ...)
 		SUI.ROOT.setup(self, ...)
-		self:process_inputs({ colour = G.C.CLEAR })
+		self:process_input({ colour = G.C.CLEAR })
 	end,
 })
 -- SUI.C with default align = "cm"
 SUI.CENTER_C = SUI.C:extend({
 	setup = function(self, ...)
 		SUI.C.setup(self, ...)
-		self:process_inputs({ align = "cm" })
+		self:process_input({ align = "cm" })
 	end,
 })
 -- SUI.R with default align = "cm"
 SUI.CENTER_R = SUI.R:extend({
 	setup = function(self, ...)
 		SUI.R.setup(self, ...)
-		self:process_inputs({ align = "cm" })
+		self:process_input({ align = "cm" })
 	end,
 })

--- a/src/sui.lua
+++ b/src/sui.lua
@@ -10,6 +10,7 @@ SMODS.SUI.special_config_keys = {
 	s_config = true, -- internal sui config
 	s_hooks = true, -- list of hooks to apply on element creation
 	s_init = true, -- init function
+	s_class = true, -- css class
 }
 
 -- Utilities
@@ -52,7 +53,7 @@ function SMODS.SUI.attach_hooks(target, hooks)
 	for func_key, new_func in pairs(hooks) do
 		local old_func = target[func_key] or function() end
 		target[func_key] = function(self, ...)
-			return new_func(self, old_func, ...)
+			return new_func(old_func, self, ...)
 		end
 	end
 	return target
@@ -195,8 +196,8 @@ function SMODS.SUI.get_topology(node, options, indent)
 
 	-- Resolve class name & id and format element in tree as `n#id.class1.class2`
 	local formatted_class_name = ""
-	if node.s_config and node.s_config.class then
-		for word in string.gmatch(node.s_config.class, "%S+") do
+	if node.s_class then
+		for word in string.gmatch(node.s_class, "%S+") do
 			formatted_class_name = formatted_class_name .. "." .. word
 		end
 	end
@@ -311,6 +312,9 @@ function SMODS.SUI.Node:post_process_input(input)
 	if input.s_init then
 		self.s_init = input.s_init
 	end
+	if input.s_class then
+		self.s_class = input.s_class
+	end
 end
 function SMODS.SUI.Node:process_input(input)
 	input = self:pre_process_input(input)
@@ -373,13 +377,13 @@ function SMODS.SUI.Node:render()
 	end
 
 	-- Apply CSS classes
-	if self.s_config.class then
+	if self.s_class then
 		local classes = self.s_config.css or SMODS.SUI.CSS
 		local old_config = self.config
 		local at_least_one_match = false
 		self.config = {}
 
-		for word in string.gmatch(self.s_config.class, "%S+") do
+		for word in string.gmatch(self.s_class, "%S+") do
 			if classes[word] then
 				at_least_one_match = true
 				for k, v in pairs(classes[word]) do
@@ -406,6 +410,7 @@ function SMODS.SUI.Node:render()
 		s_config = self.s_config,
 		s_hooks = self.s_hooks,
 		s_init = self.s_init,
+		s_class = self.s_class,
 	}
 end
 function SMODS.SUI.Node:topology(options)
@@ -416,6 +421,7 @@ function SMODS.SUI.Node:topology(options)
 		nodes = self.nodes or {},
 
 		s_config = self.s_config or {},
+		s_class = self.s_class,
 
 		attributes = {
 			align = self.config.align and string.format('"%s"', self.config.align),

--- a/src/sui.lua
+++ b/src/sui.lua
@@ -1,6 +1,6 @@
 SMODS.SUI = {}
 
-SMODS.SUI.CSS = {}
+SMODS.SUI.classes = {}
 
 SMODS.SUI.special_config_keys = {
 	n = true, -- element type
@@ -365,20 +365,20 @@ end
 
 function SMODS.SUI.Node:render()
 	-- Propagate CSS stylesheet element uses
-	if self.s_config.css ~= nil then
+	if self.s_config.classes ~= nil then
 		for _, child in ipairs(self.nodes) do
 			if not child.s_config then
 				child.s_config = {}
 			end
-			if child.s_config.css == nil then
-				child.s_config.css = self.s_config.css
+			if child.s_config.classes == nil then
+				child.s_config.classes = self.s_config.classes
 			end
 		end
 	end
 
 	-- Apply CSS classes
 	if self.s_class then
-		local classes = self.s_config.css or SMODS.SUI.CSS
+		local classes = self.s_config.classes or SMODS.SUI.classes
 		local old_config = self.config
 		local at_least_one_match = false
 		self.config = {}
@@ -386,9 +386,13 @@ function SMODS.SUI.Node:render()
 		for word in string.gmatch(self.s_class, "%S+") do
 			if classes[word] then
 				at_least_one_match = true
-				for k, v in pairs(classes[word]) do
-					self:process_config(k, v)
-				end
+                if type(classes[word]) == "function" then
+                    classes[word](self)
+                else
+                    for k, v in pairs(classes[word]) do
+                        self:process_config(k, v)
+                    end
+                end
 			end
 		end
 

--- a/src/sui.lua
+++ b/src/sui.lua
@@ -1,0 +1,554 @@
+SMODS.SUI = {}
+
+SMODS.SUI.CSS = {}
+
+SMODS.SUI.special_config_keys = {
+	n = true, -- element type
+	config = true, -- element config
+	nodes = true, -- element children
+
+	s_config = true, -- internal sui config
+	s_hooks = true, -- list of hooks to apply on element creation
+	s_init = true, -- init function
+}
+
+-- Utilities
+
+function SMODS.SUI.to_hex(v)
+	return string.format("%02X", math.floor(v * 255 + 0.5))
+end
+function SMODS.SUI.colour_to_hex(colour)
+	colour = colour or { 0, 0, 0, 0 }
+
+	local hex = "#" .. SMODS.SUI.to_hex(colour[1]) .. SMODS.SUI.to_hex(colour[2]) .. SMODS.SUI.to_hex(colour[3])
+
+	if colour[4] < 1 then
+		hex = hex .. SMODS.SUI.to_hex(colour[4])
+	end
+
+	return hex
+end
+function SMODS.SUI.input_type(i)
+	local itype = type(i)
+	if itype == "table" then
+		if Object.is(i, Moveable) then
+			return "moveable"
+		end
+		if i.n then
+			return "node"
+		end
+	end
+	return itype or "nil"
+end
+function SMODS.SUI.attach_hooks(target, hooks)
+	if not target or not hooks then
+		return
+	end
+	for _, func_key in pairs(hooks) do
+		local new_func = hooks[func_key]
+		local old_func = target[func_key] or function() end
+		target[func_key] = function(self, ...)
+			return new_func(self, old_func, ...)
+		end
+	end
+	return target
+end
+
+-- Storages for keys which needs to be resolved by iterating dictionaries
+
+SMODS.SUI.UIT_STORAGE = {
+	buffer = {},
+	fallback_to_unknown = false,
+	get_tables = function()
+		return {
+			[""] = G.UIT,
+		}
+	end,
+}
+SMODS.SUI.DEBUG_UIT_STORAGE = {
+	buffer = {},
+	fallback_to_unknown = true,
+	unknown_next_index = 1,
+	unknown_prefix = "?UIT",
+	get_tables = function()
+		return {
+			[""] = G.UIT,
+		}
+	end,
+}
+SMODS.SUI.DEBUG_CLASS_STORAGE = {
+	buffer = {},
+	fallback_to_unknown = true,
+	unknown_next_index = 1,
+	unknown_prefix = "?Class",
+	get_tables = function()
+		return {
+			[""] = _G,
+			["SMODS."] = SMODS,
+			["SMODS.SUI."] = SMODS.SUI,
+		}
+	end,
+}
+
+function SMODS.SUI.create_storage(storage)
+	return function(input)
+		-- Get value from buffer
+		if storage.buffer[input] then
+			return storage.buffer[input]
+		end
+		-- Process all tables looking for input
+		for _k, _v in pairs(storage.get_tables()) do
+			for k, v in pairs(_v) do
+				if v == input then
+					local result_key = _k .. k
+					storage.buffer[input] = result_key
+					return result_key
+				end
+			end
+		end
+
+		if storage.fallback_to_unknown then
+			-- Mark as unknown
+			local result_key = storage.unknown_prefix .. storage.unknown_next_index
+			storage.unknown_next_index = storage.unknown_next_index + 1
+			storage.buffer[input] = result_key
+			return result_key
+		end
+
+		return nil
+	end
+end
+
+-- Way to resolve G.UIT values as a key
+SMODS.SUI.get_uit_key = SMODS.SUI.create_storage(SMODS.SUI.UIT_STORAGE)
+-- Way to resolve G.UIT values as a key for debug purposes, marking unknown ones
+SMODS.SUI.get_debug_uit_key = SMODS.SUI.create_storage(SMODS.SUI.DEBUG_UIT_STORAGE)
+-- Way to resolve instances of Object as class name for debug purposes, marking unknown ones
+SMODS.SUI.get_debug_object_class_name = SMODS.SUI.create_storage(SMODS.SUI.DEBUG_CLASS_STORAGE)
+
+-- Base element behaviour
+
+function SMODS.SUI.config_merge(node, key, value)
+	node.config[key] = value
+end
+function SMODS.SUI.node_merge(node, index, value)
+	node.nodes[table.maxn(node.nodes) + 1] = value
+end
+function SMODS.SUI.extended_process_node(node, index, v)
+	local input_type = SMODS.SUI.input_type(v)
+	if input_type == "moveable" then
+		v = SUI.O({ v })
+		input_type = "node"
+	elseif input_type == "string" or input_type == "number" then
+		v = SUI.T({ colour = G.C.UI.TEXT_LIGHT, scale = 0.32, v })
+		input_type = "node"
+	end
+	if input_type == "node" then
+		if node.s_config.rc_fix_target == nil then
+			if v.n == G.UIT.C or v.n == G.UIT.O then
+				node.s_config.rc_fix_target = "C"
+			elseif v.n == G.UIT.R then
+				node.s_config.rc_fix_target = "R"
+			end
+			SMODS.SUI.Node.process_node(node, index, v)
+		elseif node.s_config.rc_fix_target == "C" and v.n == G.UIT.R then
+			SMODS.SUI.Node.process_node(node, index, SUI.C({ v }))
+		elseif node.s_config.rc_fix_target == "R'" and (v.n == G.UIT.C or v.n == G.UIT.O) then
+			SMODS.SUI.Node.process_node(node, index, SUI.R({ v }))
+		else
+			SMODS.SUI.Node.process_node(node, index, v)
+		end
+	end
+end
+function SMODS.SUI.process_node_render(node)
+	return node.render and node:render() or node
+end
+function SMODS.SUI.process_element_created(element)
+	SMODS.SUI.attach_hooks(element, element.input_node.s_hooks)
+	if element.input_node.s_init then
+		element.input_node.s_init(element)
+	end
+end
+
+-- Topology printing tools
+
+function SMODS.SUI.get_topology(node, options, indent)
+	options = options or {}
+	indent = indent or ""
+	if node.render then
+		node = node:render()
+	end
+	local formatted_class_name = ""
+	node.config = node.config or {}
+	if node.s_config and node.s_config.class then
+		for word in string.gmatch(node.s_config.class, "%S+") do
+			formatted_class_name = formatted_class_name .. "." .. word
+		end
+	end
+	local formatted_id = ""
+	if node.config.id then
+		formatted_id = "#" .. node.config.id
+	end
+	local topology_info
+	if not node.topology then
+		local uit = SMODS.SUI.get_debug_uit_key(node.n)
+		topology_info = (SUI[uit] or SMODS.SUI.Node).topology(node)
+	else
+		topology_info = node:topology()
+	end
+	local formatted_n = topology_info.n
+	local element_line = string.format("%s<%s%s%s", indent, formatted_n, formatted_id, formatted_class_name)
+	local additional_attributes = ""
+	for _, v in pairs(topology_info.attributes or {}) do
+		additional_attributes = additional_attributes .. v .. " "
+	end
+	if additional_attributes ~= "" then
+		element_line = element_line .. " " .. additional_attributes
+	end
+	local with_children = false
+	for _, subnode in pairs(topology_info.nodes or {}) do
+		if not with_children then
+			with_children = true
+			element_line = element_line .. ">"
+		end
+		element_line = element_line .. "\n" .. SMODS.SUI.get_topology(subnode, options, indent .. "    ")
+	end
+	if with_children then
+		element_line = element_line .. "\n" .. string.format("%s</%s>", indent or "", formatted_n)
+	else
+		element_line = element_line .. " />"
+	end
+	return element_line
+end
+function SMODS.SUI.print_topology(node, options)
+	return print("\n" .. SMODS.SUI.get_topology(node, options))
+end
+
+-- Base extendable SMODS.SUI node element
+
+SMODS.SUI.Node = Object:extend()
+SMODS.SUI.Node.subclasses = {}
+function SMODS.SUI.Node:extend(o)
+	local cls = Object.extend(self)
+	for k, v in pairs(o or {}) do
+		cls[k] = v
+	end
+	self.subclasses[#self.subclasses + 1] = cls
+	cls.subclasses = {}
+	return cls
+end
+
+function SMODS.SUI.Node:init(n, ...)
+	assert(n, "Not found node type for SMODS.SUI node")
+
+	self.n = n
+	self.config = {}
+	self.nodes = {}
+
+	self.s_config = {}
+	self.s_hooks = {}
+end
+function SMODS.SUI.Node:setup() end
+function SMODS.SUI.Node:__call(...)
+	if self.n then
+		self:process_inputs(...)
+		return self
+	end
+	local obj = setmetatable({}, self)
+	obj:init(...)
+	obj:setup()
+	obj:process_inputs(...)
+	return obj
+end
+
+function SMODS.SUI.Node:process_config(key, value)
+	SMODS.SUI.config_merge(self, key, value)
+end
+function SMODS.SUI.Node:post_process_input(input)
+	if input.s_config then
+		self.s_config = SMODS.merge_defaults(input.s_config or {}, self.s_config or {}) or {}
+	end
+	if input.s_hooks then
+		self.s_hooks = SMODS.merge_defaults(input.s_hooks or {}, self.s_hooks or {}) or {}
+	end
+	if input.s_init then
+		self.s_init = input.s_init
+	end
+end
+function SMODS.SUI.Node:process_node(index, value)
+	SMODS.SUI.node_merge(self, index, value)
+end
+function SMODS.SUI.Node:process_input(input)
+	local input_type = SMODS.SUI.input_type(input)
+	if input_type ~= "table" and input_type ~= "nil" then
+		input = { input }
+		input_type = "table"
+	end
+	if input_type == "table" then
+		local children_to_insert = {}
+		if input.config then
+			for k, v in pairs(input.config) do
+				self:process_config(k, v)
+			end
+		end
+		if input.nodes then
+			for k, v in pairs(input.nodes) do
+				children_to_insert[#children_to_insert + 1] = v
+			end
+		end
+		for k, v in pairs(input) do
+			if SMODS.SUI.special_config_keys[k] then
+			elseif type(k) == "number" then
+				children_to_insert[#children_to_insert + 1] = v
+			else
+				self:process_config(k, v)
+			end
+		end
+
+		self:post_process_config(input)
+
+		local child_index = 0
+		for _, v in ipairs(children_to_insert) do
+			if type(v) == "table" and #v > 0 then
+				for _, node in pairs(v) do
+					child_index = child_index + 1
+					self:process_node(child_index, node)
+				end
+			else
+				child_index = child_index + 1
+				self:process_node(child_index, v)
+			end
+		end
+	end
+end
+function SMODS.SUI.Node:process_inputs(...)
+	for _, input in ipairs({ ... }) do
+		self:process_input(input)
+	end
+end
+
+function SMODS.SUI.Node:render()
+	if self.s_config.css ~= nil then
+		for _, child in ipairs(self.nodes) do
+			if not child.s_config then
+				child.s_config = {}
+			end
+			if child.s_config.css == nil then
+				child.s_config.css = self.s_config.css
+			end
+		end
+	end
+	if self.s_config.class then
+		local classes = self.s_config.css or SMODS.SUI.CSS or {}
+		local classname = self.s_config.class
+		local old_config = self.config
+		self.config = {}
+		for word in string.gmatch(classname, "%S+") do
+			if classes[word] then
+				for k, v in pairs(classes[word]) do
+					self:process_config(k, v)
+				end
+			end
+		end
+		for k, v in pairs(old_config) do
+			self:process_config(k, v)
+		end
+	end
+	return {
+		n = self.n,
+		config = self.config,
+		nodes = self.nodes,
+		T = self.T,
+
+		s_config = self.s_config,
+		s_hooks = self.s_hooks,
+		s_init = self.s_init,
+	}
+end
+function SMODS.SUI.Node:topology()
+	self.config = self.config or {}
+	return {
+		n = SMODS.SUI.get_debug_uit_key(self.n),
+		config = self.config or {},
+		nodes = self.nodes or {},
+
+		s_config = self.s_config or {},
+
+		attributes = {
+			align = self.config.align and string.format('align="%s"', self.config.align),
+			colour = self.config.colour and string.format("colour=%s", SMODS.SUI.colour_to_hex(self.config.colour)),
+			w = self.config.w and string.format("w=%.2f", self.config.w),
+			minw = self.config.minw and string.format("minw=%.2f", self.config.minw),
+			maxw = self.config.maxw and string.format("maxw=%.2f", self.config.maxw),
+			h = self.config.w and string.format("h=%.2f", self.config.h),
+			minh = self.config.minh and string.format("minh=%.2f", self.config.minh),
+			maxh = self.config.maxh and string.format("maxh=%.2f", self.config.maxh),
+		},
+	}
+end
+
+-- Global SUi table to store all node classes
+
+function SMODS.SUI.extend_uit(n, t)
+	t = t or {}
+	t.init = t.init or function(self, ...)
+		SMODS.SUI.Node.init(self, n, ...)
+	end
+	return SMODS.SUI.Node:extend(t)
+end
+
+SUI = setmetatable({
+	padding = G.UIT.padding,
+}, {
+	__call = function(t, ...)
+		local args = { ... }
+		local uit
+
+		local arg = args[1]
+		if type(arg) == "table" then
+			uit = arg.n and (G.UIT[arg.n] and arg.n or SMODS.SUI.get_uit_key(arg.n)) or nil
+			if uit then
+				arg.n = nil
+			end
+		elseif arg then
+			uit = G.UIT[arg] and arg or SMODS.SUI.get_uit_key(arg)
+			if uit then
+				table.remove(args, 1)
+			end
+		end
+
+		if uit then
+			return t[uit](unpack(args))
+		end
+		error("Not found node type for SMODS.SUI node")
+	end,
+	__index = function(t, k)
+		if G.UIT[k] then
+			t[k] = SMODS.SUI.extend_uit(G.UIT[k])
+			return t[k]
+		end
+		error("Not found node type for SMODS.SUI node: " .. tostring(k))
+	end,
+})
+
+-- Vanilla node elements and their extensions
+
+-- G.UIT.B - just a box without any child elements
+SUI.B = SMODS.SUI.extend_uit(G.UIT.B, {
+	process_node = function(self, node, index, v) end,
+})
+
+-- G.UIT.ROOT - starting element of each UIBox
+-- Fixes R/C inside, covers text into T, objects into O
+SUI.ROOT = SMODS.SUI.extend_uit(G.UIT.ROOT, {
+	process_node = SMODS.SUI.extended_process_node,
+})
+
+-- G.UIT.C - column element
+-- Fixes R/C inside, covers text into T, objects into O
+SUI.C = SMODS.SUI.extend_uit(G.UIT.C, {
+	process_node = SMODS.SUI.extended_process_node,
+})
+
+-- G.UIT.R - row element
+-- Fixes R/C inside, covers text into T, objects into O
+SUI.R = SMODS.SUI.extend_uit(G.UIT.R, {
+	process_node = SMODS.SUI.extended_process_node,
+})
+
+-- G.UIT.O - object element
+-- can have only 1 child - object to render; all other removes old and place new
+SUI.O = SMODS.SUI.extend_uit(G.UIT.O, {
+	process_node = function(self, index, v)
+		if self.config.object then
+			self.config.object:remove()
+		end
+		self.config.object = v
+	end,
+	topology = function(self)
+		local old_topology = SMODS.SUI.Node.topology(self)
+		local meta = self.config.object and getmetatable(self.config.object)
+		old_topology.attributes.object = "object={"
+			.. (meta and SMODS.SUI.get_debug_object_class_name(meta) or "nil")
+			.. "}"
+		return old_topology
+	end,
+	render = function(self)
+		local r = SMODS.SUI.Node.render(self)
+		if type(r.config.object_func) == "function" and not r.config.object then
+			r.config.object = r.config.object_func(self)
+		end
+		if not r.config.object then
+			r.config.object = Moveable()
+		end
+		return r
+	end,
+})
+
+-- Useful shortcuts for vanilla elements
+
+-- SUI.ROOT with default colour G.C.CLEAR instead of G.C.BLACK
+SUI.CLEAR_ROOT = SUI.ROOT:extend({
+	setup = function(self, ...)
+		SUI.ROOT.setup(self, ...)
+		self:process_inputs({ colour = G.C.CLEAR })
+	end,
+})
+-- SUI.ROOT with default align = "cm"
+SUI.CENTER_ROOT = SUI.ROOT:extend({
+	setup = function(self, ...)
+		SUI.ROOT.setup(self, ...)
+		self:process_inputs({ align = "cm" })
+	end,
+})
+-- SUI.ROOT with default colour G.C.CLEAR instead of G.C.BLACK, and with default align = "cm"
+SUI.CLEAR_CENTER_ROOT = SUI.ROOT:extend({
+	setup = function(self, ...)
+		SUI.ROOT.setup(self, ...)
+		self:process_inputs({ colour = G.C.CLEAR, align = "cm" })
+	end,
+})
+-- SUI.C with default align = "cm"
+SUI.CENTER_C = SUI.C:extend({
+	setup = function(self, ...)
+		SUI.C.setup(self, ...)
+		self:process_inputs({ align = "cm" })
+	end,
+})
+-- SUI.R with default align = "cm"
+SUI.CENTER_R = SUI.R:extend({
+	setup = function(self, ...)
+		SUI.R.setup(self, ...)
+		self:process_inputs({ align = "cm" })
+	end,
+})
+
+-- Custom elements
+
+-- SUI.LOC_TEXT: easy way to render text via SMODS.localize_box
+SUI.LOC_TEXT = SUI.C:extend({
+	process_config = function(self, k, v)
+		if k == "loc_box_config" or k == "row_config" then
+			self.s_config[k] = SMODS.merge_defaults(v or {}, self.s_config[k] or {})
+		else
+			SUI.C.process_config(self, k, v)
+		end
+	end,
+	process_node = function(self, k, v)
+		local input_type = SMODS.SUI.input_type(v)
+		if input_type == "node" or input_type == "moveable" then
+			SUI.C.process_node(self, k, v)
+		else
+			local line = input_type == "string" and loc_parse_string(v) or v
+			local box_config = SMODS.merge_defaults(self.s_config.loc_box_config or {}, {
+				vars = {},
+				default_col = G.C.UI.TEXT_LIGHT,
+			})
+			SUI.C.process_node(
+				self,
+				k,
+				SUI.R({ config = self.s_config.row_config, nodes = SMODS.localize_box(line, box_config) })
+			)
+		end
+	end,
+})


### PR DESCRIPTION
This PR is WIP implementation for new advanced way for defining UI nodes, with additional quality-of-life features and extendable design which allows to create complex components.

Further explanation, examples, caveats etc. will be included in PR text later.

## Summary

<details>
  <summary>Quick example</summary>

```lua
SUI.ROOT({
	colour = G.C.CLEAR,
	outline = 1,
	outline_colour = G.C.WHITE,

	SUI.C({
		align = "cm",

		SUI.R({ colour = G.C.MULT }),
		SUI.R({ colour = G.C.CHIPS }),
	}),
	SUI.C({
		align = "cm",

		SUI.R({ colour = G.C.ORANGE }),
		SUI.R({ colour = G.C.GREEN }),
	}),
})

-- Using lua syntax for function call with table
SUI.ROOT{
	colour = G.C.CLEAR,
	SUI.C{
		align = "cm",
		SUI.R{ colour = G.C.MULT },
	},
	SUI.C{
		align = "cm",
		SUI.R{ colour = G.C.ORANGE },
	},
}
```
</details>

## Syntax

<details>
  <summary>Element creation</summary>

```lua
-- Preferred

SUI.ROOT({ ... }) -- chosen type
SUI("ROOT", { ... }) -- variable type

-- All

-- single argument, any type
-- as `n` can be key or value from `G.UIT`
SUI({ n = G.UIT.ROOT, ... })
SUI({ n = "ROOT", ... })
-- two arguments, any type
SUI(G.UIT.ROOT, { ... })
SUI("ROOT", { ... })
-- single argument, chosen type
SUI.ROOT({ ... })
SUI["ROOT"]({ ... })
```
</details>

<details>
  <summary>Adding child nodes</summary>

```lua

-- Preferred

SUI.ROOT({ child_1, child_2 }) -- general case

local content = { child_2, child_3 }
SUI.ROOT({ child_1, content, child_4 }) -- inserting multiple at once

SUI.ROOT(child_1) -- shorthand for covering element into other element

-- All

-- vanilla way
SUI.ROOT({ nodes = { child_1, child_2 } })
-- as arguments
SUI.ROOT(child_1, child_2)
-- as array
SUI.ROOT({ child_1, child_2 })
-- as array of arrays
SUI.ROOT({ child_1, { child_2, child_3 }, child_4 })
-- multiple arguments, each argument extends previous
SUI.ROOT({ child_1, child_2 }, { child_3, child_4 })
-- chained
SUI.ROOT({ child_1, child_2 })({ child_3, child_4 })
-- combined (.nodes first, then rest)
SUI.ROOT({ nodes = { child_1 }, child_2 })

-- extreme example: all listed examples for adding children
-- can be used at the same time in any order
SUI.ROOT(
	{
		nodes = { child_1, child_2 },
		child_3,
		{ child_4, child_5 },
	},
	child_6,
	{
		nodes = { child_7 },
		child_8,
		{ child_9 },
	}
)({
	child_10,
})
-- result element will be equivavelt of this element
SUI.ROOT({
	child_1,
	child_2,
	child_3,
	child_4,
	child_5,
	child_6,
	child_7,
	child_8,
	child_9,
	child_10,
})
```
</details>

<details>
  <summary>Config definition</summary>

```lua
-- vanilla way
SUI.ROOT({ config = { colour = G.C.CLEAR, padding = 0.1 } })
-- simple way
SUI.ROOT({ colour = G.C.CLEAR, padding = 0.1 })
-- multiple arguments, each argument extends previous
SUI.ROOT({ colour = G.C.CLEAR }, { padding = 0.1 })
-- chained, each call extends previous
SUI.ROOT({ colour = G.C.CLEAR })({ padding = 0.1 })
-- combined (.config first, then rest)
SUI.ROOT({ config = { colour = G.C.CLEAR }, padding = 0.1 })

-- extreme example: all listed examples for adding config
-- can be used at the same time in any order
SUI.ROOT({
	config = { colour = G.C.CLEAR, outline_colour = G.C.WHITE },
	padding = 0.1,
}, { h = 3, w = 5, colour = G.C.BLACK })({
	config = { outline = 1, padding = 0.25 },
	align = "cm",
})
-- result element will be equivavelt of this element
SUI.ROOT({
	colour = G.C.BLACK,
	outline = 1,
	outline_colour = G.C.WHITE,
	padding = 0.25,
	h = 3,
	w = 5,
	align = "cm",
})
```
</details>

## Features

<details>
  <summary>Feature: hooking UIElement methods via node definition</summary>

```lua
SUI.ROOT({
    -- init function which called when UIElement is ready to be used
    -- Important node: children is not ready in this moment, only element itself
    s_init = function(self)
        print("node created")
        self.states.collide.can = true
        self.states.click.can = true
    end,
    -- list of hooks to setup on UIElement
    s_hooks = {
        click = function(old_click, self, ...)
            print("node clicked")
            return old_click(self, ...)
        end,
        hover = function(old_hover, self, ...)
            print("node hovered")
            return old_hover(self, ...)
        end,
        update = function(old_update, self, dt, ...)
            print("node updated", dt)
            return old_update(self, dt, ...)
        end,
    },
})
```
</details>

<details>
  <summary>Feature: auto-wrap Moveable into G.UIT.O</summary>

```lua
local cardarea = CardArea(0, 0, G.CARD_W, G.CARD_H, { type = "title" })
local card = SMODS.create_card({ key = "j_joker", area = cardarea })
cardarea:emplace(card)
-- In this example, instead of `CardArea` it be any object which extends `Moveable` such as `UIBox`, `Card`, `Sprite`, etc.

SUI.ROOT({ colour = G.C.CLEAR, cardarea }) -- general case
SUI.ROOT(cardarea) -- shorthand to wrap object into element

-- Vanilla way
SUI.ROOT({
	colour = G.C.CLEAR,
	SUI.O({ object = cardarea }),
})
-- Short way, SUI.O treat children as objects
SUI.ROOT({
	colour = G.C.CLEAR,
	SUI.O({ cardarea }),
})
-- Even shorter way: ROOT, R and C wraps
-- element in G.UIT.O if see Moveable
SUI.ROOT({ colour = G.C.CLEAR, cardarea })
SUI.ROOT({ colour = G.C.CLEAR }, cardarea )
```
</details>

<details>
  <summary>Feature: auto-wrap string/number argument into G.UIT.T</summary>

```lua
-- If string or number passed as child node, it will be covered in `G.UIT.T` element
-- Default values: colour = G.C.UI.TEXT_LIGHT, scale = 0.32,

SUI.ROOT({ align = "cm", "Hello World!", child_2 })
SUI.ROOT({ align = "cm", 0.25, child_2 })

-- Is equivalent to

SUI.ROOT({ 
    align = "cm",

    SUI.T({
        colour = G.C.UI.TEXT_LIGHT,
        scale = 0.32,
        text = "Hello World!"
    }),
    child_2
})

-- Vanilla way
SUI.ROOT({
	colour = G.C.CLEAR,
	SUI.T({ text = "Hello World!", scale = 0.5, colour = G.C.MULT }),
})
-- Short way, SUI.T treat children as text
SUI.ROOT({
	colour = G.C.CLEAR,
	SUI.T({ "Hello World!", scale = 0.5, colour = G.C.MULT }),
})
-- Even shorter way: ROOT, R and C wraps
-- element in G.UIT.T if see text or number
-- In this case default values for colour and scale is applied
SUI.ROOT({ colour = G.C.CLEAR, "Hello World!" })
SUI.ROOT({ colour = G.C.CLEAR }, "Hello World!" )
```
</details>

<details>
  <summary>Feature: fix G.UIT.R/G.UIT.C child nodes mismatch</summary>

```lua
-- In vanilla, this kind of UI is unpredictable
SUI.ROOT({
	SUI.R(),
	SUI.C(),
	SUI.R(),
	SUI.O(),
	SUI.R(),
})
-- ROOT, R, C applies automatic fix for layout based on first child
-- Example above will be converted to this.
-- First child is R so other elements will be converted to R too
-- O element behave similar to C in vanilla
SUI.ROOT({
	SUI.R(),
	SUI.R({ SUI.C() }),
	SUI.R(),
	SUI.R({ SUI.O() }),
	SUI.R(),
})

-- In this example...
SUI.ROOT({
	SUI.C(),
	SUI.R(),
	SUI.O(),
	SUI.R(),
	SUI.C(),
})
-- First child is C so other elements will be converted to C too
-- O element behave similar to C in vanilla
SUI.ROOT({
	SUI.C(),
	SUI.C({ SUI.R() }),
	SUI.O(),
	SUI.C({ SUI.R() }),
	SUI.C(),
})

-- Available options to adjust how R/C fix operates.
SUI.ROOT({
    s_config = {
        rc_fix_target = "C", -- specify target: "R" or "C", or false to disable entirely
        rc_fix_align = "cm", -- add align to all additional R/C created during fixing
    }
})
```
</details>

<details>
  <summary>Feature: classes</summary>

```lua
-- Classes are way to define design for elements and reuse it in different places

local classes = {
    -- class to make element rounded and a bit of emboss
    pretty = { r = 0.1, emboss = 0.1 },
    -- class to specify sizes for small squares inside
    square = { minh = 0.5, minw = 0.5 },
    -- class with standartized padding
    -- instead of table, function can be specified for more custom logic
    padding = function(self)
        self.config.padding = 0.05
    end,
}

-- Optionally, global table can be used
SMODS.SUI.classes.pretty = { r = 0.1, emboss = 0.1 }
SMODS.SUI.classes.pretty = { minh = 0.5, minw = 0.5 }
SMODS.SUI.classes.pretty = { padding = 0.05 }

SUI.ROOT({
    s_config = {
        -- Specify a table of classes to select from
        -- This applied to children and their children (unless another table is specified)
        -- If not specified, global table `SMODS.SUI.classes` used instead
        classes = classes,
    },
    -- From here, we can use specified classes to extend element configs
    -- Separated by whitespaces, any amount of classes can be specified in any order
    -- if found, they will be applied from left to right
    s_class = "padding pretty"
    -- Element's config have higher priority than any class configs
    colour = G.C.WHITE,

    SUI.C({
        SUI.R({
            s_class = "padding",
            SUI.R({ s_class = "pretty square", colour = G.C.MULT })
        }),
        SUI.R({
            s_class = "padding",
            SUI.R({ s_class = "pretty square", colour = G.C.CHIPS })
        }),
    }),
    SUI.C({
        SUI.R({
            s_class = "padding",
            SUI.R({ s_class = "pretty square", colour = G.C.GREEN })
        }),
        SUI.R({
            s_class = "padding",
            SUI.R({ s_class = "pretty square", colour = G.C.ORANGE })
        }),
    }),
})

```
</details>

## Additional Info:
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
