### PR TITLE
Allow support for returning a font in calculation functions

### DIFF
--- a/lovely/attention_text.toml
+++ b/lovely/attention_text.toml
@@ -1,0 +1,43 @@
+[manifest]
+version = "1.0.0"
+dump_lua = true
+priority = -10
+
+# insert font from attention text
+[[patches]]
+[patches.pattern]
+target = 'functions/UI_definitions.lua'
+pattern = '''{n=G.UIT.O, config={draw_layer = 1, object = DynaText({scale = args.scale, string = args.text, maxw = args.maxw, colours = {args.colour},float = true, shadow = true, silent = not args.noisy, args.scale, pop_in = 0, pop_in_rate = 6, rotate = args.rotate or nil})}},'''
+position = 'at'
+payload = '''{n=G.UIT.O, config={draw_layer = 1, object = DynaText({scale = args.scale, string = args.text, maxw = args.maxw, colours = {args.colour},float = true, shadow = true, silent = not args.noisy, args.scale, pop_in = 0, pop_in_rate = 6, rotate = args.rotate or nil, font = args.font})}},'''
+match_indent = true
+
+# insert font into attention text
+[[patches]]
+[patches.pattern]
+target = 'functions/common_events.lua'
+pattern = '''attention_text({
+                text = text,
+                scale = config.scale or 1, 
+                hold = delay - 0.2,
+                colour = extra and extra.text_colour,
+                backdrop_colour = colour,
+                align = card_aligned,
+                major = card,
+                offset = {x = 0, y = y_off}
+            })'''
+position = 'at'
+payload = '''attention_text({
+                text = text,
+                scale = config.scale or 1, 
+                hold = delay - 0.2,
+                colour = extra and extra.text_colour,
+                backdrop_colour = colour,
+                align = card_aligned,
+                major = card,
+                offset = {x = 0, y = y_off},
+								font = extra and extra.font and (type(extra.font) == "table" and extra.font or G.FONTS[extra.font] or SMODS.Fonts[extra.font]) 
+            })'''
+match_indent = true
+
+

--- a/lovely/attention_text.toml
+++ b/lovely/attention_text.toml
@@ -16,28 +16,11 @@ match_indent = true
 [[patches]]
 [patches.pattern]
 target = 'functions/common_events.lua'
-pattern = '''attention_text({
-                text = text,
-                scale = config.scale or 1, 
-                hold = delay - 0.2,
-                colour = extra and extra.text_colour,
-                backdrop_colour = colour,
-                align = card_aligned,
-                major = card,
-                offset = {x = 0, y = y_off}
-            })'''
-position = 'at'
-payload = '''attention_text({
-                text = text,
-                scale = config.scale or 1, 
-                hold = delay - 0.2,
-                colour = extra and extra.text_colour,
-                backdrop_colour = colour,
-                align = card_aligned,
-                major = card,
-                offset = {x = 0, y = y_off},
-								font = extra and extra.font and (type(extra.font) == "table" and extra.font or G.FONTS[extra.font] or SMODS.Fonts[extra.font]) 
-            })'''
+pattern = '''offset = {x = 0, y = y_off}'''
+position = 'before'
+payload = '''
+font = extra and extra.font and (type(extra.font) == "table" and extra.font or G.FONTS[extra.font] or SMODS.Fonts[extra.font]),
+'''
 match_indent = true
 
 

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -3073,19 +3073,21 @@ function SMODS.scale_card(card, args)
 	        end
 	    end
 	end
-    if card.edition then
-        local edition = G.P_CENTERS[card.edition.key]
-        if edition.calc_scaling and type(edition.calc_scaling) == 'function' then
-            local ret = edition:calc_scaling(card, card, initial, scalar_value, args)
-            if ret then
-                if ret.override_value and not args.block_overrides.value then initial = ret.override_value.value; SMODS.calculate_effect(ret.override_value, card) end
-                if ret.override_scalar_value and not args.block_overrides.scalar then scalar_value = ret.override_scalar_value.value; SMODS.calculate_effect(ret.override_scalar_value, card) end
-                if ret.override_message and not args.block_overrides.message then scaling_message = SMODS.merge_defaults(ret.override_message, scaling_message) end
-                if ret.post then ret.post.source = card; scaling_responses[#scaling_responses + 1] = ret.post end
-                SMODS.calculate_effect(ret, card)
-            end
-        end
-    end
+	if args.do_calc_scaling then
+	    if card.edition then
+	        local edition = G.P_CENTERS[card.edition.key]
+	        if edition.calc_scaling and type(edition.calc_scaling) == 'function' then
+	            local ret = edition:calc_scaling(card, card, initial, scalar_value, args)
+	            if ret then
+	                if ret.override_value and not args.block_overrides.value then initial = ret.override_value.value; SMODS.calculate_effect(ret.override_value, card) end
+	                if ret.override_scalar_value and not args.block_overrides.scalar then scalar_value = ret.override_scalar_value.value; SMODS.calculate_effect(ret.override_scalar_value, card) end
+	                if ret.override_message and not args.block_overrides.message then scaling_message = SMODS.merge_defaults(ret.override_message, scaling_message) end
+	                if ret.post then ret.post.source = card; scaling_responses[#scaling_responses + 1] = ret.post end
+	                SMODS.calculate_effect(ret, card)
+	            end
+	        end
+	    end
+	end
 
     if type(args.operation) == 'function' then
         args.operation(args.ref_table, args.ref_value, initial, scalar_value)

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -3089,34 +3089,34 @@ function SMODS.scale_card(card, args)
     if args.operation == '-' and scalar_value < 0 then scalar_value = scalar_value * -1 end
     local scaling_message = args.scaling_message
     local scaling_responses = {}
-	for _, area in ipairs(SMODS.get_card_areas('jokers')) do
-		for _, _card in ipairs(area.cards) do
-			local obj = _card.config.center
-			if obj.calc_scaling and type(obj.calc_scaling) == "function" then
-				local ret = obj:calc_scaling(_card, card, initial, scalar_value, args)
-				if ret then
-					if ret.override_value and not args.block_overrides.value then initial = ret.override_value.value; SMODS.calculate_effect(ret.override_value, _card) end
-					if ret.override_scalar_value and not args.block_overrides.scalar then scalar_value = ret.override_scalar_value.value; SMODS.calculate_effect(ret.override_scalar_value, _card) end
-					if ret.override_message and not args.block_overrides.message then scaling_message = SMODS.merge_defaults(ret.override_message, scaling_message) end
-					if ret.post then ret.post.source = _card; scaling_responses[#scaling_responses + 1] = ret.post end
-					SMODS.calculate_effect(ret, _card)
-				end
-			end
-		end
-	end
-	if card.edition then
-		local edition = G.P_CENTERS[card.edition.key]
-		if edition.calc_scaling and type(edition.calc_scaling) == 'function' then
-			local ret = edition:calc_scaling(card, card, initial, scalar_value, args)
-			if ret then
-				if ret.override_value and not args.block_overrides.value then initial = ret.override_value.value; SMODS.calculate_effect(ret.override_value, card) end
-				if ret.override_scalar_value and not args.block_overrides.scalar then scalar_value = ret.override_scalar_value.value; SMODS.calculate_effect(ret.override_scalar_value, card) end
-				if ret.override_message and not args.block_overrides.message then scaling_message = SMODS.merge_defaults(ret.override_message, scaling_message) end
-				if ret.post then ret.post.source = card; scaling_responses[#scaling_responses + 1] = ret.post end
-				SMODS.calculate_effect(ret, card)
-			end
-		end
-	end
+    for _, area in ipairs(SMODS.get_card_areas('jokers')) do
+        for _, _card in ipairs(area.cards) do
+            local obj = _card.config.center
+            if obj.calc_scaling and type(obj.calc_scaling) == "function" then
+                local ret = obj:calc_scaling(_card, card, initial, scalar_value, args)
+                if ret then
+                    if ret.override_value and not args.block_overrides.value then initial = ret.override_value.value; SMODS.calculate_effect(ret.override_value, _card) end
+                    if ret.override_scalar_value and not args.block_overrides.scalar then scalar_value = ret.override_scalar_value.value; SMODS.calculate_effect(ret.override_scalar_value, _card) end
+                    if ret.override_message and not args.block_overrides.message then scaling_message = SMODS.merge_defaults(ret.override_message, scaling_message) end
+                    if ret.post then ret.post.source = _card; scaling_responses[#scaling_responses + 1] = ret.post end
+                    SMODS.calculate_effect(ret, _card)
+                end
+            end
+        end
+    end
+    if card.edition then
+        local edition = G.P_CENTERS[card.edition.key]
+        if edition.calc_scaling and type(edition.calc_scaling) == 'function' then
+            local ret = edition:calc_scaling(card, card, initial, scalar_value, args)
+            if ret then
+                if ret.override_value and not args.block_overrides.value then initial = ret.override_value.value; SMODS.calculate_effect(ret.override_value, card) end
+                if ret.override_scalar_value and not args.block_overrides.scalar then scalar_value = ret.override_scalar_value.value; SMODS.calculate_effect(ret.override_scalar_value, card) end
+                if ret.override_message and not args.block_overrides.message then scaling_message = SMODS.merge_defaults(ret.override_message, scaling_message) end
+                if ret.post then ret.post.source = card; scaling_responses[#scaling_responses + 1] = ret.post end
+                SMODS.calculate_effect(ret, card)
+            end
+        end
+    end
 
     if type(args.operation) == 'function' then
         args.operation(args.ref_table, args.ref_value, initial, scalar_value)

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -3050,26 +3050,29 @@ function SMODS.scale_card(card, args)
     args.block_overrides = args.block_overrides or {}
     args.ref_table = args.ref_table or card.ability.extra
     args.scalar_table = args.scalar_table or args.ref_table
+	args.do_calc_scaling = args.do_calc_scaling ~= nil and args.do_calc_scaling or true
     local initial = args.ref_table[args.ref_value]
     local scalar_value = args.scalar_table[args.scalar_value]
     if args.operation == '-' and scalar_value < 0 then scalar_value = scalar_value * -1 end
     local scaling_message = args.scaling_message
     local scaling_responses = {}
-    for _, area in ipairs(SMODS.get_card_areas('jokers')) do
-        for _, _card in ipairs(area.cards) do
-            local obj = _card.config.center
-            if obj.calc_scaling and type(obj.calc_scaling) == "function" then
-                local ret = obj:calc_scaling(_card, card, initial, scalar_value, args)
-                if ret then
-                    if ret.override_value and not args.block_overrides.value then initial = ret.override_value.value; SMODS.calculate_effect(ret.override_value, _card) end
-                    if ret.override_scalar_value and not args.block_overrides.scalar then scalar_value = ret.override_scalar_value.value; SMODS.calculate_effect(ret.override_scalar_value, _card) end
-                    if ret.override_message and not args.block_overrides.message then scaling_message = SMODS.merge_defaults(ret.override_message, scaling_message) end
-                    if ret.post then ret.post.source = _card; scaling_responses[#scaling_responses + 1] = ret.post end
-                    SMODS.calculate_effect(ret, _card)
-                end
-            end
-        end
-    end
+	if args.do_calc_scaling then
+	    for _, area in ipairs(SMODS.get_card_areas('jokers')) do
+	        for _, _card in ipairs(area.cards) do
+	            local obj = _card.config.center
+	            if obj.calc_scaling and type(obj.calc_scaling) == "function" then
+	                local ret = obj:calc_scaling(_card, card, initial, scalar_value, args)
+	                if ret then
+	                    if ret.override_value and not args.block_overrides.value then initial = ret.override_value.value; SMODS.calculate_effect(ret.override_value, _card) end
+	                    if ret.override_scalar_value and not args.block_overrides.scalar then scalar_value = ret.override_scalar_value.value; SMODS.calculate_effect(ret.override_scalar_value, _card) end
+	                    if ret.override_message and not args.block_overrides.message then scaling_message = SMODS.merge_defaults(ret.override_message, scaling_message) end
+	                    if ret.post then ret.post.source = _card; scaling_responses[#scaling_responses + 1] = ret.post end
+	                    SMODS.calculate_effect(ret, _card)
+	                end
+	            end
+	        end
+	    end
+	end
     if card.edition then
         local edition = G.P_CENTERS[card.edition.key]
         if edition.calc_scaling and type(edition.calc_scaling) == 'function' then

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -3084,43 +3084,38 @@ function SMODS.scale_card(card, args)
     args.block_overrides = args.block_overrides or {}
     args.ref_table = args.ref_table or card.ability.extra
     args.scalar_table = args.scalar_table or args.ref_table
-	args.do_calc_scaling = args.do_calc_scaling ~= nil and args.do_calc_scaling or true
     local initial = args.ref_table[args.ref_value]
     local scalar_value = args.scalar_table[args.scalar_value]
     if args.operation == '-' and scalar_value < 0 then scalar_value = scalar_value * -1 end
     local scaling_message = args.scaling_message
     local scaling_responses = {}
-	if args.do_calc_scaling then
-	    for _, area in ipairs(SMODS.get_card_areas('jokers')) do
-	        for _, _card in ipairs(area.cards) do
-	            local obj = _card.config.center
-	            if obj.calc_scaling and type(obj.calc_scaling) == "function" then
-	                local ret = obj:calc_scaling(_card, card, initial, scalar_value, args)
-	                if ret then
-	                    if ret.override_value and not args.block_overrides.value then initial = ret.override_value.value; SMODS.calculate_effect(ret.override_value, _card) end
-	                    if ret.override_scalar_value and not args.block_overrides.scalar then scalar_value = ret.override_scalar_value.value; SMODS.calculate_effect(ret.override_scalar_value, _card) end
-	                    if ret.override_message and not args.block_overrides.message then scaling_message = SMODS.merge_defaults(ret.override_message, scaling_message) end
-	                    if ret.post then ret.post.source = _card; scaling_responses[#scaling_responses + 1] = ret.post end
-	                    SMODS.calculate_effect(ret, _card)
-	                end
-	            end
-	        end
-	    end
+	for _, area in ipairs(SMODS.get_card_areas('jokers')) do
+		for _, _card in ipairs(area.cards) do
+			local obj = _card.config.center
+			if obj.calc_scaling and type(obj.calc_scaling) == "function" then
+				local ret = obj:calc_scaling(_card, card, initial, scalar_value, args)
+				if ret then
+					if ret.override_value and not args.block_overrides.value then initial = ret.override_value.value; SMODS.calculate_effect(ret.override_value, _card) end
+					if ret.override_scalar_value and not args.block_overrides.scalar then scalar_value = ret.override_scalar_value.value; SMODS.calculate_effect(ret.override_scalar_value, _card) end
+					if ret.override_message and not args.block_overrides.message then scaling_message = SMODS.merge_defaults(ret.override_message, scaling_message) end
+					if ret.post then ret.post.source = _card; scaling_responses[#scaling_responses + 1] = ret.post end
+					SMODS.calculate_effect(ret, _card)
+				end
+			end
+		end
 	end
-	if args.do_calc_scaling then
-	    if card.edition then
-	        local edition = G.P_CENTERS[card.edition.key]
-	        if edition.calc_scaling and type(edition.calc_scaling) == 'function' then
-	            local ret = edition:calc_scaling(card, card, initial, scalar_value, args)
-	            if ret then
-	                if ret.override_value and not args.block_overrides.value then initial = ret.override_value.value; SMODS.calculate_effect(ret.override_value, card) end
-	                if ret.override_scalar_value and not args.block_overrides.scalar then scalar_value = ret.override_scalar_value.value; SMODS.calculate_effect(ret.override_scalar_value, card) end
-	                if ret.override_message and not args.block_overrides.message then scaling_message = SMODS.merge_defaults(ret.override_message, scaling_message) end
-	                if ret.post then ret.post.source = card; scaling_responses[#scaling_responses + 1] = ret.post end
-	                SMODS.calculate_effect(ret, card)
-	            end
-	        end
-	    end
+	if card.edition then
+		local edition = G.P_CENTERS[card.edition.key]
+		if edition.calc_scaling and type(edition.calc_scaling) == 'function' then
+			local ret = edition:calc_scaling(card, card, initial, scalar_value, args)
+			if ret then
+				if ret.override_value and not args.block_overrides.value then initial = ret.override_value.value; SMODS.calculate_effect(ret.override_value, card) end
+				if ret.override_scalar_value and not args.block_overrides.scalar then scalar_value = ret.override_scalar_value.value; SMODS.calculate_effect(ret.override_scalar_value, card) end
+				if ret.override_message and not args.block_overrides.message then scaling_message = SMODS.merge_defaults(ret.override_message, scaling_message) end
+				if ret.post then ret.post.source = card; scaling_responses[#scaling_responses + 1] = ret.post end
+				SMODS.calculate_effect(ret, card)
+			end
+		end
 	end
 
     if type(args.operation) == 'function' then


### PR DESCRIPTION
basicly you can do this now
<img width="213" height="121" alt="image" src="https://github.com/user-attachments/assets/a8610fa3-03fe-4559-a409-92920d601461" />
supports either a font table, font index (vanilla fonts), or font key (custom fonts)


## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
