### PR TITLE
Actually define the frames if mod icon is animated

### DIFF
--- a/src/preflight/loader.lua
+++ b/src/preflight/loader.lua
@@ -750,6 +750,7 @@ local function load_mods()
                 local data = SMODS.NFS.newFileData(mod.path.."/assets/1x/"..mod.icon_path)
                 local image_data = love.graphics.newImage(data)
                 local atlas_table = mod.icon_width and mod.icon_width ~= image_data:getWidth() and 'ANIMATION_ATLAS' or "ASSET_ATLAS"
+                local frames = atlas_table == 'ANIMATION_ATLAS' and math.floor(image_data:getWidth() / mod.icon_width)
                 SMODS.Atlas {
                     key = "modicon",
                     path = mod.icon_path,
@@ -757,7 +758,8 @@ local function load_mods()
                     py = image_data:getHeight(),
                     atlas_table = atlas_table,
                     fps = mod.icon_fps,
-                    image = image_data
+                    image = image_data,
+                    frames = frames
                 }
             end
             if mod.can_load and not mod.lovely_only then


### PR DESCRIPTION
If animated mod icon is defined via JSON, it is considered an AnimatedSprite, but because the `frames` were not defined for it at all, it is a 1-frame animation...



## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
