### PR TITLE
make SMODS.game_table_from_type support ref_table/ref_value

### DIFF
--- a/src/utils/weights.lua
+++ b/src/utils/weights.lua
@@ -29,7 +29,18 @@ function SMODS.poll_object(args)
     for _, key in ipairs(pool) do
         local weight_table = {}
         
-        local w, m_w = SMODS.get_weight_of_object(G[SMODS.game_table_from_type[key.type] or 'P_CENTERS'][key.key or key], key.weight, args)
+        local obj_type = SMODS.game_table_from_type[key.type]
+        local obj_pool = G.P_CENTERS
+
+        if obj_type then
+            if type(obj_type) == "table" then
+                obj_pool = obj_type.ref_table[obj_type.ref_value]
+            else
+                obj_pool = G[obj_type]
+            end
+        end
+
+        local w, m_w = SMODS.get_weight_of_object(obj_pool[key.key or key], key.weight, args)
         weight_table = {key = key.key or key, weight = m_w}
         
         total_weight = total_weight + w


### PR DESCRIPTION
made this change because Lemniscate stores custom game object type pools in its own namespace instead of `G` and i don't feel like doing a massive refactor

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [X] I didn't make new lovely files or all new lovely files have appropriate priority.
