### PR TITLE
3 more attributes

### DIFF
--- a/src/game_objects/attributes.lua
+++ b/src/game_objects/attributes.lua
@@ -500,3 +500,24 @@ SMODS.Attribute({
         'j_hiker'
     }
 })
+
+SMODS.Attribute({
+    key = 'shop',
+    keys = {
+        'j_astronomer', 'j_chaos', 'j_flash'
+    }
+})
+
+SMODS.Attribute({
+    key = 'booster',
+    keys = {
+        'j_red_card'
+    }
+})
+
+SMODS.Attribute({
+    key = 'hand_level',
+    keys = {
+        'j_space'
+    }
+})

--- a/src/game_objects/attributes.lua
+++ b/src/game_objects/attributes.lua
@@ -511,7 +511,7 @@ SMODS.Attribute({
 SMODS.Attribute({
     key = 'booster',
     keys = {
-        'j_red_card'
+        'j_red_card', 'j_hallucination', 'j_astronomer'
     }
 })
 

--- a/src/game_objects/attributes.lua
+++ b/src/game_objects/attributes.lua
@@ -518,6 +518,6 @@ SMODS.Attribute({
 SMODS.Attribute({
     key = 'hand_level',
     keys = {
-        'j_space'
+        'j_space', 'j_burnt'
     }
 })


### PR DESCRIPTION
these are attributes i've found myself adding to multiple mods because of their frequency of use across all of modded balatro, i think having them officially would be useful. they all also have precedence in vanilla (i've avoided adding any attributes that see frequent use in modded but have no jokers in vanilla). wiki PR will be up in 5 seconds

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
