### PR TITLE
Fix bug in `Gradient.update`

### DIFF
--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -644,18 +644,17 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
         inject = function(self) self[1], self[2], self[3], self[4] = 0,0,0,1 end,
         update = function(self, dt)
             if #self.colours < 2 then return end
-            local timer = G.TIMERS.REAL%self.cycle
-            local start_index = math.ceil(timer*#self.colours/self.cycle)
+            local timer = (G.TIMERS.REAL*#self.colours/self.cycle) % #self.colours
+            local start_index = 1 + math.floor(timer)
             local end_index = start_index == #self.colours and 1 or start_index+1
             local start_colour, end_colour = self.colours[start_index], self.colours[end_index]
-            local partial_timer = (timer%(self.cycle/#self.colours))*#self.colours/self.cycle
+            local partial_timer = timer % 1
+            local blend = partial_timer
+            if self.interpolation == 'trig' then
+                blend = 0.5*(1-math.cos(partial_timer*math.pi))
+            end
             for i = 1, 4 do
-                if self.interpolation == 'linear' then
-
-                    self[i] = start_colour[i] + partial_timer*(end_colour[i]-start_colour[i])
-                elseif self.interpolation == 'trig' then
-                    self[i] = start_colour[i] + 0.5*(1-math.cos(partial_timer*math.pi))*(end_colour[i]-start_colour[i])
-                end
+                self[i] = (1-blend)*start_colour[i] + blend*end_colour[i]
             end
         end,
     }


### PR DESCRIPTION
This fixes #1368 by replacing `math.ceil` with 1 + `math.floor` so that `start_index` is never 0

I made a few other changes but I can remove them if you want:
- I moved most of the blend calculations out of the for loop to increase performance and readability
- Made it default to linear rather than nothing
- Made the code a lot more legible 

I test the updated code and gradients still work properly

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
