### PR TITLE
Fixed Vouchers' `:calculate_dollar_bonus()` not being called.

### DIFF
--- a/lovely/better_calc.toml
+++ b/lovely/better_calc.toml
@@ -841,7 +841,7 @@ payload = '''
 local i = 0
 for _, area in ipairs(SMODS.get_card_areas('jokers')) do
     for _, _card in ipairs(area.cards) do
-        local ret, ret_opts = _card:calculate_dollar_bonus()
+        local ret, ret_opts = ((_card.config or {}).center or {}).calculate_dollar_bonus and _card.config.center:calculate_dollar_bonus() or _card:calculate_dollar_bonus()
         ret_opts = ret_opts or {}
 
         -- TARGET: calc_dollar_bonus per card


### PR DESCRIPTION
*Title, I think the default `Card:calculate_dollar_bonus()` func was being called instead.



## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
