### PR TITLE
SMODS.reset_card

### DIFF
--- a/lovely/scaling.toml
+++ b/lovely/scaling.toml
@@ -3,6 +3,8 @@ version = "1.0.0"
 dump_lua = true
 priority = -10
 
+# SCALING VALUES
+
 # Ceremonial Dagger
 [[patches]]
 [patches.pattern]
@@ -705,4 +707,82 @@ SMODS.scale_card(self, {
     end,
     message_key = 'a_xmult'
 })
+'''
+
+# RESETTING VALUES
+
+# Campfire / Hit the Road
+[[patches]]
+[patches.pattern]
+target = 'card.lua'
+match_indent = true
+position = 'at'
+pattern = '''
+self.ability.x_mult = 1
+return {
+    message = localize('k_reset'),
+    colour = G.C.RED
+}
+'''
+payload = '''
+SMODS.reset_card(self, {
+    ref_table = self.ability,
+    ref_value = 'x_mult',
+    reset_value = 1,
+    message_colour = G.C.RED
+})
+return nil, true
+'''
+
+# Ride the Bus
+[[patches]]
+[patches.pattern]
+target = 'card.lua'
+match_indent = true
+position = 'at'
+pattern = '''
+local last_mult = self.ability.mult
+self.ability.mult = 0
+if last_mult > 0 then 
+    return {
+        card = self,
+        message = localize('k_reset')
+    }
+end
+'''
+payload = '''
+if self.ability.mult > 0 then
+    SMODS.reset_card(self, {
+        ref_table = self.ability,
+        ref_value = 'mult',
+        reset_value = 0
+    })
+    return nil, true
+end
+'''
+
+# Obelisk
+[[patches]]
+[patches.pattern]
+target = 'card.lua'
+match_indent = true
+position = 'at'
+pattern = '''
+if self.ability.x_mult > 1 then
+    self.ability.x_mult = 1
+    return {
+        card = self,
+        message = localize('k_reset')
+    }
+end
+'''
+payload = '''
+if self.ability.x_mult > 1 then
+    SMODS.reset_card(self, {
+        ref_table = self.ability,
+        ref_value = 'x_mult',
+        reset_value = 1
+    })
+    return nil, true
+end
 '''

--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -726,6 +726,12 @@ function SMODS.is_eternal(card, trigger) end
 --- Args must contain `ref_table`, `ref_value`, and `scalar_value`. It may optionally contain `scalar_table`, used in place of `ref_table` for the `scalar_value`, and `operation` to designate the scaling operation, which defaults to `"+"`
 function SMODS.scale_card(card, args) end
 
+---@param card Card|table
+---@param args? table|{ref_table: table, ref_value: string, reset_value: number, operation: fun(ref_table: table, ref_value: string, initial: number, reset: number)?, block_override: boolean?, reset_message: table?, message_key: string?, message_colour: table?, message_delay: number?, no_message: boolean?}
+--- Tells Jokers that this card is resetting allowing for resetting detection
+--- Args must contain `ref_table`, `ref_value`, and `reset_value`. It may optionally contain an `operation` function to define the behavior of resetting
+function SMODS.reset_card(card, args) end
+
 ---@param prototype_obj SMODS.GameObject|table
 ---@param args table?
 ---@return boolean?, table?

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -3149,6 +3149,60 @@ function SMODS.multiplicative_scaling(ref_table, ref_value, initial, modifier)
     ref_table[ref_value] = initial * modifier
 end
 
+function SMODS.reset_card(card, args)
+    if not G.deck then return end
+    args.ref_table = args.ref_table or card.ability.extra
+    local initial = args.ref_table[args.ref_value]
+    local reset_value = args.reset_value or 0
+    local reset_message = args.reset_message
+    local reset_responses = {}
+    local override = false
+    for _, area in ipairs(SMODS.get_card_areas('jokers')) do
+        for _, _card in ipairs(area.cards) do
+            local obj = _card.config.center
+            if obj.calc_resetting and type(obj.calc_resetting) == "function" then
+                local ret = obj:calc_resetting(_card, card, initial, reset_value, args)
+                if ret then
+                    if ret.override and not args.block_override then override = true; SMODS.calculate_effect(ret.override, _card) end
+                    if ret.post then ret.post.source = _card; reset_responses[#reset_responses + 1] = ret.post end
+                    SMODS.calculate_effect(ret, _card)
+                end
+            end
+        end
+    end
+    if card.edition then
+        local edition = G.P_CENTERS[card.edition.key]
+        if edition.calc_resetting and type(edition.calc_resetting) == 'function' then
+            local ret = edition:calc_resetting(card, card, initial, reset_value, args)
+            if ret then
+                if ret.override and not args.block_override then override = true; SMODS.calculate_effect(ret.override, card) end
+                if ret.post then ret.post.source = card; reset_responses[#reset_responses + 1] = ret.post end
+                SMODS.calculate_effect(ret, card)
+            end
+        end
+    end
+
+    if not override then
+        if type(args.operation) == 'function' then
+            args.operation(args.ref_table, args.ref_value, initial, reset_value)
+        else
+            args.ref_table[args.ref_value] = reset_value
+        end
+
+        reset_message = reset_message or {
+            message = localize(args.message_key or 'k_reset'),
+            colour = args.message_colour or G.C.FILTER,
+            delay = args.message_delay,
+        }
+        if next(reset_message) and not args.no_message then
+            SMODS.calculate_effect(reset_message, card)
+        end
+    end
+    for _, ret in ipairs(reset_responses) do
+        SMODS.calculate_effect(ret, ret.source)
+    end
+end
+
 function SMODS.quip(quip_type)
     if not quip_type then return nil end
     local pool = {}

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -3163,7 +3163,12 @@ function SMODS.reset_card(card, args)
             if obj.calc_resetting and type(obj.calc_resetting) == "function" then
                 local ret = obj:calc_resetting(_card, card, initial, reset_value, args)
                 if ret then
-                    if ret.override and not args.block_override then override = true; SMODS.calculate_effect(ret.override, _card) end
+                    if ret.override and not args.block_override then
+                        override = true
+                        if type(ret.override) == "table" then
+                            SMODS.calculate_effect(ret.override, _card)
+                        end
+                    end
                     if ret.post then ret.post.source = _card; reset_responses[#reset_responses + 1] = ret.post end
                     SMODS.calculate_effect(ret, _card)
                 end
@@ -3175,7 +3180,12 @@ function SMODS.reset_card(card, args)
         if edition.calc_resetting and type(edition.calc_resetting) == 'function' then
             local ret = edition:calc_resetting(card, card, initial, reset_value, args)
             if ret then
-                if ret.override and not args.block_override then override = true; SMODS.calculate_effect(ret.override, card) end
+                if ret.override and not args.block_override then
+                    override = true
+                    if type(ret.override) == "table" then
+                        SMODS.calculate_effect(ret.override, card)
+                    end
+                end
                 if ret.post then ret.post.source = card; reset_responses[#reset_responses + 1] = ret.post end
                 SMODS.calculate_effect(ret, card)
             end

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -3151,24 +3151,20 @@ end
 
 function SMODS.reset_card(card, args)
     if not G.deck then return end
+    args.block_overrides = args.block_overrides or {}
     args.ref_table = args.ref_table or card.ability.extra
     local initial = args.ref_table[args.ref_value]
     local reset_value = args.reset_value or 0
     local reset_message = args.reset_message
     local reset_responses = {}
-    local override = false
     for _, area in ipairs(SMODS.get_card_areas('jokers')) do
         for _, _card in ipairs(area.cards) do
             local obj = _card.config.center
             if obj.calc_resetting and type(obj.calc_resetting) == "function" then
                 local ret = obj:calc_resetting(_card, card, initial, reset_value, args)
                 if ret then
-                    if ret.override and not args.block_override then
-                        override = true
-                        if type(ret.override) == "table" then
-                            SMODS.calculate_effect(ret.override, _card)
-                        end
-                    end
+                    if ret.override_value and not args.block_overrides.value then reset_value = ret.override_value.value; SMODS.calculate_effect(ret.override_value, _card) end
+                    if ret.override_message and not args.block_overrides.message then reset_message = SMODS.merge_defaults(ret.override_message, reset_message) end
                     if ret.post then ret.post.source = _card; reset_responses[#reset_responses + 1] = ret.post end
                     SMODS.calculate_effect(ret, _card)
                 end
@@ -3180,33 +3176,27 @@ function SMODS.reset_card(card, args)
         if edition.calc_resetting and type(edition.calc_resetting) == 'function' then
             local ret = edition:calc_resetting(card, card, initial, reset_value, args)
             if ret then
-                if ret.override and not args.block_override then
-                    override = true
-                    if type(ret.override) == "table" then
-                        SMODS.calculate_effect(ret.override, card)
-                    end
-                end
+                if ret.override_value and not args.block_overrides.value then reset_value = ret.override_value.value; SMODS.calculate_effect(ret.override_value, card) end
+                if ret.override_message and not args.block_overrides.message then reset_message = SMODS.merge_defaults(ret.override_message, reset_message) end
                 if ret.post then ret.post.source = card; reset_responses[#reset_responses + 1] = ret.post end
                 SMODS.calculate_effect(ret, card)
             end
         end
     end
 
-    if not override then
-        if type(args.operation) == 'function' then
-            args.operation(args.ref_table, args.ref_value, initial, reset_value)
-        else
-            args.ref_table[args.ref_value] = reset_value
-        end
+    if type(args.operation) == 'function' then
+        args.operation(args.ref_table, args.ref_value, initial, reset_value)
+    else
+        args.ref_table[args.ref_value] = reset_value
+    end
 
-        reset_message = reset_message or {
-            message = localize(args.message_key or 'k_reset'),
-            colour = args.message_colour or G.C.FILTER,
-            delay = args.message_delay,
-        }
-        if next(reset_message) and not args.no_message then
-            SMODS.calculate_effect(reset_message, card)
-        end
+    reset_message = reset_message or {
+        message = localize(args.message_key or 'k_reset'),
+        colour = args.message_colour or G.C.FILTER,
+        delay = args.message_delay,
+    }
+    if next(reset_message) and not args.no_message then
+        SMODS.calculate_effect(reset_message, card)
     end
     for _, ret in ipairs(reset_responses) do
         SMODS.calculate_effect(ret, ret.source)


### PR DESCRIPTION
adds `SMODS.reset_card(card, args)`, to be used to reset a card's value back to default, for jokers like Ride the Bus. works similarly to `SMODS.scale_card`, though it's much simpler: `reset_value` is a simple number stating what the new value will be (since jokers don't use config values for this, and manipulating it wouldn't be as common anyway). an `operation` function is still provided as an option, in case a joker needs to do additional behavior at the same time as resetting (if you had a scaling hand-size joker that reset, for example)

objects can define `calc_resetting` similarly to `calc_scaling`, which is also much simpler. instead of returning new values, it just returns `override` as a boolean in the return table (or as an effect to be calculated at the regular timing). this prevents the original resetting as well as whatever message it would return

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
