### PR TITLE
Prevent crash i think

### DIFF
--- a/src/utils.lua
+++ b/src/utils.lua
@@ -827,6 +827,7 @@ function convert_save_data()
             end
         end
         if v.losses_by_key then
+            v.losses = {}
             for kk,vv in pairs(v.losses_by_key) do
                 local index = G.P_STAKES[kk] and G.P_STAKES[kk].order
                 if index then v.losses[index] = vv end
@@ -852,6 +853,7 @@ function convert_save_data()
             end
         end
         if v.losses_by_key then
+            v.losses = {}
             for kk,vv in pairs(v.losses_by_key) do
                 local index = G.P_STAKES[kk] and G.P_STAKES[kk].order
                 if index then v.losses[index] = vv end


### PR DESCRIPTION
I have never heard anyone actually report the crash this theoretically avoids but afaict it it is possible for `v.losses_by_key` to exist without `v.losses` so

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
