### PR TITLE
make marble joker timing work like vanilla

### DIFF
--- a/lovely/better_calc.toml
+++ b/lovely/better_calc.toml
@@ -1759,16 +1759,22 @@ G.E_MANAGER:add_event(Event({
 playing_card_joker_effects({true})
 '''
 payload = '''
+local context_blueprint_card = context.blueprint_card
+local front = pseudorandom_element(G.P_CARDS, pseudoseed('marb_fr'))
+G.playing_card = (G.playing_card and G.playing_card + 1) or 1
+local card = Card(G.play.T.x + G.play.T.w/2, G.play.T.y, G.CARD_W, G.CARD_H, front, G.P_CENTERS.m_stone, {playing_card = G.playing_card})
+card.states.visible = nil
 G.E_MANAGER:add_event(Event({
     func = function()
-        local card = create_playing_card({
-            front = pseudorandom_element(G.P_CARDS, pseudoseed('marb_fr')),
-            center = G.P_CENTERS.m_stone}, G.play, nil, nil, {G.C.SECONDARY_SET.Enhanced})
-        SMODS.calculate_effect({message = localize('k_plus_stone'), colour = G.C.SECONDARY_SET.Enhanced}, context.blueprint_card or self)
-        playing_card_joker_effects({card})
+        card:start_materialize({G.C.SECONDARY_SET.Enhanced})
+        card:add_to_deck()
+        G.play:emplace(card)
+        table.insert(G.playing_cards, card)
         return true
     end}))
+SMODS.calculate_effect({message = localize('k_plus_stone'), colour = G.C.SECONDARY_SET.Enhanced}, context_blueprint_card or self)
 draw_card(G.play,G.deck, 90,'up', nil)
+playing_card_joker_effects({card})
 '''
 # DNA
 [[patches]]


### PR DESCRIPTION
fixes a few issues with the SMODS patch to marble joker. in vanilla, the card lingers for a moment (waiting for the "+1 Stone" message to finish) before it is drawn to the deck. previously, this patch made it so that this lingering no longer happens. additionally, the patch broke how blueprint copies the message. it also changed the order that events trigger, though i'm not sure that that affected anything. all of these issues are now resolved
this patch now makes the code work more similarly to DNA, where it invisibly creates the card immediately, not using `create_playing_card` (so that we can immediately provide the reference to `playing_card_joker_effects`), and queues an event to materialize it. as far as i could tell, this has no adverse effects, and makes the visuals now 1:1 with vanilla

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
