### PR TITLE
format lsp info correctly

### DIFF
--- a/src/utils/weights.lua
+++ b/src/utils/weights.lua
@@ -1,7 +1,7 @@
 -- TODO: how do soul objects fit into this system?
 
 -- Returns a `key` of the polled object type
----@param args table|{type: string?, attributes: table[string]?, pool: table[string]?, seed: string?, chance: number?, guaranteed: boolean?}
+---@param args table|{type: string?, attributes: string[]?, pool: string[]?, seed: string?, chance: number?, guaranteed: boolean?}
 function SMODS.poll_object(args)
     assert(args, "SMODS.poll_object called with no args."..SMODS.log_crash_info(debug.getinfo(2)))
     assert((args.type or (args.types and type(args.types) == 'table') or (args.attributes and type(args.attributes) == 'table') or (args.pool and type(args.pool) == 'table')), "SMODS.poll_object called without a pool source." .. SMODS.log_crash_info(debug.getinfo(2)))


### PR DESCRIPTION
Tables of strings are `string[]`, not `[string]`

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
