### PR TITLE
fix: add nil guard to SMODS.is_eternal

### DIFF
--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2995,6 +2995,7 @@ function Card:should_hide_front()
 end
 
 function SMODS.is_eternal(card, trigger)
+    if not card then return false end
     local calc_return = {}
     local ovr_compat = false
     local ret = false


### PR DESCRIPTION
## Description

**Problem:** Game crashes with `attempt to index local 'card' (a nil value)` when `SMODS.is_eternal(card)` is called with a nil card.

This is a public API function called from many locations across mods (`G.jokers.cards[i]`, `G.hand.highlighted[i]`, destroy contexts, etc.). Under certain conditions (empty hand, out-of-bounds index, invalid context), the card parameter can be nil.

**Solution:** Added `if not card then return false end` guard at the start of the function. Returns `false` (safe default — not eternal) for nil cards. This is consistent with the function's contract: a nonexistent card cannot be eternal.

## Stack trace from affected mod

```
main.lua:2122: [SMODS _ "src/utils.lua"]:3000: attempt to index local 'card' (a nil value)
```

## Affected callers

Found in the wild calling `SMODS.is_eternal` without nil checks:
- `G.jokers.cards[my_pos +/- 1]` — nil when at array boundary
- `G.hand.highlighted[i]` — nil when no cards highlighted
- Various destroy/remove contexts where `destroying_card` may not exist
