### PR TITLE
Suit shades

### DIFF
--- a/lovely/playing_card.toml
+++ b/lovely/playing_card.toml
@@ -234,7 +234,8 @@ line_prepend = '$indent'
 payload = '''
 local suit = SMODS.Suits[self.base.suit] or {}
 self.base.suit_nominal = suit.suit_nominal or 0
-self.base.suit_nominal_original = suit_base_nominal_original or suit.suit_nominal or 0'''
+self.base.suit_nominal_original = suit_base_nominal_original or suit.suit_nominal or 0
+self.base.shade = suit.shade'''
 
 # Card:change_suit()
 [[patches]]

--- a/lsp_def/classes/suit.lua
+++ b/lsp_def/classes/suit.lua
@@ -15,6 +15,7 @@
 ---@field hc_ui_atlas? string Atlas used for high-contrast mini suit symbol in deck view. 
 ---@field lc_colour? table HEX color of the suit text for low-contrast. 
 ---@field hc_colour? table HEX color of the suit text for high-contrast. 
+---@field shade? string A string that identifies a "shade" for the suit, e.g. "light" and "dark" suits.
 ---@field __call? fun(self: SMODS.Suit|table, o: SMODS.Suit|table): nil|table|SMODS.Suit
 ---@field extend? fun(self: SMODS.Suit|table, o: SMODS.Suit|table): table Primary method of creating a class. 
 ---@field check_duplicate_register? fun(self: SMODS.Suit|table): boolean? Ensures objects already registered will not register. 

--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -873,3 +873,10 @@ function SMODS.copy_card(card, args) end
 ---@param args {set: string?, area: CardArea|table?, playing_card: integer?}?
 ---@return Card|table
 function SMODS.add_to_deck(card, args) end
+
+---Checks if a card counts as at least one suit that matches the provided suit shade
+---@param card Card|table Card to check
+---@param shade string Suit shade to check for
+---@param bypass_debuff boolean? Whether to ignore the card's debuff status
+---@return boolean
+function Card.is_suit_shade(card, shade, bypass_debuff)

--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -879,4 +879,4 @@ function SMODS.add_to_deck(card, args) end
 ---@param shade string Suit shade to check for
 ---@param bypass_debuff boolean? Whether to ignore the card's debuff status
 ---@return boolean
-function Card.is_suit_shade(card, shade, bypass_debuff)
+function Card.is_suit_shade(card, shade, bypass_debuff) end

--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -2082,6 +2082,7 @@ SMODS.UndiscoveredCompat = {
         ui_pos = { x = 1, y = 1 },
         keep_base_colours = true,
         sort_id = 3,
+        shade = "light",
     }
     SMODS.Suit {
         key = 'Clubs',
@@ -2090,6 +2091,7 @@ SMODS.UndiscoveredCompat = {
         ui_pos = { x = 2, y = 1 },
         keep_base_colours = true,
         sort_id = 4,
+        shade = "dark",
     }
     SMODS.Suit {
         key = 'Hearts',
@@ -2098,6 +2100,7 @@ SMODS.UndiscoveredCompat = {
         ui_pos = { x = 0, y = 1 },
         keep_base_colours = true,
         sort_id = 2,
+        shade = "light",
     }
     SMODS.Suit {
         key = 'Spades',
@@ -2106,6 +2109,7 @@ SMODS.UndiscoveredCompat = {
         ui_pos = { x = 3, y = 1 },
         keep_base_colours = true,
         sort_id = 1,
+        shade = "dark",
     }
     -------------------------------------------------------------------------------------------------
     ----- API CODE GameObject.Rank

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -4161,3 +4161,16 @@ function SMODS.add_to_deck(card, args)
     area:emplace(card)
     return card
 end
+
+function Card:is_suit_shade(shade, bypass_debuff)
+    if self.debuff and not bypass_debuff then return end
+    if SMODS.has_no_suit(self) then
+        return false
+    end
+    for i, v in pairs(SMODS.Suits) do
+        if self:is_suit(i, bypass_debuff) and shade == v.shade then
+            return true
+        end
+    end
+    return false
+end


### PR DESCRIPTION
This is a small feature that allows SMODS.Suit objects to be classified into "shades". By default, Diamonds and Hearts count as "light" suits while Clubs and Spades are "dark" suits. This is mainly just a way to centralize and formalize the light and dark suit classifications that many mods use already (e.g. Paperback, Madcap, Bunco, UNIK's mod, even POLTERWORX).

Important additions:
`SMODS.Suit` definitions may now specify `shade = "something"`, where the shade can be any string at all. `"dark"` and `"light"` are used in the vanilla suit definitions. If no shade is provided, it's just left as `nil`.
`card.base.shade` is the same string (or nil) as specified in the suit definition.
`Card:is_suit_shade(shade, bypass_debuff)` is a new function that works very similarly to `Card:is_suit`. You pass a string for the shade, and the function checks if the relevant card counts as at least one suit that matches that shade.

Food for thought:
It may be interesting to make Smeared Joker make every suit of the same shade count as each other, instead of just explicitly laying out the 4 vanilla suits. However, that would require a description change, and is probably not suited for SMODS itself.
Allowing wild cards (and other stuff that counts as any suit) to count as any shade, even if there are no suits in-game that actually match that shade?
I know y'all want to put new util functions in separate files in the new utils folder, but `Card:is_suit_shade` was so small I figured it wouldn't be out of place in the main utils.lua file until that gets fully split up. I can certainly move it if desired

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [X] I didn't modify api's or I've updated lsp definitions.
- [X] I didn't make new lovely files or all new lovely files have appropriate priority.
