### PR TITLE
`select_card` can now allow for select and use at the same time

### DIFF
--- a/lovely/booster.toml
+++ b/lovely/booster.toml
@@ -311,6 +311,40 @@ if card.ability.consumeable and card.area == G.pack_cards and G.pack_cards and b
 end
 '''
 
+[[patches]]
+[patches.pattern]
+target = 'functions/UI_definitions.lua'
+match_indent = true
+position = 'at'
+pattern = '''
+if ((card.area == G.consumeables and G.consumeables) or (card.area == G.pack_cards and G.pack_cards)) and
+'''
+payload = '''
+if (card.area == G.pack_cards and G.pack_cards) and card.ability.consumeable and booster_obj and card:selectable_from_pack(booster_obj) then
+    local select_area, can_also_use = card:selectable_from_pack(booster_obj)
+    local select_button_text = SMODS.get_select_text(card, booster_obj) or localize('b_select')
+    if can_also_use then
+        base_attach.children.use = G.UIDEF.card_focus_button{
+            card = card, parent = base_attach, type = 'use',
+            func = 'can_use_consumeable', button = 'use_card', card_width = card_width,
+            SMODS_use_card = true
+        }
+        base_attach.children.select = G.UIDEF.card_focus_button{
+            card = card, parent = base_attach, type = 'custom',
+            func = 'can_select_from_booster', button = 'use_card', card_width = card_width,
+            label = select_button_text, align = 'cl', minw = 1.1, 
+            focus_button = 'leftshoulder', focus_button_orientation = 'tli',
+            focus_button_x_offset = 0.1, align_left = true, 
+        }
+    else
+        base_attach.children.use = G.UIDEF.card_focus_button{
+            card = card, parent = base_attach, type = 'select',
+            func = 'can_select_from_booster', button = 'use_card', card_width = card_width,
+        }
+    end
+elseif ((card.area == G.consumeables and G.consumeables) or (card.area == G.pack_cards and G.pack_cards)) and
+'''
+
 # Remove select button
 [[patches]]
 [patches.pattern]

--- a/lovely/booster.toml
+++ b/lovely/booster.toml
@@ -278,16 +278,77 @@ if card.ability.consumeable then
     if (card.area == G.pack_cards and G.pack_cards) then
 '''
 payload = '''
-if card.ability.consumeable and card.area == G.pack_cards and G.pack_cards and booster_obj and SMODS.card_select_area(card, booster_obj) and card:selectable_from_pack(booster_obj) then
-    if (card.area == G.pack_cards and G.pack_cards) then
+if card.ability.consumeable and card.area == G.pack_cards and G.pack_cards and booster_obj then
+    local select_area, can_also_use = card:selectable_from_pack(booster_obj)
+    if (card.area == G.pack_cards and G.pack_cards) and select_area then
         local select_button_text = SMODS.get_select_text(card, booster_obj) or localize('b_select')
-        return {n=G.UIT.ROOT, config = {padding = 0, colour = G.C.CLEAR}, nodes={
-                {n=G.UIT.R, config={ref_table = card, r = 0.08, padding = 0.1, align = "bm", minw = 0.5*card.T.w - 0.15, maxw = 0.9*card.T.w - 0.15, minh = 0.3*card.T.h, hover = true, shadow = true, colour = G.C.UI.BACKGROUND_INACTIVE, one_press = true, button = 'use_card', func = 'can_select_from_booster'}, nodes={
-                {n=G.UIT.T, config={text = select_button_text, colour = G.C.UI.TEXT_LIGHT, scale = 0.45, shadow = true}}
+        if can_also_use then
+            card.children.select_button = UIBox{
+                definition = {n=G.UIT.ROOT, config = {padding = 0, colour = G.C.CLEAR}, nodes={
+                    {n=G.UIT.R, config = {padding = 0, align = "cl"}, nodes={
+                        {n=G.UIT.R, config={ref_table = card, r = 0.08, padding = 0.1, align = "cl", minw = 0.8*card.T.w, minh = 0.4 * card.T.h, maxh = 0.6 * card.T.h, hover = true, shadow = true, colour = G.C.UI.BACKGROUND_INACTIVE, one_press = true, button = 'use_card', func = 'can_select_from_booster'}, nodes={
+                            {n=G.UIT.T, config={text = select_button_text, colour = G.C.UI.TEXT_LIGHT, scale = 0.45, shadow = true}}
+                        }},
+                    }}
                 }},
-            }}
+                config = {align = "cl", offset = { x=(card.ability.consumeable and 0.1 or 0) + 0.4, y=0}, parent = card}
+            }
+            return {n=G.UIT.ROOT, config = {padding = 0, colour = G.C.CLEAR}, nodes={
+                    {n=G.UIT.R, config = {padding = 0, align = "bm"}, nodes={
+                        {n=G.UIT.R, config={ref_table = card, r = 0.08, padding = 0.1, align = "bm", minw = 0.5*card.T.w - 0.15, minh = 0.45*card.T.h, maxw = 0.7*card.T.w - 0.15, hover = true, shadow = true, colour = G.C.UI.BACKGROUND_INACTIVE, one_press = true, button = 'use_card', func = 'can_use_consumeable', SMODS_use_card = true}, nodes={
+                            {n=G.UIT.T, config={text = localize('b_use'),colour = G.C.UI.TEXT_LIGHT, scale = 0.55, shadow = true}}
+                        }},
+                    }},
+                }}
+        else
+            return {n=G.UIT.ROOT, config = {padding = 0, colour = G.C.CLEAR}, nodes={
+                    {n=G.UIT.R, config={ref_table = card, r = 0.08, padding = 0.1, align = "bm", minw = 0.5*card.T.w - 0.15, maxw = 0.9*card.T.w - 0.15, minh = 0.3*card.T.h, hover = true, shadow = true, colour = G.C.UI.BACKGROUND_INACTIVE, one_press = true, button = 'use_card', func = 'can_select_from_booster'}, nodes={
+                    {n=G.UIT.T, config={text = select_button_text, colour = G.C.UI.TEXT_LIGHT, scale = 0.45, shadow = true}}
+                    }},
+                }}
+        end
     end
 end
+'''
+
+# Remove select button
+[[patches]]
+[patches.pattern]
+target = 'card.lua'
+match_indent = true
+position = 'after'
+pattern = '''
+if self.children.use_button then self.children.use_button:remove(); self.children.use_button = nil end
+'''
+payload = '''
+if self.children.select_button then self.children.select_button:remove(); self.children.select_button = nil end
+'''
+
+[[patches]]
+[patches.pattern]
+target = 'card.lua'
+match_indent = true
+position = 'after'
+pattern = '''
+elseif self.children.use_button then
+    self.children.use_button:remove()
+    self.children.use_button = nil
+end
+'''
+payload = '''
+if self.children.select_button and not (self.highlighted and self.area and self.area.config.type ~= 'shop') then self.children.select_button:remove(); self.children.select_button = nil end
+'''
+
+[[patches]]
+[patches.pattern]
+target = 'functions/button_callbacks.lua'
+match_indent = true
+position = 'after'
+pattern = '''
+if card.children.use_button then card.children.use_button:remove(); card.children.use_button = nil end
+'''
+payload = '''
+if card.children.select_button then card.children.select_button:remove(); card.children.select_button = nil end
 '''
 
 # G.FUNCS.use_card()
@@ -370,7 +431,7 @@ pattern = '''if self.shop_voucher then G.GAME.current_round.voucher = nil end'''
 payload = '''G.STATE = G.STATES.SMODS_REDEEM_VOUCHER'''
 
 # G.FUNCS.use_card()
-# Consumables in areas other than the consumable don't count 
+# Consumables in areas other than the consumable don't count
 # as picking an item in boosters when used
 [[patches]]
 [patches.pattern]

--- a/lovely/center.toml
+++ b/lovely/center.toml
@@ -512,7 +512,7 @@ if G.booster_pack and not G.booster_pack.alignment.offset.py and (card.ability.c
 '''
 payload = '''
 local nc
-local select_to = card.area == G.pack_cards and G.pack_cards and booster_obj and SMODS.card_select_area(card, booster_obj) and card:selectable_from_pack(booster_obj)
+local select_to = not e.config.SMODS_use_card and card.area == G.pack_cards and G.pack_cards and booster_obj and SMODS.card_select_area(card, booster_obj) and card:selectable_from_pack(booster_obj)
 if card.ability.consumeable and not select_to then
     local obj = card.config.center
     if obj.keep_on_use and type(obj.keep_on_use) == 'function' then

--- a/lovely/controller.toml
+++ b/lovely/controller.toml
@@ -1,0 +1,69 @@
+[manifest]
+version = "1.0.0"
+dump_lua = true
+priority = -10
+
+# G.UIDEF.card_focus_button
+# Add additional controller button options
+[[patches]]
+[patches.pattern]
+target = 'functions/UI_definitions.lua'
+match_indent = true
+position = 'before'
+pattern = '''
+elseif args.type == 'buy_and_use' then
+'''
+payload = '''
+elseif args.type == 'custom' then
+    button_contents = args.button_contents or {n=G.UIT.T, config={text = args.label or localize('b_use'), colour = args.text_colour or G.C.WHITE, scale = args.scale or 0.5, shadow = args.shadow}}
+'''
+
+[[patches]]
+[patches.pattern]
+target = 'functions/UI_definitions.lua'
+match_indent = true
+position = 'at'
+pattern = '''
+{n=G.UIT.R, config={id = args.type == 'buy_and_use' and 'buy_and_use' or nil, ref_table = args.card, ref_parent = args.parent, align =  args.type == 'sell' and 'cl' or 'cr', colour = G.C.BLACK, shadow = true, r = 0.08, func = args.func, one_press = true, button = args.button, focus_args = {type = 'none'}, hover = true}, nodes={
+          {n=G.UIT.R, config={align = args.type == 'sell' and 'cl' or 'cr', minw = 1 + (args.type == 'select' and 0.1 or 0), minh = args.type == 'sell' and 1.5 or 1, padding = 0.08,
+              focus_args = {button = args.type == 'sell' and 'leftshoulder' or args.type == 'buy_and_use' and 'leftshoulder' or 'rightshoulder', scale = 0.55, orientation = args.type == 'sell' and 'tli' or 'tri', offset = {x = args.type == 'sell' and 0.1 or -0.1, y = 0}, type = 'none'},
+'''
+payload = '''
+{n=G.UIT.R, config={id = args.id or args.type == 'buy_and_use' and 'buy_and_use' or nil, ref_table = args.card, ref_parent = args.parent, align = args.align or args.type == 'sell' and 'cl' or 'cr', colour = args.colour or G.C.BLACK, shadow = true, r = 0.08, func = args.func, one_press = true, button = args.button, SMODS_use_card = args.SMODS_use_card, focus_args = {type = 'none'}, hover = true}, nodes={
+          {n=G.UIT.R, config={align = args.align or args.type == 'sell' and 'cl' or 'cr', minw = args.minw or (1 + (args.type == 'select' and 0.1 or 0)), minh = args.minh or (args.type == 'sell' and 1.5 or 1), padding = 0.08,
+              focus_args = {button = args.focus_button or args.type == 'sell' and 'leftshoulder' or args.type == 'buy_and_use' and 'leftshoulder' or 'rightshoulder', scale = 0.55, orientation = args.focus_button_orientation or args.type == 'sell' and 'tli' or 'tri', offset = {x = args.focus_button_x_offset or args.type == 'sell' and 0.1 or -0.1, y = 0}, type = 'none'},
+'''
+
+[[patches]]
+[patches.pattern]
+target = 'functions/UI_definitions.lua'
+match_indent = true
+position = 'at'
+pattern = '''
+args.type ~= 'sell' and {n=G.UIT.C, config={align = "cm",minw = 0.2, minh = 0.6}, nodes={}} or nil,
+{n=G.UIT.C, config={align = "cm", maxw = 1}, nodes={
+button_contents
+}},
+args.type == 'sell' and {n=G.UIT.C, config={align = "cm",minw = 0.2, minh = 0.6}, nodes={}} or nil,
+'''
+payload = '''
+not args.align_left and args.type ~= 'sell' and {n=G.UIT.C, config={align = "cm",minw = 0.2, minh = 0.6}, nodes={}} or nil,
+{n=G.UIT.C, config={align = "cm", maxw = 1}, nodes={
+button_contents
+}},
+(args.align_left or args.type == 'sell') and {n=G.UIT.C, config={align = "cm",minw = 0.2, minh = 0.6}, nodes={}} or nil,
+'''
+
+[[patches]]
+[patches.pattern]
+target = 'functions/UI_definitions.lua'
+match_indent = true
+position = 'at'
+pattern = '''
+align = args.type == 'sell' and 'cl' or 'cr',
+        offset = {x=(args.type == 'sell' and -1 or 1)*((args.card_width or 0) - 0.17 - args.card.T.w/2),y=args.type == 'buy_and_use' and 0.6 or (args.buy_and_use) and -0.6 or 0}, 
+'''
+payload = '''
+align = args.align or args.type == 'sell' and 'cl' or 'cr',
+        offset = {x=args.x_offset or (((args.align_left or args.type == 'sell') and -1 or 1)*((args.card_width or 0) - 0.17 - args.card.T.w/2)),y=args.y_offset or (args.type == 'buy_and_use' and 0.6 or (args.buy_and_use) and -0.6 or 0)}, 
+'''

--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -544,14 +544,16 @@ function SMODS.debug_calculation() end
 
 ---@param card Card|table
 ---@param pack SMODS.Booster|table
----@return boolean|string
+---@return boolean|string, boolean?
 --- Controls if the card should be selectable from a Booster Pack.
+--- Additionally returns `true` as a second value if it can also be used.
 function Card.selectable_from_pack(card, pack) end
 
 ---@param card Card|table
 ---@param pack SMODS.Booster|table
----@return string|{[string]: string}
+---@return string|{[string]: string}, boolean?
 --- Controls the area a card should be after selection from a Booster Pack.
+--- Additionally returns `true` as a second value if it can also be used.
 function SMODS.card_select_area(card, pack) end
 
 ---@param pool (string|"UNAVAILABLE")[]

--- a/src/card_draw.lua
+++ b/src/card_draw.lua
@@ -184,6 +184,7 @@ SMODS.DrawStep {
             end
         end
         if self.children.use_button and self.highlighted then self.children.use_button:draw() end
+        if self.children.select_button and self.highlighted then self.children.select_button:draw() end
     end,
 } 
 

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2488,12 +2488,12 @@ function Card.selectable_from_pack(card, pack)
             if key == card.config.center_key then return false end
         end
     end
-    local select_area = SMODS.card_select_area(card, pack)
+    local select_area, can_also_use = SMODS.card_select_area(card, pack)
     if select_area then
         if type(select_area) == 'table' then
             if select_area[card.ability.set] then return select_area[card.ability.set] else return false end
         end
-        return select_area
+        return select_area, can_also_use
     end
 end
 
@@ -3523,27 +3523,27 @@ function UIElement:draw_pixellated_strikethough(_type, _parallax, _emboss, _prog
 end
 
 function SMODS.card_select_area(card, pack)
-    local select_area
+    local select_area, can_also_use
     if card.config.center.select_card then
         if type(card.config.center.select_card) == "function" then -- Card's value takes first priority
-            select_area = card.config.center:select_card(card, pack)
+            select_area, can_also_use = card.config.center:select_card(card, pack)
         else
             select_area = card.config.center.select_card
         end
     elseif SMODS.ConsumableTypes[card.ability.set] and SMODS.ConsumableTypes[card.ability.set].select_card then -- ConsumableType is second priority
         if type(SMODS.ConsumableTypes[card.ability.set].select_card) == "function" then
-            select_area = SMODS.ConsumableTypes[card.ability.set]:select_card(card, pack)
+            select_area, can_also_use = SMODS.ConsumableTypes[card.ability.set]:select_card(card, pack)
         else
             select_area = SMODS.ConsumableTypes[card.ability.set].select_card
         end
     elseif pack.select_card then -- Pack is third priority
         if type(pack.select_card) == "function" then
-            select_area = pack:select_card(card, pack)
+            select_area, can_also_use = pack:select_card(card, pack)
         else
             select_area = pack.select_card
         end
     end
-    return select_area
+    return select_area, can_also_use
 end
 
 function SMODS.get_select_text(card, pack)


### PR DESCRIPTION
If `select_card` (as a function) returns `true` as the second return value (in the card, consumabletype or booster) then it adds an extra button to the card when highlighted in a booster which gives the player the option to either select or use the card.

<img width="255" height="262" alt="image" src="https://github.com/user-attachments/assets/39c80aef-0ccf-453e-8a23-c71ef9f36081" />

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
