### PR TITLE
Set greater than to greater than or equals in last_hand_oneshot to reflect vanilla behavior 

### DIFF
--- a/lovely/scoring_calculation.toml
+++ b/lovely/scoring_calculation.toml
@@ -208,7 +208,7 @@ pattern = '''
 delay(0.3)
 '''
 payload = '''
-    SMODS.last_hand_oneshot = SMODS.calculate_round_score() > G.GAME.blind.chips
+    SMODS.last_hand_oneshot = SMODS.calculate_round_score() >= G.GAME.blind.chips
     SMODS.last_hand_score = SMODS.calculate_round_score()
     G.E_MANAGER:add_event(Event({
       trigger = 'immediate',


### PR DESCRIPTION
For this issue:
https://github.com/Steamodded/smods/issues/1414

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [X] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [X] I didn't modify api's or I've updated lsp definitions.
- [X] I didn't make new lovely files or all new lovely files have appropriate priority.
