### PR TITLE
Made it so stickers with animated atlii animate

### DIFF
--- a/src/ui.lua
+++ b/src/ui.lua
@@ -453,6 +453,13 @@ function Game:update(dt)
 	else
 		SMODS.wheel_velocity.y = 0
 	end
+	if G.shared_stickers then
+        for k,v in pairs(G.shared_stickers) do
+            if v and v:is(AnimatedSprite) then
+                v:animate()
+            end
+        end
+    end
     gameUpdateRef(self, dt)
 end
 


### PR DESCRIPTION
Thanks to @ThunderEdge73, who showed me how to animate my stickers, I wondered why Thunk did not bother checking for animated atlii in stickers, so now it does go through G.shared_stickers, check if the atlas is animated (via `:is(AnimatedSprite)`) and animates it
## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [X] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [X] I didn't modify api's or I've updated lsp definitions.
- [X] I didn't make new lovely files or all new lovely files have appropriate priority.
