### PR TITLE
Fix for cards with negative `card_limit` drawing ghost cards

### DIFF
--- a/lovely/better_calc.toml
+++ b/lovely/better_calc.toml
@@ -1197,12 +1197,12 @@ pattern = '''
 draw_card(G.deck,G.hand, i*100/hand_space,'up', true)
 '''
 payload = '''
-if cards_to_draw[i] and cards_to_draw[i].ability and cards_to_draw[i].ability.extra_slots_used then
-    SMODS.cards_to_draw = SMODS.cards_to_draw + cards_to_draw[i].ability.extra_slots_used
+if cards_to_draw[i] and cards_to_draw[i].ability and (cards_to_draw[i].ability.extra_slots_used or cards_to_draw[i].ability.card_limit) then
+    SMODS.cards_to_draw = SMODS.cards_to_draw + (cards_to_draw[i].ability.extra_slots_used or 0) - (cards_to_draw[i].ability.card_limit or 0)
     G.E_MANAGER:add_event(Event({
         trigger = 'immediate',
         func = function()                
-            SMODS.cards_to_draw = SMODS.cards_to_draw - cards_to_draw[i].ability.extra_slots_used
+            SMODS.cards_to_draw = SMODS.cards_to_draw - (cards_to_draw[i].ability.extra_slots_used or 0) + (cards_to_draw[i].ability.card_limit or 0)
             return true
         end
     }))


### PR DESCRIPTION
Given the following enhancement:
```lua
SMODS.Enhancement {
	key = "test",
	config = {
		card_limit = -1
	}
}
```
When two cards - a card with the above enhancement, and a card without that above enhancement - are drawn, a third "ghost card" may also be drawn.

https://github.com/user-attachments/assets/75fb4416-3748-4e78-8e6b-4336f14420f4

This PR fixes that issue by simply accounting for `cards_to_draw[i].ability.card_limit` when calculating `SMODS.cards_to_draw`.

https://github.com/user-attachments/assets/a659ff11-7485-4821-95f0-13d8146e721a

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [X] I didn't make new lovely files or all new lovely files have appropriate priority.