### PR TITLE
more stake order fixes

### DIFF
--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -724,6 +724,17 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
             -- should only need to do this once per injection routine
         end,
         post_inject_class = function(self)
+            -- more sorting, to account for vanilla stakes going above modded stakes
+            for i, v in ipairs(G.P_CENTER_POOLS[self.set]) do
+                if v.above_stake and G.P_STAKES[v.above_stake] then
+                    v.order = G.P_STAKES[v.above_stake].order + 1
+                    end
+                for ii, vv in ipairs(G.P_CENTER_POOLS[self.set]) do
+                    if vv.key ~= v.key and vv.order >= v.order then
+                        vv.order = vv.order + 1
+                    end
+                end
+            end
             table.sort(G.P_CENTER_POOLS[self.set], function(a, b) return a.order < b.order end)
             for i,v in ipairs(G.P_CENTER_POOLS[self.set]) do
                 G.P_STAKES[v.key].order = i


### PR DESCRIPTION
Minor tweak to the stake injection process, so that modders can take ownership of a vanilla stake and properly force it to be above a modded stake (if that is attempted on the latest smods release, the vanilla stake is injected before the modded stake can be injected, and it therefore never properly sets its order because the modded stake's order isn't known yet)

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [X] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [X] I didn't modify api's or I've updated lsp definitions.
- [X] I didn't make new lovely files or all new lovely files have appropriate priority.
