### PR TITLE
add SMODS.get_virtual_suits

### DIFF
--- a/lovely/playing_card.toml
+++ b/lovely/playing_card.toml
@@ -134,7 +134,7 @@ local suits = {
   }
 '''
 position = 'at'
-payload = 'local suits = SMODS.Suit.obj_buffer'
+payload = 'local suits = SMODS.get_virtual_suits()'
 match_indent = true
 
 [[patches]]

--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -889,3 +889,8 @@ function SMODS.copy_card(card, args) end
 ---@param args {set: string?, area: CardArea|table?, playing_card: integer?}?
 ---@return Card|table
 function SMODS.add_to_deck(card, args) end
+
+---Returns a copy of SMODS.Suit.obj_buffer
+---Hook this function and edit the return if you want the game to see suits that don't exist, or not see suits that do exist
+---@return string[]
+function SMODS.get_virtual_suits() end

--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -892,5 +892,6 @@ function SMODS.add_to_deck(card, args) end
 
 ---Returns a copy of SMODS.Suit.obj_buffer
 ---Hook this function and edit the return if you want the game to see suits that don't exist, or not see suits that do exist
+---Intended for calculation purposes; to get suits that can actually appear on cards you still want the obj_buffer
 ---@return string[]
 function SMODS.get_virtual_suits() end

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2650,8 +2650,9 @@ end
 
 function SMODS.seeing_double_check(hand, suit)
     local suit_tally = {}
-    for i = #SMODS.Suit.obj_buffer, 1, -1 do
-        suit_tally[SMODS.Suit.obj_buffer[i]] = 0
+    local suitlist = SMODS.get_virtual_suits()
+    for i = #suitlist, 1, -1 do
+        suit_tally[suitlist[i]] = 0
     end
     for i = 1, #hand do
         if not SMODS.has_any_suit(hand[i]) then
@@ -2669,6 +2670,14 @@ function SMODS.seeing_double_check(hand, suit)
         end
     end
     if saw_double(suit_tally, suit) then return true else return false end
+end
+
+function SMODS.get_virtual_suits()
+    local ret = {}
+    for i,v in ipairs(SMODS.Suit.obj_buffer) do
+        ret[i] = v
+    end
+    return ret
 end
 
 local function parse_tooltip_vars(str, separator)


### PR DESCRIPTION
Helper function that returns a copy of `SMODS.Suit.obj_buffer` so it can be hooked and modified (e.g. to make all cards of a specified rank count as an extra suit that otherwise doesn't exist, or to give a Blind an effect like "Hearts no longer count as a suit")

I'm still on the fence about one bit of functionality, though: should this have a parameter to indicate when the "real" suit list is desired, or should the function just not be used in those instances?

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
