### PR TITLE
fix vanilla center/all tag attributes, remove blind attributes

### DIFF
--- a/src/game_objects/attributes.lua
+++ b/src/game_objects/attributes.lua
@@ -49,7 +49,9 @@ function SMODS.populate_attributes()
             if G.P_CENTERS[key] then
                 G.P_CENTERS[key].attributes = G.P_CENTERS[key].attributes or {}
                 G.P_CENTERS[key].attributes[attribute.key] = true
-            end
+            elseif G.P_TAGS[key] then
+                G.P_TAGS[key].attributes = G.P_TAGS[key].attributes or {}
+                G.P_TAGS[key].attributes[attribute.key] = true
         end
     end
 
@@ -81,7 +83,7 @@ function Blind:has_attribute(attribute)
 end
 
 function Tag:has_attribute(attribute)
-    return self.config.center:has_attribute(attribute)
+    return G.P_TAGS[self.key]:has_attribute(attribute)
 end
 
 SMODS.Attribute({

--- a/src/game_objects/attributes.lua
+++ b/src/game_objects/attributes.lua
@@ -78,10 +78,6 @@ function Card:has_attribute(attribute)
     return self.config.center:has_attribute(attribute)
 end
 
-function Blind:has_attribute(attribute)
-    return self.config.center:has_attribute(attribute)
-end
-
 function Tag:has_attribute(attribute)
     return G.P_TAGS[self.key]:has_attribute(attribute)
 end
@@ -212,8 +208,6 @@ SMODS.Attribute({
         'c_star', 'c_moon', 'c_sun', 'c_world', 'c_sigil',
 
         'm_wild',
-
-        'bl_club', 'bl_goad', 'bl_head', 'bl_window'
     }
 })
 
@@ -223,8 +217,6 @@ SMODS.Attribute({
         'j_greedy_joker', 'j_smeared', 'j_rough_gem',
 
         'c_star',
-
-        'bl_window'
     }
 })
 
@@ -234,8 +226,6 @@ SMODS.Attribute({
         'j_lusty_joker', 'j_smeared', 'j_bloodstone',
 
         'c_sun',
-
-        'bl_head'
     }
 })
 
@@ -245,8 +235,6 @@ SMODS.Attribute({
         'j_wrathful_joker', 'j_smeared', 'j_arrowhead', 'j_blackboard',
 
         'c_world',
-
-        'bl_goad'
     }
 })
 
@@ -256,8 +244,6 @@ SMODS.Attribute({
         'j_gluttenous_joker', 'j_smeared', 'j_onyx_agate', 'j_seeing_double', 'j_blackboard',
 
         'c_moon',
-
-        'bl_club'
     }
 })
 
@@ -275,8 +261,6 @@ SMODS.Attribute({
         'c_uranus', 'c_neptune', 'c_pluto', 'c_planet_x', 'c_ceres', 'c_eris',
 
         'v_telescope', 'v_observatory',
-
-        'bl_ox', 'bl_mouth', 'bl_eye'
     }
 })
 
@@ -417,8 +401,6 @@ SMODS.Attribute({
         'j_smiley', 'j_sock_and_buskin', 'j_caino',
 
         'c_familiar',
-
-        'bl_mark', 'bl_plant'
     }
 })
 
@@ -458,8 +440,6 @@ SMODS.Attribute({
 
         'tag_garbage',
 
-        'bl_hook', 'bl_water',
-
         'Purple' -- seal
     }
 })
@@ -488,8 +468,6 @@ SMODS.Attribute({
     key = 'lose_economy',
     keys = {
         'c_wraith',
-
-        'bl_ox', 'bl_tooth'
     }
 })
 
@@ -502,8 +480,6 @@ SMODS.Attribute({
         'c_wheel_of_fortune',
 
         'm_glass', 'm_lucky',
-
-        'bl_wheel'
     }
 })
 
@@ -612,8 +588,6 @@ SMODS.Attribute({
         'p_buffoon_normal_1', 'p_buffoon_normal_2', 'p_buffoon_jumbo_1', 'p_buffoon_mega_1',
 
         'tag_uncommon', 'tag_rare', 'tag_negative', 'tag_foil', 'tag_holo', 'tag_polychrome', 'tag_top_up',
-
-        'bl_final_heart'
     }
 })
 
@@ -667,8 +641,6 @@ SMODS.Attribute({
         'v_grabber', 'v_nacho_tong', 'v_hieroglyph',
 
         'tag_handy',
-        
-        'bl_needle'
     }
 })
 
@@ -754,8 +726,6 @@ SMODS.Attribute({
         'v_paint_brush', 'v_palette',
 
         'tag_juggle',
-
-        'bl_manacle'
     }
 })
 
@@ -790,8 +760,6 @@ SMODS.Attribute({
     key = 'on_sell',
     keys = {
         'j_luchador', 'j_diet_cola', 'j_invisible',
-
-        'bl_final_leaf'
     }
 })
 
@@ -815,17 +783,17 @@ SMODS.Attribute({
 
 SMODS.Attribute({
     key = 'debuff',
-    keys = { 'bl_club', 'bl_goad', 'bl_plant', 'bl_head', 'bl_final_leaf', 'bl_window', 'bl_pillar', 'bl_final_heart' }
+    keys = {}
 })
 
 SMODS.Attribute({
     key = 'face_down',
-    keys = { 'bl_fish', 'bl_house', 'bl_mark', 'bl_wheel', 'bl_final_acorn' }
+    keys = {}
 })
 
 SMODS.Attribute({
     key = 'large_blind',
-    keys = { 'bl_wall', 'bl_final_vessel' }
+    keys = {}
 })
 
 SMODS.Attribute({
@@ -869,8 +837,6 @@ SMODS.Attribute({
         'c_uranus', 'c_neptune', 'c_pluto', 'c_planet_x', 'c_ceres', 'c_eris',
 
         'tag_orbital',
-
-        'bl_arm'
     }
 })
 

--- a/src/game_objects/attributes.lua
+++ b/src/game_objects/attributes.lua
@@ -52,6 +52,12 @@ function SMODS.populate_attributes()
             end
         end
     end
+
+    for _, center in pairs(G.P_CENTERS) do
+        if not center.has_attribute then
+            center.has_attribute = SMODS.Center.has_attribute
+        end
+    end
 end
 
 function Card:has_attribute(attribute)

--- a/src/game_objects/attributes.lua
+++ b/src/game_objects/attributes.lua
@@ -53,9 +53,21 @@ function SMODS.populate_attributes()
         end
     end
 
-    for _, center in pairs(G.P_CENTERS) do
-        if not center.has_attribute then
-            center.has_attribute = SMODS.Center.has_attribute
+    for _, c_type in pairs {
+        "Joker",
+        "Consumeables",
+        "Voucher",
+        "Enhanced",
+        "Default",
+        "Edition",
+        "Booster",
+        "Seal",
+        "Tag"
+    } do
+        for _, center in pairs(G.P_CENTER_POOLS[c_type]) do
+            if not center.has_attribute then
+                center.has_attribute = SMODS.Center.has_attribute
+            end
         end
     end
 end


### PR DESCRIPTION
as per title, this adds the `has_attribute` function to all centers in `G.P_CENTERS` that don't already have it, allowing the function to work on those centers and therefore not crash when run on e.g. a vanilla joker
additionally, this adds attributes themselves + the has_attribute function to tags, finishing the half-baked implementation of them (the has_attribute function wouldn't work at all, and tags wouldn't even receive any attributes). it's debatable whether tags should even have attributes, given that they're not technically centers, but they are in G.P_CENTER_POOLS.
that said, this also removes the similarly half-baked implementation of blind attributes, for similar reasons as tag attributes with the additional issues of blinds not even being in G.P_CENTER_POOLS and the fact that it was crashing in the options menu whenever i tried adding the has_attribute function to them.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [X] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [X] I didn't modify api's or I've updated lsp definitions.
- [X] I didn't make new lovely files or all new lovely files have appropriate priority.
