### PR TITLE
one more stake order fix

### DIFF
--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -711,20 +711,22 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
                     G.sticker_map[self.key] = nil
                 end
             end
-            -- Sorts stake into the correct spot
-            if self.above_stake and G.P_STAKES[self.above_stake] then
-                self.order = G.P_STAKES[self.above_stake].order + 1
-            end
-            for i, v in pairs(G.P_STAKES) do
-                if i ~= self.key and v.order >= self.order then
-                    v.order = v.order + 1
-                end
-            end
             self.injected = true
             -- should only need to do this once per injection routine
         end,
         post_inject_class = function(self)
-            table.sort(G.P_CENTER_POOLS[self.set], function(a, b) return a.order < b.order end)
+            -- sort stakes into the correct spot
+            local stakes_fixed = false
+            repeat
+                table.sort(G.P_CENTER_POOLS[self.set], function(a, b) return a.order < b.order end)
+                stakes_fixed = true
+                for i, v in ipairs(G.P_CENTER_POOLS[self.set]) do
+                    if v.above_stake and G.P_STAKES[v.above_stake] and v.order < G.P_STAKES[v.above_stake].order then
+                        v.order = G.P_STAKES[v.above_stake].order + 1
+                        stakes_fixed = false
+                    end
+                end
+            until stakes_fixed
             for i,v in ipairs(G.P_CENTER_POOLS[self.set]) do
                 G.P_STAKES[v.key].order = i
             end


### PR DESCRIPTION
I submitted an earlier PR that addressed this same issue, but further development on my own mod revealed that the fix was not totally satisfactory, and there was another case of stakes that could slip out of position during the sorting process. This fix moves _all_ the sorting to the `post_inject_class` function, as opposed to sorting each stake individually as it's injected. Vanilla sees no changes in stake order, and all of my use cases don't see any issues in intended stake order.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [X] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [X] I didn't modify api's or I've updated lsp definitions.
- [X] I didn't make new lovely files or all new lovely files have appropriate priority.
