### PR TITLE
Fix bosses_used compatibility on save load

### DIFF
--- a/lovely/blind.toml
+++ b/lovely/blind.toml
@@ -651,6 +651,21 @@ payload = '''
 SMODS.reset_blind_choices(self.GAME.round_resets.blind_choices)
 '''
 
+# Restore bosses_used compatibility on loaded saves.
+[[patches]]
+[patches.pattern]
+target = 'game.lua'
+match_indent = true
+position = 'after'
+pattern = '''
+self.GAME = saveTable and saveTable.GAME or self:init_game_object()
+'''
+payload = '''
+if saveTable and SMODS.normalize_bosses_used_table then
+    self.GAME.bosses_used = SMODS.normalize_bosses_used_table(self.GAME.bosses_used)
+end
+'''
+
 # Handle setting new blinds
 [[patches]]
 [patches.pattern]

--- a/src/game_objects/blind.lua
+++ b/src/game_objects/blind.lua
@@ -68,6 +68,38 @@ SMODS.Blinds.modifies_draw = {
     bl_serpent = true
 }
 
+function SMODS.normalize_bosses_used_table(bosses_used)
+    local normalized = { boss = {}, small = {}, big = {} }
+    local typed_keys = { boss = true, small = true, big = true }
+
+    if type(bosses_used) == 'table' then
+        for key, value in pairs(bosses_used) do
+            if typed_keys[key] and type(value) == 'table' then
+                for blind_key, count in pairs(value) do
+                    normalized[key][blind_key] = count
+                end
+            elseif not typed_keys[key] and type(value) ~= 'table' then
+                normalized.boss[key] = value
+            end
+        end
+    end
+
+    for key, blind in pairs(G.P_BLINDS or {}) do
+        if blind.boss and normalized.boss[key] == nil then normalized.boss[key] = 0 end
+        if blind.small and normalized.small[key] == nil then normalized.small[key] = 0 end
+        if blind.big and normalized.big[key] == nil then normalized.big[key] = 0 end
+    end
+
+    return setmetatable(normalized, {
+        __index = function(t, key)
+            return t.boss[key] or t.big[key] or t.small[key]
+        end,
+        __newindex = function(t, key, value)
+            rawset(t.boss, key, value)
+        end
+    })
+end
+
 function SMODS.add_boss_to_used_table(boss_key, type)
     if G.P_BLINDS[boss_key][type].allow_others then 
         G.GAME.bosses_used[type][boss_key] = G.GAME.bosses_used[type][boss_key] + 1


### PR DESCRIPTION

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's
- [x] I didn't modify api's
- [x] I didn't make new lovely files 

This restores compatibility for `G.GAME.bosses_used` after loading saves.

Custom Small/Big Blinds changed `bosses_used` from a flat table into a typed table:

```lua
  {
    boss = {},
    small = {},
    big = {},
  }
```
New runs get a metatable that preserves old flat-key access like:

  G.GAME.bosses_used["bl_wall"]

However, save serialization does not preserve metatables. After loading a save, old mods that access
G.GAME.bosses_used["bl_*"] receive nil, even when the value exists under G.GAME.bosses_used.boss.

This patch normalizes loaded bosses_used tables and restores the compatibility metatable after Game:start_run loads
save data. keeps the new typed structure while preserving the old flat access pattern used by existing mods built against
 vanilla Balatro / earlier SMODS behavior.