### PR TITLE
Only call Blind in_pool for matching blind types

### DIFF
--- a/src/utils/weights.lua
+++ b/src/utils/weights.lua
@@ -174,21 +174,22 @@ function SMODS.create_blind_pool(blind_type, skip_cull)
     end
 
     for k, v in pairs(G.P_BLINDS) do
-        local res, options = SMODS.add_to_pool(v)
-        options = options or {}
-        if not v[blind_type] then
-        elseif boss_already_chosen(k) then
-        elseif options.ignore_showdown_check then
-            eligible_bosses[k] = res and true or nil
-        elseif blind_type == 'boss' then
-            if
-                ((SMODS.is_showdown_ante()) == (v.boss.showdown or false)) and ((v[blind_type].min or G.GAME.round_resets.ante) <= math.max(1, G.GAME.round_resets.ante)) and ((v[blind_type].max or G.GAME.round_resets.ante) >= G.GAME.round_resets.ante)
-            then
+        if v[blind_type] then
+            local res, options = SMODS.add_to_pool(v)
+            options = options or {}
+            if boss_already_chosen(k) then
+            elseif options.ignore_showdown_check then
                 eligible_bosses[k] = res and true or nil
-            end
-        else
-            if (v[blind_type].min or G.GAME.round_resets.ante) <= math.max(1, G.GAME.round_resets.ante) and (v[blind_type].max or G.GAME.round_resets.ante) >= G.GAME.round_resets.ante then
-                eligible_bosses[k] = res and true or nil
+            elseif blind_type == 'boss' then
+                if
+                    ((SMODS.is_showdown_ante()) == (v.boss.showdown or false)) and ((v[blind_type].min or G.GAME.round_resets.ante) <= math.max(1, G.GAME.round_resets.ante)) and ((v[blind_type].max or G.GAME.round_resets.ante) >= G.GAME.round_resets.ante)
+                then
+                    eligible_bosses[k] = res and true or nil
+                end
+            else
+                if (v[blind_type].min or G.GAME.round_resets.ante) <= math.max(1, G.GAME.round_resets.ante) and (v[blind_type].max or G.GAME.round_resets.ante) >= G.GAME.round_resets.ante then
+                    eligible_bosses[k] = res and true or nil
+                end
             end
         end
     end


### PR DESCRIPTION

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.

When generating a small or big blind pool, boss-only blinds were still having their in_pool callbacks executed even
though they could never enter that pool. This can trigger side effects or crashes in mods whose boss blind in_pool
logic assumes it is being checked for the boss pool.

The return value from type-mismatched in_pool calls was already ignored by if not v[blind_type], so this should not
change valid pool membership. It only avoids calling in_pool for blinds that cannot be part of the requested pool.

This changes `SMODS.create_blind_pool` so `SMODS.add_to_pool(v)` is only called after confirming the blind supports
the requested `blind_type`.

Before:

```lua
  local res, options = SMODS.add_to_pool(v)
  if not v[blind_type] then
```
After:
```lua
  if v[blind_type] then
      local res, options = SMODS.add_to_pool(v)
```
The existing branch order is preserved:

* boss_already_chosen
* options.ignore_showdown_check
* blind_type == 'boss'
* small/big normal checks


