### PR TITLE
Added support for `badge_shader` field in `mod.json`.

### DIFF
--- a/src/preflight/loader.lua
+++ b/src/preflight/loader.lua
@@ -146,6 +146,7 @@ function loadMods(modsDirectory)
         priority = { type = 'number', default = 0 },
         badge_colour = { type = 'string', check = function(mod, s) local success, hex = pcall(sUtil.hex, s); mod.badge_colour = success and hex or sUtil.hex('666665FF') end },
         badge_text_colour = { type = 'string', check = function(mod, s) local success, hex = pcall(sUtil.hex, s); mod.badge_text_colour = success and hex or sUtil.hex('FFFFFFFF') end},
+        badge_shader = { type = 'string', },
         prefix = { type = 'string', required = true, check = function(mod, s) if string.find(s, '%$') then error("Disallowed use of reserved prefix "..s) end end },
         version = { type = 'string', check = function(mod, x) return x and sUtil.V(x):is_valid() and x or '0.0.0' end },
         dump_loc = { type = 'boolean' },

--- a/src/ui.lua
+++ b/src/ui.lua
@@ -3291,6 +3291,10 @@ function SMODS.create_blind_mod_badge()
     end
 end
 
+function SMODS.modbadge_shader_on_blind()
+    return true
+end
+
 G.FUNCS.HUD_blind_badge = function(e)
     if G.GAME.blind.in_blind then
         if G.GAME.blind.config.blind.mod then
@@ -3299,6 +3303,7 @@ G.FUNCS.HUD_blind_badge = function(e)
                 G.GAME.blind_badge.name = mod.display_name
                 e.UIBox:add_child(SMODS.create_blind_mod_badge(), e)
                 e.config.colour = mod.badge_colour or G.C.DYN_UI.MAIN
+                e.config.shader = SMODS.modbadge_shader_on_blind() and mod.badge_shader or nil
                 e.config.emboss = 0.05
                 e.states.visible = true
             end

--- a/src/ui.lua
+++ b/src/ui.lua
@@ -3291,10 +3291,6 @@ function SMODS.create_blind_mod_badge()
     end
 end
 
-function SMODS.modbadge_shader_on_blind()
-    return true
-end
-
 G.FUNCS.HUD_blind_badge = function(e)
     if G.GAME.blind.in_blind then
         if G.GAME.blind.config.blind.mod then
@@ -3303,7 +3299,7 @@ G.FUNCS.HUD_blind_badge = function(e)
                 G.GAME.blind_badge.name = mod.display_name
                 e.UIBox:add_child(SMODS.create_blind_mod_badge(), e)
                 e.config.colour = mod.badge_colour or G.C.DYN_UI.MAIN
-                e.config.shader = SMODS.modbadge_shader_on_blind() and mod.badge_shader or nil
+                e.config.shader = not G.GAME.blind.config.blind.no_shader_on_modbadge and mod.badge_shader or nil
                 e.config.emboss = 0.05
                 e.states.visible = true
             end

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -546,7 +546,7 @@ function SMODS.create_mod_badges(obj, badges)
                 end,
             })
             badges[#badges + 1] = {n=G.UIT.R, config={align = "cm"}, nodes={
-                {n=G.UIT.R, config={align = "cm", colour = mod.badge_colour or G.C.GREEN, r = 0.1, minw = 2, minh = 0.36, emboss = 0.05, padding = 0.03*size}, nodes={
+                {n=G.UIT.R, config={align = "cm", colour = mod.badge_colour or G.C.GREEN, shader = not obj.no_shader_on_modbadge and mod.badge_shader or nil, r = 0.1, minw = 2, minh = 0.36, emboss = 0.05, padding = 0.03*size}, nodes={
                   {n=G.UIT.B, config={h=0.1,w=0.03}},
                   {n=G.UIT.O, config={id = 'smods_mod_badge_text', object=badge_scroll}},
                   {n=G.UIT.B, config={h=0.1,w=0.03}},


### PR DESCRIPTION
+Title, this allows more easily having mod badge shaders. 

! If this is merged, #1423 should probably be looked at and fixed.



## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
