### PR TITLE
fix mods being loaded when disabled

### DIFF
--- a/src/preflight/loader.lua
+++ b/src/preflight/loader.lua
@@ -558,7 +558,7 @@ function loadMods(modsDirectory)
         if mod.can_load  ~= nil then return mod.can_load end
         seen = seen or {}
         local can_load = true
-        if seen[mod.id] then return true end
+        if seen[mod.id] ~= nil then return seen[mod.id] end
         seen[mod.id] = true
         local load_issues = {
             dependencies = {},
@@ -675,6 +675,7 @@ function loadMods(modsDirectory)
         end
         if not can_load then
             mod.load_issues = load_issues
+            seen[mod.id] = false
             return false
         end
         for _, x in ipairs(mod.dependencies or {}) do


### PR DESCRIPTION
there is a specific case where the mod loads when disabled, given the mods are loaded in this order:

CryptidMoreMarioJokers, Amulet (disabled), Cryptid

CryptidMoreMarioJokers requires Amulet, which is disabled, so `check_dependencies(Amulet)` returns false. it then requires Cryptid, which then requires Amulet, but this time `check_dependencies(Amulet)` returns true because it's already checked but can_load is not set yet. this causes Cryptid to make Amulet's `can_load` to true, then causing Amulet to load without patches, and Cryptid being able to load while it should be reporting missing Amulet dependencies

this PR just makes the unloadable mods stays unloadable after it is seen but without can_load being set yet

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
