### PR TITLE
(Run Select) update next page text if optional pages change

### DIFF
--- a/src/utils/run_select.lua
+++ b/src/utils/run_select.lua
@@ -250,7 +250,16 @@ G.FUNCS.run_select_can_change_page = function(e)
         end
     end
 
-    local final = SMODS.RunSelect.Internals.current_page == #SMODS.RunSelect.Internals.pages or SMODS.RunSelect.Functions.get_page_key(1) > #SMODS.RunSelect.Internals.pages
+    local next_page_index = SMODS.RunSelect.Functions.get_page_key(1)
+    local final = SMODS.RunSelect.Internals.current_page == #SMODS.RunSelect.Internals.pages or next_page_index > #SMODS.RunSelect.Internals.pages
+    local next_button_text = final and localize('run_select_play') or (localize('run_select_'..SMODS.RunSelect.Internals.pages[next_page_index]) .. ' >')
+
+    if next_button_text ~= SMODS.RunSelect.Internals.next_button_text then
+        SMODS.RunSelect.Internals.next_button_text = next_button_text
+        e.children[1].children[1].config.object:remove()
+        e.children[1].children[1].config.object = DynaText({string = {{ref_table = SMODS.RunSelect.Internals, ref_value = 'next_button_text'}}, colours = {G.C.WHITE}, shadow = true, maxw = 1.8, pop_in_rate = 0, scale = 0.4, silent = true})
+        e.children[1].children[1].config.object.ui_object_updated = true
+    end
 
     e.config.button = final and 'run_select_start_run' or 'run_select_change_page'
     e.config.colour =  final and SMODS.RunSelect.Colours.play or SMODS.RunSelect.Colours.nav_button


### PR DESCRIPTION
This is best explained with an example case:
I added a new RunSelectPage to my mod that allows the player to toggle stickers in the run. It came in between the stake select page and starting the run. However, I wanted a specific stake to skip the sticker page entirely (as it would force all stickers to be enabled). Without this PR, the text for the button that takes you to the next page (or starts the run) would not update properly, staying stuck on what it displayed upon first entering the page.
See attached video for a demonstration of the new behavior (watch the button switch from "Select Stickers >" to "Play"). Note that the button already functioned properly, it's merely a visual issue that this PR addresses.


https://github.com/user-attachments/assets/4f5f7a51-82f4-48c4-9b9a-7a0d784cf63c



## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [X] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [X] I didn't modify api's or I've updated lsp definitions.
- [X] I didn't make new lovely files or all new lovely files have appropriate priority.
