### PR TITLE
Fix crashes caused by code expecting the old `G.GAME.bosses_used` structure

### DIFF
--- a/lovely/blind.toml
+++ b/lovely/blind.toml
@@ -630,7 +630,7 @@ if v.big then bosses_used.big[k] = 0 end
 ## Custom Small/Big Blinds
 [[patches]]
 [patches.pattern]
-target = 'functions/common_events.lua'
+target = 'functions/button_callbacks.lua'
 pattern = '''G.GAME.round_resets.blind_choices.Boss = get_new_boss()'''
 position = 'at'
 match_indent = true

--- a/lovely/weights.toml
+++ b/lovely/weights.toml
@@ -3,24 +3,6 @@ version = "1.0.0"
 dump_lua = true
 priority = -10
 
-# Bypass get_new_boss()
-[[patches]]
-[patches.pattern]
-target = 'functions/common_events.lua'
-match_indent = true
-position = 'before'
-pattern = '''
-local eligible_bosses = {}
-'''
-payload = '''
--- Use SMODS object weight system when enabled
-if SMODS.optional_features.object_weights then
-    local ret_boss = SMODS.poll_object({type = 'Blind', seed = 'boss'})
-    G.GAME.bosses_used[ret_boss] = G.GAME.bosses_used[ret_boss] + 1
-    return ret_boss
-end
-'''
-
 # Bypass create_card_for_shop()
 [[patches]]
 [patches.pattern]


### PR DESCRIPTION
My attempt at fixing #1443, issues introduced by e318298 changing the structure of `G.GAME.bosses_used` to add `small`, `big`, and `boss` blind keys. Specifically:

- Removed an outdated patch
- Changed the target of a patch that was not being applied

There might still be more errant instances of `G.GAME.bosses_used` assumed to be the old structure, but this fixes the crashes I was encountering.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
