### PR TITLE
Fix: quick start tooltip now respects page order

### DIFF
--- a/src/game_objects/runselectpage.lua
+++ b/src/game_objects/runselectpage.lua
@@ -27,7 +27,7 @@ SMODS.RunSelectPage = SMODS.GameObject:extend({
         end
         if not self.injected then
             if self.quick_start_text then
-                table.insert(SMODS.RunSelect.Internals.quick_start_text_functions, self.quick_start_text)
+                table.insert(SMODS.RunSelect.Internals.quick_start_text_functions, self.page, self.quick_start_text)
             end
             table.insert(SMODS.RunSelect.Internals.pages, self.page, self.key)
             for i = self.page + 1, #SMODS.RunSelect.Internals.pages do


### PR DESCRIPTION
`SMODS.RunSelect`'s quick start text should respect page order, like Galdur used to do. However, it did not (BEFORE):
<img width="246" height="249" alt="before fix" src="https://github.com/user-attachments/assets/0148f903-3f0a-4589-b7a6-e9b55b84a7e2" />

By changing the insertion order of the quick start text functions to be the same as Galdur, the quick start text should respect page order again (AFTER):
<img width="224" height="244" alt="after fix" src="https://github.com/user-attachments/assets/c28a06bb-d241-4f52-aa5b-14a858abcd80" />

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [X] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [X] I didn't modify api's or I've updated lsp definitions.
- [X] I didn't make new lovely files or all new lovely files have appropriate priority.
