### PR TITLE
feat(nativefs): normalize file paths

### DIFF
--- a/libs/nativefs/nativefs.lua
+++ b/libs/nativefs/nativefs.lua
@@ -549,4 +549,18 @@ do
     end
 end
 
+function nativefs.getNormalizedPath(path)
+    if nativefs.getInfo(path) then return path end
+    path = path:gsub("\\","/"):gsub("/$","")
+    local parent_dir = nativefs.getNormalizedPath(path:gsub("/[^/]*$",""))
+    for _,v in pairs(nativefs.getDirectoryItems(parent_dir)) do
+        if (parent_dir.."/"..v):lower() == path:lower() then
+            return parent_dir.."/"..v
+        end
+    end
+    -- No valid path found. This will propagate out to return a partial match.
+    return path
+end
+
+
 return nativefs

--- a/lsp_def/lib/nativefs.lua
+++ b/lsp_def/lib/nativefs.lua
@@ -91,4 +91,10 @@ function nativefs.getDirectoryItemsInfo(path, filtertype) end
 ---@return table|{type: love.FileType, size: number, modtime: number} info
 function nativefs.getInfo(path, filtertype) end
 
+---@param path string
+---@return string
+--- Given a file path, looks for a valid file path that is equivalent to the input up to case. Does nothing on case insensitive filesystems.
+function nativefs.getNormalizedPath(path) end
+
+
 return nativefs

--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -496,7 +496,12 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
         process_loc_text = function() end,
         pre_inject_class = function(self)
             G:set_render_settings() -- restore originals first in case a texture pack was disabled
-        end
+        end,
+        post_inject_class = function(self)
+            for _, v in pairs(G.I.SPRITE) do
+                v:reset()
+            end
+        end,
     }
 
     SMODS.Atlas {

--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -465,14 +465,8 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
                 self.image_data = assert(love.image.newImageData(file_data),
                     ('Failed to initialize image data for Atlas %s'):format(self.key))
             else
-                self.full_path = NFS.getNormalizedPath(
-                    string.gsub(
-                        self.full_path,
-                        "assets/" .. G.SETTINGS.GRAPHICS.texture_scaling .. "x/",
-                        "assets/"..(3 - G.SETTINGS.GRAPHICS.texture_scaling) .. "x/",
-                        1
-                    )
-                )
+                self.full_path = NFS.getNormalizedPath((self.path_mod or self.mod or SMODS).path ..
+                    'assets/' .. (3 - G.SETTINGS.GRAPHICS.texture_scaling) .. 'x/' .. file_path)
                 file_data = assert(NFS.newFileData(self.full_path),
                     ('Failed to collect file data for Atlas %s'):format(self.key))
                 self.image_data = assert(love.image.newImageData(file_data),

--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -328,8 +328,8 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
             local file_path = self.path
             if file_path == 'DEFAULT' then return end
 
-            self.full_path = (self.path_mod or self.mod or SMODS).path ..
-                'assets/fonts/' .. file_path
+            self.full_path = NFS.getNormalizedPath((self.path_mod or self.mod or SMODS).path ..
+                'assets/fonts/' .. file_path)
             local file_data = assert(NFS.newFileData(self.full_path),
                 ('Failed to collect file data for Font %s'):format(self.key))
             self.FONT = assert(love.graphics.newFont(file_data, self.render_scale or G.TILESIZE),
@@ -458,14 +458,21 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
             -- language specific sprites override fully defined sprites only if that language is set
             if self.language and G.SETTINGS.language ~= self.language and G.SETTINGS.real_language ~= self.language then return end
             if not self.language and (self.obj_table[('%s_%s'):format(self.key, G.SETTINGS.language)] or self.obj_table[('%s_%s'):format(self.key, G.SETTINGS.real_language)]) then return end
-            self.full_path = (self.path_mod or self.mod or SMODS).path ..
-                'assets/' .. G.SETTINGS.GRAPHICS.texture_scaling .. 'x/' .. file_path
+            self.full_path = NFS.getNormalizedPath((self.path_mod or self.mod or SMODS).path ..
+                'assets/' .. G.SETTINGS.GRAPHICS.texture_scaling .. 'x/' .. file_path)
             local file_data = NFS.newFileData(self.full_path)
             if file_data then
                 self.image_data = assert(love.image.newImageData(file_data),
                     ('Failed to initialize image data for Atlas %s'):format(self.key))
             else
-                self.full_path = string.gsub(self.full_path, "assets/" .. G.SETTINGS.GRAPHICS.texture_scaling .. "x/", "assets/"..(3 - G.SETTINGS.GRAPHICS.texture_scaling) .. "x/", 1)
+                self.full_path = NFS.getNormalizedPath(
+                    string.gsub(
+                        self.full_path,
+                        "assets/" .. G.SETTINGS.GRAPHICS.texture_scaling .. "x/",
+                        "assets/"..(3 - G.SETTINGS.GRAPHICS.texture_scaling) .. "x/",
+                        1
+                    )
+                )
                 file_data = assert(NFS.newFileData(self.full_path),
                     ('Failed to collect file data for Atlas %s'):format(self.key))
                 self.image_data = assert(love.image.newImageData(file_data),
@@ -557,8 +564,8 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
                 ((G.SETTINGS.real_language and self.path[G.SETTINGS.real_language]) or self.path[G.SETTINGS.language] or self.path['default'] or self.path['en-us']) or self.path
             if file_path == 'DEFAULT' then return end
             local prev_path = self.full_path
-            self.full_path = (self.path_mod or self.mod or SMODS).path ..
-                'assets/sounds/' .. file_path
+            self.full_path = NFS.getNormalizedPath((self.path_mod or self.mod or SMODS).path ..
+                'assets/sounds/' .. file_path)
             if prev_path == self.full_path then return end
             self.data = NFS.read('data', self.full_path)
             --self.decoder = love.sound.newDecoder(self.data)
@@ -3395,8 +3402,8 @@ SMODS.UndiscoveredCompat = {
         set = 'Shader',
         send_vars = nil, -- function (sprite) - get custom externs to send to shader.
         inject = function(self)
-            self.full_path = (self.path_mod or self.mod or SMODS).path ..
-                'assets/shaders/' .. self.path
+            self.full_path = NFS.getNormalizedPath((self.path_mod or self.mod or SMODS).path ..
+                'assets/shaders/' .. self.path)
 
             local file = assert(NFS.read(self.full_path),
                 ('Failed to collect file data for Shader %s'):format(self.key))

--- a/src/preflight/loader.lua
+++ b/src/preflight/loader.lua
@@ -882,7 +882,7 @@ function SMODS.load_file(path, id)
     if not mod then
         error("Mod not found. Ensure you are passing the correct ID.")
     end
-    local file_path = mod.path .. path
+    local file_path = NFS.getNormalizedPath(mod.path .. path)
     local file_content, err = NFS.read(file_path)
     if not file_content then return  nil, "Error reading file '" .. path .. "' for mod with ID '" .. mod.id .. "': " .. err end
     local chunk, err = load(file_content, "=[SMODS " .. mod.id .. ' "' .. path .. '"]')

--- a/src/ui.lua
+++ b/src/ui.lua
@@ -1615,7 +1615,7 @@ function SMODS.load_mod_config(mod)
         return load(NFS.read(('config/%s.jkr'):format(mod.id)), ('=[SMODS %s "config"]'):format(mod.id))()
     end)
     local s2, default_config = pcall(function()
-        return load(NFS.read(mod.path..(mod.config_file or 'config.lua')), ('=[SMODS %s "default_config"]'):format(mod.id))()
+        return load(NFS.read(NFS.getNormalizedPath(mod.path..(mod.config_file or 'config.lua'))), ('=[SMODS %s "default_config"]'):format(mod.id))()
     end)
     if not s1 or type(config) ~= 'table' then config = {} end
     if not s2 or type(default_config) ~= 'table' then default_config = {} end

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -212,6 +212,7 @@ end
 
 local function handle_loc_file(dir, language, force, mod_id)
     for k, v in ipairs({ dir .. language .. '.lua', dir .. language .. '.json' }) do
+        v = NFS.getNormalizedPath(v)
         if NFS.getInfo(v) then
             parse_loc_file(v, force, mod_id)
             break


### PR DESCRIPTION
This tries to solve the issue of mod devs being inconsiderate of case sensitive filesystems existing. It does this using a function `nativefs.getNormalizedPath` that searches for a valid path that differs only by case and passing file paths provided by mods through it.

Also fixes a bug where existing sprites from a modified vanilla atlas revert to their unmodified state when atlases are reloaded.
## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
