### PR TITLE
More strict card area checks for To-Do List

### DIFF
--- a/lovely/fixes.toml
+++ b/lovely/fixes.toml
@@ -929,3 +929,24 @@ pattern = '''
 payload = '''
 (self.ability.consumeable or SMODS.UndiscoveredCompat[self.ability.set]) and
 '''
+
+# Make sure To-Do List poker hands queue does not advance if it appears in unexpected card areas
+[[patches]]
+[patches.pattern]
+target = 'card.lua'
+match_indent = true
+position = 'at'
+pattern = '''
+while not self.ability.to_do_poker_hand do
+    self.ability.to_do_poker_hand = pseudorandom_element(_poker_hands, pseudoseed((self.area and self.area.config.type == 'title') and 'false_to_do' or 'to_do'))
+    if self.ability.to_do_poker_hand == old_hand then self.ability.to_do_poker_hand = nil end
+end
+'''
+payload = '''
+local is_collection_area = self.area and (self.area.config.type == 'title' or self.area.config.type == 'title_2' or self.area.config.collection)
+
+while not self.ability.to_do_poker_hand do
+    self.ability.to_do_poker_hand = pseudorandom_element(_poker_hands, pseudoseed(is_collection_area and 'false_to_do' or 'to_do'))
+    if self.ability.to_do_poker_hand == old_hand then self.ability.to_do_poker_hand = nil end
+end
+'''

--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -2857,8 +2857,10 @@ function Card:quantum_set_ability(center)
         local old_hand = self.ability.to_do_poker_hand
         self.ability.to_do_poker_hand = nil
 
+        local is_collection_area = self.area and (self.area.config.type == 'title' or self.area.config.type == 'title_2' or self.area.config.collection)
+
         while not self.ability.to_do_poker_hand do
-            self.ability.to_do_poker_hand = pseudorandom_element(_poker_hands, pseudoseed((self.area and self.area.config.type == 'title') and 'false_to_do' or 'to_do'))
+            self.ability.to_do_poker_hand = pseudorandom_element(_poker_hands, pseudoseed(is_collection_area and 'false_to_do' or 'to_do'))
             if self.ability.to_do_poker_hand == old_hand then self.ability.to_do_poker_hand = nil end
         end
     end


### PR DESCRIPTION
This PR updates card area check for To-Do List to make sure it's poker hands pseudorandom queue does not advance in collection card areas.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
