### PR TITLE
Made it so the currently used consumable still gets calculated.

### DIFF
--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -2669,6 +2669,7 @@ end
 
 local use_consumeable = Card.use_consumeable
 function Card:use_consumeable(area, copier)
+	SMODS.currently_used_consumable = self
 	local ret = use_consumeable(self, area, copier)
 	if SMODS.post_prob and next(SMODS.post_prob) then
         local prob_tables = SMODS.post_prob
@@ -2678,6 +2679,7 @@ function Card:use_consumeable(area, copier)
             SMODS.calculate_context(v)
         end
     end
+	SMODS.currently_used_consumable = nil
 	return ret
 end
 

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2363,6 +2363,7 @@ function SMODS.get_card_areas(_type, _context)
     end
     if _type == 'jokers' then
         local t = {G.jokers, G.consumeables, G.vouchers}
+         if SMODS.currently_used_consumable and not SMODS.currently_used_consumable.area then table.insert(t, {cards = {SMODS.currently_used_consumable}}) end
         -- TARGET: add your own CardAreas for joker evaluation
         return t
     end

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -1836,6 +1836,20 @@ function SMODS.calculate_card_areas(_type, context, return_table, args)
                 end
                 ::skip::
             end
+            if area == G.consumeables and SMODS.currently_used_consumable and not SMODS.currently_used_consumable.area and not SMODS.check_looping_context(SMODS.currently_used_consumable) then
+                local eval, post = eval_card(SMODS.currently_used_consumable, context)
+                local effects = {eval}
+                for _,v in ipairs(post) do effects[#effects+1] = v end
+                if return_table then
+                    for _,v in ipairs(effects) do
+                        return_table[#return_table+1] = v
+                    end
+                else
+                    local f = SMODS.trigger_effects(effects, SMODS.currently_used_consumable)
+                    for k,v in pairs(f) do flags[k] = v end
+                    SMODS.update_context_flags(context, flags)
+                end
+            end
         end
     end
 
@@ -2363,7 +2377,6 @@ function SMODS.get_card_areas(_type, _context)
     end
     if _type == 'jokers' then
         local t = {G.jokers, G.consumeables, G.vouchers}
-         if SMODS.currently_used_consumable and not SMODS.currently_used_consumable.area then table.insert(t, {cards = {SMODS.currently_used_consumable}}) end
         -- TARGET: add your own CardAreas for joker evaluation
         return t
     end


### PR DESCRIPTION
*Title, `G.FUNCS.use_card()` calls `area:remove_card()` before `card:use_consumeable()`. With these changes, the currently used consumable will still be calculated for any contexts it causes. (E.g. `mod_probability`)


## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
