### PR TITLE
Use depthstencil for storing stencil buffer

### DIFF
--- a/lovely/ui_overflow.toml
+++ b/lovely/ui_overflow.toml
@@ -11,7 +11,7 @@ target = "game.lua"
 pattern = '''love.graphics.setCanvas{self.CANVAS}'''
 position = "at"
 payload = '''
-love.graphics.setCanvas{self.CANVAS, stencil = true}
+love.graphics.setCanvas{self.CANVAS, depthstencil = SMODS.stencil_canvas}
 '''
 match_indent = true
 

--- a/lsp_def/ui.lua
+++ b/lsp_def/ui.lua
@@ -131,8 +131,9 @@ function SMODS.pop_from_stencil_stack() end
 --- Cleanup stencil stack
 function SMODS.reset_stencil_stack() end
 
---- Reload stencil stack by cleaning up current stencil and redrawing all stencils from stack
-function SMODS.reload_stencil_stack() end
+--- Restore stencil buffer in current canvas
+--- @param full boolean Fully reload stencil stack by cleaning up current stencil and redrawing all stencils from stack
+function SMODS.reload_stencil_stack(full) end
 
 ---@param str string
 ---@return any

--- a/src/card_draw.lua
+++ b/src/card_draw.lua
@@ -399,7 +399,6 @@ SMODS.DrawStep {
                     )
                 end
                 love.graphics.pop()
-                SMODS.reload_stencil_stack()
                 sprite.role.draw_major = self
                 sprite:draw_shader('dissolve', nil, nil, nil, self.children.center)
             end

--- a/src/ui.lua
+++ b/src/ui.lua
@@ -3,6 +3,7 @@ SMODS.GUI.DynamicUIManager = {}
 
 -- used to properly truncate overflow content inside another overflow content
 SMODS.stencil_stack = {}
+SMODS.stencil_canvas = nil
 
 function SMODS.push_to_stencil_stack(stencil_fn)
     assert(type(stencil_fn) == "function", "No stencil function passed to SMODS.push_to_stencil_stack")
@@ -46,17 +47,29 @@ function SMODS.reset_stencil_stack()
     love.graphics.stencil(function() end)
 end
 function SMODS.reload_stencil_stack()
-    local stack_snapshot = SMODS.shallow_copy(SMODS.stencil_stack)
-    SMODS.reset_stencil_stack()
-    for _, stencil_fn in ipairs(stack_snapshot) do
-        SMODS.push_to_stencil_stack(stencil_fn)
-    end
+    love.graphics.setCanvas({ love.graphics.getCanvas(), depthstencil = SMODS.stencil_canvas })
 end
 
 local gameDrawRef = Game.draw
 function Game:draw(...)
     SMODS.reset_stencil_stack()
     gameDrawRef(self, ...)
+end
+
+local old_get_canvas = love.graphics.getCanvas
+function love.graphics.getCanvas(...)
+    local r = old_get_canvas(...)
+    if r.depthstencil then return r[1], r.depthstencil end
+    return r, nil
+end
+
+local old_resize = love.resize
+function love.resize(w, h, ...)
+    old_resize(w, h, ...)
+    SMODS.stencil_canvas = love.graphics.newCanvas(w, h, {
+        format = "stencil8",
+        readable = false,
+    })
 end
 
 --

--- a/src/ui.lua
+++ b/src/ui.lua
@@ -46,8 +46,15 @@ function SMODS.reset_stencil_stack()
     love.graphics.setStencilTest()
     love.graphics.stencil(function() end)
 end
-function SMODS.reload_stencil_stack()
+function SMODS.reload_stencil_stack(full)
     love.graphics.setCanvas({ love.graphics.getCanvas(), depthstencil = SMODS.stencil_canvas })
+    if full then
+        local stack_snapshot = SMODS.shallow_copy(SMODS.stencil_stack)
+        SMODS.reset_stencil_stack()
+        for _, stencil_fn in ipairs(stack_snapshot) do
+            SMODS.push_to_stencil_stack(stencil_fn)
+        end
+    end
 end
 
 local gameDrawRef = Game.draw

--- a/src/ui.lua
+++ b/src/ui.lua
@@ -59,8 +59,7 @@ end
 local old_get_canvas = love.graphics.getCanvas
 function love.graphics.getCanvas(...)
     local r = old_get_canvas(...)
-    if r.depthstencil then return r[1], r.depthstencil end
-    return r, nil
+    return r.depthstencil and r[1] or r
 end
 
 local old_resize = love.resize


### PR DESCRIPTION
This PR changes how stencil stored and operated.

Previously, `love.graphics.setCanvas({ canvas, stencil = true })` was used which created temporary stencil buffer for each canvas, so stencil buffer gets lost after every canvas change, and so manual `SMODS.reload_stencil_stack()` call was needed to restore it.

Now, new `SMODS.stencil_canvas` is created which stores stencil buffer data and can be reapplied to restore stencil in much more performant way `love.graphics.setCanvas({ canvas, depthstencil = SMODS.stencil_canvas })`. `SMODS.reload_stencil_stack()` was repurposed to do exactly that for backwards compatibility.

Additionally, added `full` argument (`SMODS.reload_stencil_stack(true)`) which fully redraws stencil as before.

Because `love.graphics.getCanvas()` have different output when depthstencil is used, it was hooked to return only canvas as before.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
