### PR TITLE
Minor `CardArea` unhighlight logic fix

### DIFF
--- a/lovely/cardarea.toml
+++ b/lovely/cardarea.toml
@@ -36,3 +36,18 @@ pattern = "if not card.states.drag.is then"
 position = "at"
 payload = "if not card.states.drag.is and not card.disable_align then"
 match_indent = true
+
+# Do not call remove_from_highlighted on an unhighlighted card
+[[patches]]
+[patches.pattern]
+target = 'cardarea.lua'
+match_indent = true
+position = 'at'
+pattern = '''
+self:remove_from_highlighted(card, true)
+'''
+payload = '''
+if card.highlighted then
+    self:remove_from_highlighted(card, true)
+end
+'''


### PR DESCRIPTION
Prevents the game from calling `CardArea.remove_from_highlighted` on a to-be-removed card regardless of its highlight state.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [X] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [X] I didn't modify api's or I've updated lsp definitions.
- [X] I didn't make new lovely files or all new lovely files have appropriate priority.
