### PR TITLE
Allow for arbitrary sets in ui

### DIFF
--- a/lovely/ui.toml
+++ b/lovely/ui.toml
@@ -382,6 +382,17 @@ match_indent = true
 
 [[patches]]
 [patches.pattern]
+target = 'functions/common_events.lua'
+pattern = """elseif _c.name == "The World" then loc_vars = {_c.config.max_highlighted, localize(_c.config.suit_conv, 'suits_plural'), colours = {G.C.SUITS[_c.config.suit_conv]}}
+end
+localize{type = 'descriptions', key = _c.key, set = _c.set, nodes = desc_nodes, vars = _c.vars or loc_vars}"""
+position = "after"
+payload = """    elseif _c.set then --Fallback for unrecognized sets
+        localize{type = 'descriptions', key = _c.key, set = _c.set, nodes = desc_nodes, vars = _c.vars or loc_vars}"""
+match_indent = false
+
+[[patches]]
+[patches.pattern]
 target = 'functions/UI_definitions.lua'
 pattern = '''
 function info_tip_from_rows(desc_nodes, name)


### PR DESCRIPTION
For info queues and stuff. If a set name is unrecognized, the fallback behavior is now to treat it as a description, instead of doing nothing.

N.B. I'm like 95% sure there's a more elegant way to do this than the one I went with (this patch is happening in between two other patches that affect the same area and I don't even know how the order is determined) but I wasn't able to figure it what it was.

Don't worry if this pr looks familiar. I have a normal amount of understanding of how git works.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
