### PR TITLE
fix vouchers being duplicated

### DIFF
--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2668,7 +2668,14 @@ function SMODS.get_next_vouchers(vouchers)
 
         -- Use SMODS object weight system when enabled
         if SMODS.optional_features.object_weights then
-            center = SMODS.poll_object({type = 'Voucher', seed = _pool_key})
+            center = SMODS.poll_object({type = 'Voucher', seed = _pool_key, filter = function(pool)
+                for _, v in ipairs(pool) do
+                    if vouchers.spawn[v.key] then
+                        v.key = 'UNAVAILABLE'
+                    end
+                end
+                return pool
+            end})
         else
             center = pseudorandom_element(_pool, pseudoseed(_pool_key))
             local it = 1


### PR DESCRIPTION
with object weights enabled, `SMODS.get_next_vouchers` did not account for vouchers that were already set to be spawned, meaning you could see the same voucher multiple times at once. this resolves this by filtering the pool to set any already to-be-spawned vouchers to `UNAVAILABLE`

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
