### PR TITLE
Feat: Debuffed contexts & UI

### DIFF
--- a/lovely/better_calc.toml
+++ b/lovely/better_calc.toml
@@ -34,7 +34,7 @@ match_indent = true
 payload = '''
 function eval_card(card, context)
     context = context or {}
-    if not card:can_calculate(context.ignore_debuff, context.remove_playing_cards or context.joker_type_destroyed) then
+    if not card:can_calculate(context.ignore_debuff, context.remove_playing_cards or context.joker_type_destroyed) and not context.debuffed_calculation then
         if card.ability.rental then
             local ret = {}
             ret[SMODS.Stickers.rental] = card:calculate_sticker(context, 'rental')
@@ -44,7 +44,7 @@ function eval_card(card, context)
     end
 	local vanilla_debuff_handling
     for _, key in ipairs(SMODS.custom_debuff_handling) do if card.config.center_key == key then vanilla_debuff_handling = true; break end end
-    if context.other_card and context.other_card.can_calculate and not context.other_card:can_calculate(context.ignore_other_debuff or context.ignore_debuff) and not vanilla_debuff_handling then return {}, {} end
+    if context.other_card and context.other_card.can_calculate and not context.other_card:can_calculate(context.ignore_other_debuff or context.ignore_debuff) and not vanilla_debuff_handling and not context.debuffed_calculation then return {}, {} end
     local ret = {}
 '''
 

--- a/lovely/ui.toml
+++ b/lovely/ui.toml
@@ -552,3 +552,22 @@ pattern = '''
 G.HUD_blind.alignment.offset.y = -10'''
 payload = '''
 ease_value(G.HUD.alignment.offset, 'y', 0 - G.HUD.alignment.offset.y)'''
+
+# this patch was made for when you still want to show card's abilities even when it is debuffed
+[[patches]]
+[patches.pattern]
+target = 'functions/common_events.lua'
+match_indent = true
+position = 'at'
+pattern = '''    elseif specific_vars and specific_vars.debuffed then'''
+payload = '''elseif specific_vars and specific_vars.debuffed and SMODS.should_use_debuffed_description({ vars = (specific_vars or _c.vars) })  then'''
+# this one too lol
+# rationale of these being at patches is because these are elseif clauses and there are not a lot of ways you can go about it
+[[patches]]
+[patches.pattern]
+target = 'card.lua'
+match_indent = true
+position = 'at'
+pattern = '''    elseif self.debuff then'''
+payload = '''elseif self.debuff and SMODS.should_use_debuffed_description({ card = self }) then
+'''

--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -31,8 +31,11 @@
 ---@field before? true Check if `true` for effects that happen before hand scoring.
 ---@field after? true Check if `true` for effects that happen after hand scoring.
 ---@field main_scoring? true Check if `true` for effects that happen during scoring.
+---@field debuffed_main_scoring? true Check if `true` for effects that happen during "scoring" of debuffed cards.
 ---@field individual? true Check if `true` for effects on individual playing cards during scoring.
+---@field debuffed_individual? true Check if `true` for effects on a debuffed individual playing cards during scoring.
 ---@field repetition? true Check if `true` for adding repetitions to playing cards.
+---@field debuffed_repetition? true Check if `true` for adding repetitions to debuffed playing cards.
 ---@field edition? true `true` for any Edition-specific context (e.x. context.pre_joker and context.post_joker).
 ---@field pre_joker? true Check if `true` for triggering editions on jokers before they score.
 ---@field post_joker? true Check if `true` for triggering editions on jokers after they score.

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -2227,11 +2227,21 @@ function SMODS.score_card(card, context)
             percent = percent + percent_delta
         end
 
-        context.main_scoring = true
+        
+        if context.debuffed_calculation then
+            context.debuffed_main_scoring = true
+        else
+            context.main_scoring = true
+        end
         local effects = { eval_card(card, context) }
         SMODS.calculate_quantum_enhancements(card, effects, context)
         context.main_scoring = nil
-        context.individual = true
+        context.debuffed_main_scoring = nil
+        if context.debuffed_calculation then
+            context.debuffed_individual = true
+        else
+            context.individual = true
+        end
         context.other_card = card
 
         if next(effects) then
@@ -2242,11 +2252,18 @@ function SMODS.score_card(card, context)
         local flags = SMODS.trigger_effects(effects, card)
 
         context.individual = nil
+        context.debuffed_individual = nil
+
         if reps[j] == 1 and flags.calculated then
-            context.repetition = true
+            if context.debuffed_calculation then
+                context.debuffed_repetition = true
+            else
+                context.repetition = true
+            end
             context.card_effects = effects
             SMODS.calculate_repetitions(card, context, reps)
             context.repetition = nil
+            context.debuffed_repetition = nil
             context.card_effects = nil
         end
         j = j + (flags.calculated and 1 or #reps)
@@ -2276,6 +2293,12 @@ function SMODS.calculate_main_scoring(context, scoring_hand)
                 }))
                 card_eval_status_text(card, 'debuff')
             end
+            if scoring_hand then
+                if in_scoring then context.cardarea = G.play else context.cardarea = 'unscored' end
+            end
+            context.debuffed_calculation = true
+            SMODS.score_card(card, context)
+            context.debuffed_calculation = nil
         else
             if scoring_hand then
                 if in_scoring then context.cardarea = G.play else context.cardarea = 'unscored' end
@@ -2304,7 +2327,11 @@ function SMODS.calculate_end_of_round_effects(context)
             SMODS.calculate_quantum_enhancements(card, effects, context)
 
             context.playing_card_end_of_round = nil
-            context.individual = true
+            if context.debuffed_calculation then
+                context.debuffed_individual = true
+            else
+                context.individual = true
+            end
             context.other_card = card
             -- context.end_of_round individual calculations
 
@@ -2314,13 +2341,19 @@ function SMODS.calculate_end_of_round_effects(context)
             local flags = SMODS.trigger_effects(effects, card)
 
             context.individual = nil
-            context.repetition = true
+            context.debuffed_individual = nil
+            if context.debuffed_calculation then
+                context.debuffed_repetition = true
+            else
+                context.repetition = true
+            end
             context.card_effects = effects
             if reps[j] == 1 then
                 SMODS.calculate_repetitions(card, context, reps)
             end
 
             context.repetition = nil
+            context.debuffed_repetition = nil
             context.card_effects = nil
             context.other_card = nil
             j = j + (flags.calculated and 1 or #reps)
@@ -3271,6 +3304,7 @@ local game_start_run = Game.start_run
 function Game:start_run(args)
     game_start_run(self, args)
     G.SCORE_DISPLAY_QUEUE = nil
+    G.BLIND_SIZE_DISPLAY_QUEUE = nil
     G.E_MANAGER:add_event(Event({
         trigger = 'immediate',
         func = function()
@@ -4635,4 +4669,20 @@ function SMODS.split_string(_string, parts)
     end
 
     return text_output
+end
+
+-- card will always override center and that will override vars
+function SMODS.should_use_debuffed_description( conf )
+    local conf = conf or {}
+    local vars = conf.vars or {}
+    local center = conf.center
+    local card = conf.card
+    if card then 
+        center = card.config.center
+    end
+    if center then 
+        vars = (center.loc_vars and type(center.loc_vars) == 'function' and 
+                ((center:loc_vars({}, card) or {}).vars or {}))
+    end
+    return not (vars or {}).no_debuffed_description
 end


### PR DESCRIPTION
This PR introduces additional contexts for dealing with debuffed cards in particular.

ALSO BLIND_SIZE_DISPLAY_QUEUE is reset on every run start feel free to pull it out if this PR is rejected.

## Rationale
There is no context for this yet so I think it would benefit everyone even if it is extremely niche 😭

## New Contexts
`context.debuffed_main_scoring`, `context.debuffed_individual`, `context.debuffed_repetition`. These works exactly like their non-debuffed counterparts but they act on debuffed playing cards instead. 

## New Vars return
Setting `no_debuffed_description` to `true` when returning `vars` table will make the original ability text show up as if it is not debuffed (it will still have the Debuffed badge, however).

## New Function
`SMODS.should_use_debuffed_description` is used to determine if a card's ability description should be replaced with "Debuffed" texts. Used in situation listed above.

## Example Video
https://github.com/user-attachments/assets/0fc9b563-da4f-46c8-8380-0f8e4a0edbc8

Feel free to suggest for edits.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
