### PR TITLE
Feat: Corner Radii, Corner Shapes, and Custom UIBox Shapes

### DIFF
--- a/lovely/ui.toml
+++ b/lovely/ui.toml
@@ -573,7 +573,7 @@ else
   corner_radius_config_table = { res }
 end
 corner_radius_config_table.default = math.min(self.VT.w, self.VT.h + math.abs(ext_up)/G.TILESIZE) > 3.5 and 0.8 or math.min(self.VT.w, self.VT.h + math.abs(ext_up)/G.TILESIZE) > 0.3 and 0.6 or 0.15
-corner_radius_corners.default = SMODS.default_box_corner
+corner_radius_corners.default = #corner_radius_corners == 0 and SMODS.default_box_corner
 local parsed_res_config = SMODS.parse_ui_config_table(corner_radius_config_table, {"tl", "tr", "br", "bl"})
 local parsed_corners_config = SMODS.parse_ui_config_table(corner_radius_corners, {"tl", "tr", "br", "bl"})
 --[[

--- a/lovely/ui.toml
+++ b/lovely/ui.toml
@@ -552,3 +552,109 @@ pattern = '''
 G.HUD_blind.alignment.offset.y = -10'''
 payload = '''
 ease_value(G.HUD.alignment.offset, 'y', 0 - G.HUD.alignment.offset.y)'''
+
+# the following patches are made for custom corner radii
+# starting with nullifying the default
+[[patches]]
+[patches.pattern]
+target = 'engine/ui.lua'
+match_indent = true
+position = 'after'
+pattern = '''        local res = self.config.res or math.min(self.VT.w, self.VT.h + math.abs(ext_up)/G.TILESIZE) > 3.5 and 0.8 or math.min(self.VT.w, self.VT.h + math.abs(ext_up)/G.TILESIZE) > 0.3 and 0.6 or 0.15'''
+payload = '''
+local corner_radius_config_table, smoothness = self.config.res, self.config.smoothness
+local vanilla_res = false
+if type(self.config.res) == 'table' then
+  corner_radius_config_table = self.config.res
+else
+  vanilla_res = true
+  corner_radius_config_table = { res }
+end
+if type(self.config.smoothness) == 'table' then
+  smoothness = self.config.smoothness
+else
+  smoothness = { self.config.smoothness }
+end
+corner_radius_config_table.default = math.min(self.VT.w, self.VT.h + math.abs(ext_up)/G.TILESIZE) > 3.5 and 0.8 or math.min(self.VT.w, self.VT.h + math.abs(ext_up)/G.TILESIZE) > 0.3 and 0.6 or 0.15
+local parsed_res_config = SMODS.parse_ui_config_table(corner_radius_config_table, {"tl", "tr", "br", "bl"})
+local parsed_smth_config = SMODS.parse_ui_config_table(smoothness, {"tl", "tr", "br", "bl"})
+--[[
+'''
+
+[[patches]]
+[patches.pattern]
+target = 'engine/ui.lua'
+match_indent = true
+position = 'before'
+pattern = '''        for k, v in ipairs(vertices) do'''
+payload = '''
+]]
+-- thanks foo54 and sleepyg11 for figuring this out for me and for bringing it to my attention
+local totw, toth = self.VT.w*G.TILESIZE, (self.VT.h + math.abs(ext_up)/G.TILESIZE)*G.TILESIZE
+local vertices = { 
+}
+if parsed_res_config.tl then
+  local res = vanilla_res and res or parsed_res_config.tl
+  local subw, subh = self.VT.w*G.TILESIZE-4*res, (self.VT.h + math.abs(ext_up)/G.TILESIZE)*G.TILESIZE-4*res
+  for _, k in ipairs{
+    subw/2, subh/2-ext_up, 
+    -- from 0, res*4 to res*4, 0
+    0,4*res-ext_up,
+    1*res,4*res-ext_up,
+    1*res,2*res-ext_up,
+    2*res,2*res-ext_up,
+    2*res,1*res-ext_up,
+    4*res,1*res-ext_up,
+    4*res,0*res-ext_up,
+  } do vertices[#vertices+1] = k end
+end
+if parsed_res_config.tr then
+  local res = vanilla_res and res or parsed_res_config.tr
+  local subw, subh = self.VT.w*G.TILESIZE-4*res, (self.VT.h + math.abs(ext_up)/G.TILESIZE)*G.TILESIZE-4*res
+  for _, k in ipairs{
+    -- from totw - res*4, 0 to totw, res*4
+    subw,0*res-ext_up,
+    subw,1*res-ext_up,
+    subw+2*res,1*res-ext_up,
+    subw+2*res,2*res-ext_up,
+    subw+3*res,2*res-ext_up,
+    subw+3*res,4*res-ext_up,
+    totw,4*res-ext_up,
+  } do vertices[#vertices+1] = k end
+end
+if parsed_res_config.br then
+  local res = vanilla_res and res or parsed_res_config.br
+  local subw, subh = self.VT.w*G.TILESIZE-4*res, (self.VT.h + math.abs(ext_up)/G.TILESIZE)*G.TILESIZE-4*res
+  for _, k in ipairs{
+    -- from totw, toth - 4*res to totw - res*4, toth
+    totw,subh-ext_up,
+    subw+3*res, subh-ext_up,
+    subw+3*res, subh+2*res-ext_up,
+    subw+2*res, subh+2*res-ext_up,
+    subw+2*res, subh+3*res-ext_up,
+    subw, subh+3*res-ext_up,
+    subw, toth-ext_up,
+  } do vertices[#vertices+1] = k end
+end
+if parsed_res_config.bl then
+  local res = vanilla_res and res or parsed_res_config.bl
+  local subw, subh = self.VT.w*G.TILESIZE-4*res, (self.VT.h + math.abs(ext_up)/G.TILESIZE)*G.TILESIZE-4*res
+  for _, k in ipairs{
+    -- from 4*res, toth to 0, toth - 4*res
+    4*res, toth-ext_up,
+    4*res, subh+3*res-ext_up,
+    2*res, subh+3*res-ext_up,
+    2*res, subh+2*res-ext_up,
+    1*res, subh+2*res-ext_up,
+    1*res, subh-ext_up,
+    0, subh-ext_up,
+  } do vertices[#vertices+1] = k end
+end
+if parsed_res_config.tl then
+  local res = vanilla_res and res or parsed_res_config.tl
+  local subw, subh = self.VT.w*G.TILESIZE-4*res, (self.VT.h + math.abs(ext_up)/G.TILESIZE)*G.TILESIZE-4*res
+  vertices[#vertices+1] = 0
+  vertices[#vertices+1] = 4*res-ext_up
+end
+
+'''

--- a/lovely/ui.toml
+++ b/lovely/ui.toml
@@ -562,7 +562,9 @@ match_indent = true
 position = 'after'
 pattern = '''        local res = self.config.res or math.min(self.VT.w, self.VT.h + math.abs(ext_up)/G.TILESIZE) > 3.5 and 0.8 or math.min(self.VT.w, self.VT.h + math.abs(ext_up)/G.TILESIZE) > 0.3 and 0.6 or 0.15'''
 payload = '''
-local corner_radius_config_table, smoothness = self.config.res, self.config.smoothness
+local corner_radius_config_table = self.config.res
+local corner_radius_corners = self.config.corners or {}
+
 local vanilla_res = false
 if type(self.config.res) == 'table' then
   corner_radius_config_table = self.config.res
@@ -570,14 +572,10 @@ else
   vanilla_res = true
   corner_radius_config_table = { res }
 end
-if type(self.config.smoothness) == 'table' then
-  smoothness = self.config.smoothness
-else
-  smoothness = { self.config.smoothness }
-end
 corner_radius_config_table.default = math.min(self.VT.w, self.VT.h + math.abs(ext_up)/G.TILESIZE) > 3.5 and 0.8 or math.min(self.VT.w, self.VT.h + math.abs(ext_up)/G.TILESIZE) > 0.3 and 0.6 or 0.15
+corner_radius_corners.default = SMODS.default_box_corner
 local parsed_res_config = SMODS.parse_ui_config_table(corner_radius_config_table, {"tl", "tr", "br", "bl"})
-local parsed_smth_config = SMODS.parse_ui_config_table(smoothness, {"tl", "tr", "br", "bl"})
+local parsed_corners_config = SMODS.parse_ui_config_table(corner_radius_corners, {"tl", "tr", "br", "bl"})
 --[[
 '''
 
@@ -596,65 +594,52 @@ local vertices = {
 if parsed_res_config.tl then
   local res = vanilla_res and res or parsed_res_config.tl
   local subw, subh = self.VT.w*G.TILESIZE-4*res, (self.VT.h + math.abs(ext_up)/G.TILESIZE)*G.TILESIZE-4*res
-  for _, k in ipairs{
-    subw/2, subh/2-ext_up, 
-    -- from 0, res*4 to res*4, 0
-    0,4*res-ext_up,
-    1*res,4*res-ext_up,
-    1*res,2*res-ext_up,
-    2*res,2*res-ext_up,
-    2*res,1*res-ext_up,
-    4*res,1*res-ext_up,
-    4*res,0*res-ext_up,
-  } do vertices[#vertices+1] = k end
+  vertices[#vertices+1] = subw/2
+  vertices[#vertices+1] = subh/2-ext_up
+  SMODS.calculate_corners(vertices, {
+    ext_up = ext_up,
+    res = res,
+    corners = parsed_corners_config.tl,
+    corner_from = {0, 0}
+  })
 end
 if parsed_res_config.tr then
   local res = vanilla_res and res or parsed_res_config.tr
-  local subw, subh = self.VT.w*G.TILESIZE-4*res, (self.VT.h + math.abs(ext_up)/G.TILESIZE)*G.TILESIZE-4*res
-  for _, k in ipairs{
-    -- from totw - res*4, 0 to totw, res*4
-    subw,0*res-ext_up,
-    subw,1*res-ext_up,
-    subw+2*res,1*res-ext_up,
-    subw+2*res,2*res-ext_up,
-    subw+3*res,2*res-ext_up,
-    subw+3*res,4*res-ext_up,
-    totw,4*res-ext_up,
-  } do vertices[#vertices+1] = k end
+  SMODS.calculate_corners(vertices, {
+    ext_up = ext_up,
+    res = res,
+    inverted = true,
+    x_neg = true,
+    corners = parsed_corners_config.tr,
+    corner_from = {totw, 0}
+  })
 end
 if parsed_res_config.br then
   local res = vanilla_res and res or parsed_res_config.br
   local subw, subh = self.VT.w*G.TILESIZE-4*res, (self.VT.h + math.abs(ext_up)/G.TILESIZE)*G.TILESIZE-4*res
-  for _, k in ipairs{
-    -- from totw, toth - 4*res to totw - res*4, toth
-    totw,subh-ext_up,
-    subw+3*res, subh-ext_up,
-    subw+3*res, subh+2*res-ext_up,
-    subw+2*res, subh+2*res-ext_up,
-    subw+2*res, subh+3*res-ext_up,
-    subw, subh+3*res-ext_up,
-    subw, toth-ext_up,
-  } do vertices[#vertices+1] = k end
+  SMODS.calculate_corners(vertices, {
+    ext_up = ext_up,
+    res = res,
+    x_neg = true,
+    y_neg = true,
+    corners = parsed_corners_config.br,
+    corner_from = {totw, toth}
+  })
 end
+
 if parsed_res_config.bl then
   local res = vanilla_res and res or parsed_res_config.bl
-  local subw, subh = self.VT.w*G.TILESIZE-4*res, (self.VT.h + math.abs(ext_up)/G.TILESIZE)*G.TILESIZE-4*res
-  for _, k in ipairs{
-    -- from 4*res, toth to 0, toth - 4*res
-    4*res, toth-ext_up,
-    4*res, subh+3*res-ext_up,
-    2*res, subh+3*res-ext_up,
-    2*res, subh+2*res-ext_up,
-    1*res, subh+2*res-ext_up,
-    1*res, subh-ext_up,
-    0, subh-ext_up,
-  } do vertices[#vertices+1] = k end
+  SMODS.calculate_corners(vertices, {
+    ext_up = ext_up,
+    res = res,
+    inverted = true,
+    y_neg = true,
+    corners = parsed_corners_config.bl,
+    corner_from = {0, toth}
+  })
 end
-if parsed_res_config.tl then
-  local res = vanilla_res and res or parsed_res_config.tl
-  local subw, subh = self.VT.w*G.TILESIZE-4*res, (self.VT.h + math.abs(ext_up)/G.TILESIZE)*G.TILESIZE-4*res
-  vertices[#vertices+1] = 0
-  vertices[#vertices+1] = 4*res-ext_up
-end
+vertices[#vertices+1] = vertices[3]
+vertices[#vertices+1] = vertices[4]
+
 
 '''

--- a/lovely/ui.toml
+++ b/lovely/ui.toml
@@ -562,8 +562,10 @@ match_indent = true
 position = 'after'
 pattern = '''        local res = self.config.res or math.min(self.VT.w, self.VT.h + math.abs(ext_up)/G.TILESIZE) > 3.5 and 0.8 or math.min(self.VT.w, self.VT.h + math.abs(ext_up)/G.TILESIZE) > 0.3 and 0.6 or 0.15'''
 payload = '''
+local vanilla_res_number = res
 local corner_radius_config_table = self.config.res
 local corner_radius_corners = self.config.corners or {}
+local custom_shape = self.config.shape
 
 local vanilla_res = false
 if type(self.config.res) == 'table' then
@@ -591,55 +593,73 @@ payload = '''
 local totw, toth = self.VT.w*G.TILESIZE, (self.VT.h + math.abs(ext_up)/G.TILESIZE)*G.TILESIZE
 local vertices = { 
 }
-if parsed_res_config.tl then
-  local res = vanilla_res and res or parsed_res_config.tl
-  local subw, subh = self.VT.w*G.TILESIZE-4*res, (self.VT.h + math.abs(ext_up)/G.TILESIZE)*G.TILESIZE-4*res
-  vertices[#vertices+1] = subw/2
-  vertices[#vertices+1] = subh/2-ext_up
-  SMODS.calculate_corners(vertices, {
-    ext_up = ext_up,
-    res = res,
-    corners = parsed_corners_config.tl,
-    corner_from = {0, 0}
-  })
-end
-if parsed_res_config.tr then
-  local res = vanilla_res and res or parsed_res_config.tr
-  SMODS.calculate_corners(vertices, {
-    ext_up = ext_up,
-    res = res,
-    inverted = true,
-    x_neg = true,
-    corners = parsed_corners_config.tr,
-    corner_from = {totw, 0}
-  })
-end
-if parsed_res_config.br then
-  local res = vanilla_res and res or parsed_res_config.br
-  local subw, subh = self.VT.w*G.TILESIZE-4*res, (self.VT.h + math.abs(ext_up)/G.TILESIZE)*G.TILESIZE-4*res
-  SMODS.calculate_corners(vertices, {
-    ext_up = ext_up,
-    res = res,
-    x_neg = true,
-    y_neg = true,
-    corners = parsed_corners_config.br,
-    corner_from = {totw, toth}
-  })
+if custom_shape and type(custom_shape) == 'table' then
+  vertices = custom_shape
+elseif custom_shape and type(custom_shape) == 'string' and SMODS.CUSTOM_UI_SHAPES_FUNCTION[custom_shape] and type(SMODS.CUSTOM_UI_SHAPES_FUNCTION[custom_shape]) == 'table' then
+  vertices = SMODS.CUSTOM_UI_SHAPES_FUNCTION[custom_shape]
+else
+  if parsed_res_config.tl then
+    local res = vanilla_res and res or parsed_res_config.tl
+    local subw, subh = self.VT.w*G.TILESIZE-4*res, (self.VT.h + math.abs(ext_up)/G.TILESIZE)*G.TILESIZE-4*res
+    vertices[#vertices+1] = subw/2
+    vertices[#vertices+1] = subh/2-ext_up
+    SMODS.calculate_corners(vertices, {
+      ext_up = ext_up,
+      res = res,
+      corners = parsed_corners_config.tl,
+      corner_from = {0, 0}
+    })
+  end
+  if parsed_res_config.tr then
+    local res = vanilla_res and res or parsed_res_config.tr
+    SMODS.calculate_corners(vertices, {
+      ext_up = ext_up,
+      res = res,
+      inverted = true,
+      x_neg = true,
+      corners = parsed_corners_config.tr,
+      corner_from = {totw, 0}
+    })
+  end
+  if parsed_res_config.br then
+    local res = vanilla_res and res or parsed_res_config.br
+    local subw, subh = self.VT.w*G.TILESIZE-4*res, (self.VT.h + math.abs(ext_up)/G.TILESIZE)*G.TILESIZE-4*res
+    SMODS.calculate_corners(vertices, {
+      ext_up = ext_up,
+      res = res,
+      x_neg = true,
+      y_neg = true,
+      corners = parsed_corners_config.br,
+      corner_from = {totw, toth}
+    })
+  end
+
+  if parsed_res_config.bl then
+    local res = vanilla_res and res or parsed_res_config.bl
+    SMODS.calculate_corners(vertices, {
+      ext_up = ext_up,
+      res = res,
+      inverted = true,
+      y_neg = true,
+      corners = parsed_corners_config.bl,
+      corner_from = {0, toth}
+    })
+  end
+  vertices[#vertices+1] = vertices[3]
+  vertices[#vertices+1] = vertices[4]
 end
 
-if parsed_res_config.bl then
-  local res = vanilla_res and res or parsed_res_config.bl
-  SMODS.calculate_corners(vertices, {
+if custom_shape and type(custom_shape) == 'string' and SMODS.CUSTOM_UI_SHAPES_FUNCTION[custom_shape] and type(SMODS.CUSTOM_UI_SHAPES_FUNCTION[custom_shape]) == 'function' then
+  vertices = custom_shape({
+    vertices = vertices,
+    vanilla_res = vanilla_res_number,
+    corner_radius_config = parsed_res_config,
+    corner_shapes_config = parsed_corners_config,
     ext_up = ext_up,
-    res = res,
-    inverted = true,
-    y_neg = true,
-    corners = parsed_corners_config.bl,
-    corner_from = {0, toth}
+    subw = subw,
+    subh = subh,
+    totw = totw,
+    toth = toth,
   })
 end
-vertices[#vertices+1] = vertices[3]
-vertices[#vertices+1] = vertices[4]
-
-
 '''

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -4642,8 +4642,7 @@ end
 function SMODS.parse_ui_config_table(config, key_tables)
     if not config or not type(config) == 'table' or not next(config) then return end -- if config is empty
     if not key_tables or not type(key_tables) == 'table' or not next(key_tables) then return end -- if key_tables is empty
-    local defaults = config.default or 0
-    if not config.default then defaults = config[1] end -- gets default from first element
+    local defaults = config.default or config[1] or 0
     local return_table = {}
     for index, key in ipairs(key_tables) do
         return_table[key] = config[key] or config[index] or defaults

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -4652,6 +4652,8 @@ end
 
 SMODS.default_box_corner = { 0, 1, 1, 2, 2, 4, 4, }
 
+SMODS.CUSTOM_UI_SHAPES_FUNCTION = {}
+
 function SMODS.calculate_corners(vertices, config)
     config = config or {}
     local ext_up = config.ext_up or 0

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -4636,3 +4636,34 @@ function SMODS.split_string(_string, parts)
 
     return text_output
 end
+
+
+
+---@param config table? table that contains config to be parsed. `default` may be passed to properly assign default value
+---@param key_tables table? table that contains list of keys and that order determines the default order if no key is provided
+function SMODS.parse_ui_config_table(config, key_tables)
+    if not config or not type(config) == 'table' or not next(config) then return end -- if config is empty
+    if not key_tables or not type(key_tables) == 'table' or not next(key_tables) then return end -- if key_tables is empty
+    local defaults = config.default or 0
+    if not config.default then defaults = config[1] end -- gets default from first element
+    local return_table = {}
+    for index, key in ipairs(key_tables) do
+        return_table[key] = config[key] or config[index] or defaults
+    end
+    return return_table
+end
+
+function SMODS.calculate_corners(vertices, config)
+    config = config or {}
+    local ext_up = config.ext_up or 0
+    local corners = config.corners or { 0, 1, 1, 2, 2, 4, 4, }
+    local res = config.res or 1
+    local bottom = config.bottom or false
+    local ext_up = config.ext_up or 0
+    local corner_from = config.corner_from or { 0 , 0 }
+    for i = 1, #corners do
+        local xcorner, ycorner = corners[i], corners[#corners - i + 1]
+        vertices[#vertices+1] = corner_from[0] + xcorner*res
+        vertices[#vertices+1] = corner_from[1] + ycorner*res - ext_up
+    end
+end

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -4637,8 +4637,6 @@ function SMODS.split_string(_string, parts)
     return text_output
 end
 
-
-
 ---@param config table? table that contains config to be parsed. `default` may be passed to properly assign default value
 ---@param key_tables table? table that contains list of keys and that order determines the default order if no key is provided
 function SMODS.parse_ui_config_table(config, key_tables)
@@ -4653,17 +4651,25 @@ function SMODS.parse_ui_config_table(config, key_tables)
     return return_table
 end
 
+SMODS.default_box_corner = { 0, 1, 1, 2, 2, 4, 4, }
+
 function SMODS.calculate_corners(vertices, config)
     config = config or {}
     local ext_up = config.ext_up or 0
-    local corners = config.corners or { 0, 1, 1, 2, 2, 4, 4, }
+    local x_neg = config.x_neg
+    local y_neg = config.y_neg
+    local corners = config.corners or SMODS.default_box_corner
+    local inverted = config.inverted
     local res = config.res or 1
-    local bottom = config.bottom or false
-    local ext_up = config.ext_up or 0
     local corner_from = config.corner_from or { 0 , 0 }
     for i = 1, #corners do
-        local xcorner, ycorner = corners[i], corners[#corners - i + 1]
-        vertices[#vertices+1] = corner_from[0] + xcorner*res
-        vertices[#vertices+1] = corner_from[1] + ycorner*res - ext_up
+        local xcorner, ycorner
+        if inverted then 
+            xcorner, ycorner = corners[#corners - i + 1], corners[i]
+        else
+            xcorner, ycorner = corners[i], corners[#corners - i + 1]
+        end
+        vertices[#vertices+1] = corner_from[1] + (x_neg and -1 or 1)*xcorner*res
+        vertices[#vertices+1] = corner_from[2] + (y_neg and -1 or 1)*ycorner*res - ext_up
     end
 end

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -4652,7 +4652,31 @@ end
 
 SMODS.default_box_corner = { 0, 1, 1, 2, 2, 4, 4, }
 
-SMODS.CUSTOM_UI_SHAPES_FUNCTION = {}
+-- automatically generate superellipse corner
+function SMODS.superellipse(n, res, counts)
+    local ret = {}
+    local n = n or 2
+    local res = res or 4
+    local angle = 0
+    local step_val = 90 / (counts or 18) 
+    while angle <= 90 do
+        -- i want x component of something rotating from -x axis to +y axis
+        local t = (angle - 90) * math.pi / 180 -- convert to radians
+        local a = math.abs( math.cos ( t ) / 1 ) ^ n
+        local b = math.abs( math.sin ( t ) / 1 ) ^ n
+        local c = 1 / ( ( a + b ) ^ ( 1 / n ) )
+        ret[#ret+1] = res + c * math.sin ( t ) * res
+        angle = angle + step_val
+    end
+    return ret
+end
+
+-- these should preferrably max out at 4 but it's quite flexible
+SMODS.CUSTOM_UI_SHAPES_FUNCTION = {
+    default = { 0, 1, 1, 2, 2, 4, 4, },
+    bevel = {0, 4,},
+    fast_rounded = {0, 1, 2, 4,},
+}
 
 function SMODS.calculate_corners(vertices, config)
     config = config or {}


### PR DESCRIPTION
This PR changes how corners are calculated. You can now specify how each corner's radius and corner jaggedness

some absurd example here
```lua
G.FUNCS.overlay_menu({
    definition = create_UIBox_generic_options({
        back_func = "settings",
        contents = {
                { n = G.UIT.R, config = { colour = G.C.RED, r = 1, res = {5}, corners = {{0,0.1,0.2,0.4,0.8,1.6,3.2,4},{0,0.1,0.2,0.4,0.8,1.6,3.2,4},{0,0.1,0.2,0.4,0.8,1.6,3.2,4},{0,0.1,0.2,0.4,0.8,1.6,3.2,4}}, minw = 10, minh = 5 }}
            }
        })
    }) 
```
<img width="1536" height="864" alt="image" src="https://github.com/user-attachments/assets/e799bbd8-d121-496c-b3b2-43e8214a166c" />


## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
