### PR TITLE
feat: force pixel

### DIFF
--- a/lsp_def/classes/atlas.lua
+++ b/lsp_def/classes/atlas.lua
@@ -16,6 +16,7 @@
 ---@field raw_key? boolean Sets whether the mod prefix is added to atlas key. Used for overriding vanilla sprites. 
 ---@field language? string Key to a language. Restricts the atlas to only when this language is enabled. 
 ---@field disable_mipmap? boolean Sets if the sprite is affected by the mipmap. 
+---@field force_pixel? boolean If enabled, will always load the 1x sprite and force pixel smoothing off. Useful for lower resolution pixel art that looks odd with smoothing. 
 ---@field __call? fun(self: SMODS.Atlas|table, o: SMODS.Atlas|table): nil|table|SMODS.Atlas
 ---@field extend? fun(self: SMODS.Atlas|table, o: SMODS.Atlas|table): table Primary method of creating a class. 
 ---@field check_duplicate_register? fun(self: SMODS.Atlas|table): boolean? Ensures objects already registered will not register. 

--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -478,7 +478,6 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
             if self.language and G.SETTINGS.language ~= self.language and G.SETTINGS.real_language ~= self.language then return end
             local texture_scaling = G.SETTINGS.GRAPHICS.texture_scaling
             if self.force_pixel then
-                print("gjejgergjergj")
                 texture_scaling = 1
             end
             if not self.language and (self.obj_table[('%s_%s'):format(self.key, G.SETTINGS.language)] or self.obj_table[('%s_%s'):format(self.key, G.SETTINGS.real_language)]) then return end

--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -477,6 +477,10 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
             -- language specific sprites override fully defined sprites only if that language is set
             if self.language and G.SETTINGS.language ~= self.language and G.SETTINGS.real_language ~= self.language then return end
             local texture_scaling = G.SETTINGS.GRAPHICS.texture_scaling
+            if self.force_pixel then
+                print("gjejgergjergj")
+                texture_scaling = 1
+            end
             if not self.language and (self.obj_table[('%s_%s'):format(self.key, G.SETTINGS.language)] or self.obj_table[('%s_%s'):format(self.key, G.SETTINGS.real_language)]) then return end
             self.full_path = NFS.getNormalizedPath((self.path_mod or self.mod or SMODS).path ..
                 'assets/' .. texture_scaling .. 'x/' .. file_path)
@@ -509,7 +513,10 @@ Set `prefix_config.key = false` on your object instead.]]):format(obj.key), obj.
                 self.image_data = imageData2
             end
             self.image = love.graphics.newImage(self.image_data,
-                { mipmaps = true, dpiscale = G.SETTINGS.GRAPHICS.texture_scaling })
+                { mipmaps = true, dpiscale = texture_scaling })
+            if self.force_pixel then
+                self.image:setFilter("nearest", "nearest")
+            end
             self.columns = self.image:getWidth() / self.px
             self.rows = self.image:getHeight() / self.py
             G[atlas_table_map[self.atlas_table]][self.key_noloc or self.key] = self


### PR DESCRIPTION
Adds an option to atlases to force them to be loaded at 1x scale, with nearest neighbour filtering. This can be used to fixed oddities in sprites that is caused by pixel art smoothing.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
