### PR TITLE
Auto-add Stickers to loc_colours

### DIFF
--- a/src/game_object.lua
+++ b/src/game_object.lua
@@ -3205,6 +3205,7 @@ SMODS.UndiscoveredCompat = {
             G.STAGE_OBJECT_INTERRUPT = true
             self.sticker_sprite = SMODS.create_sprite(0, 0, G.CARD_W, G.CARD_H, self.atlas, self.pos, self.sprite_args)
             G.STAGE_OBJECT_INTERRUPT = false
+			G.ARGS.LOC_COLOURS[self.key] = self.badge_colour
             G.shared_stickers[self.key] = self.sticker_sprite
         end,
         -- relocating sticker checks to here, so if the sticker has different checks than default


### PR DESCRIPTION
Automatically add loc_colours entries corresponding to stickers

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
