### PR TITLE
Fix: (ctrl+)b crash on new profile

### DIFF
--- a/src/utils/run_select.lua
+++ b/src/utils/run_select.lua
@@ -304,9 +304,21 @@ function SMODS.RunSelect.Functions.start_run(_quick_start, _skip_wipe)
     local run_args = {}
     SMODS.RunSelect.Functions.clean_up()
     
-    local access = _quick_start and G.PROFILES[G.SETTINGS.profile].last_choices or SMODS.RunSelect.Setup.choices
-    for k, v in pairs(access) do
+    run_args.deck_choice = "b_red"
+    run_args.stake_choice = "stake_white"
+    for k, v in pairs(SMODS.RunSelect.Setup.choices) do
         run_args[k] = v
+    end
+    if _quick_start and _skip_wipe ~= true then
+        for k, v in pairs(G.PROFILES[G.SETTINGS.profile].last_choices or {}) do
+            run_args[k] = v
+        end
+    end
+
+    if SMODS.RunSelect.Setup.choices.enable_seed then
+        run_args.seed = SMODS.RunSelect.Setup.choices.seed
+    else
+        run_args.seed = nil
     end
 
     if SMODS.RunSelect.Setup.choices.enable_seed then


### PR DESCRIPTION
When pressing b with debug mode enabled (or ctrl+b with debugplus), the game instantly starts a new run. The modded `SMODS.RunSelect.Functions.start_run` has some issues compared to the vanilla `Game:start_run` implementation that this PR aims to fix:

1. On a fresh profile, pressing (ctrl+)b caused the new modded RunSelect to crash. I fixed it to fallback to Red Deck and White Stake, like the vanilla version.

2. While in the vanilla run select screen, pressing (ctrl+)b starts a run with the currently viewed deck. I modified the new modded RunSelect to also respect the currently viewed deck and stake.

What I have NOT fixed/changed but did notice:
Pressing (ctrl+)b while in a challenge run resets to an "empty" challenge deck on vanilla, and resets to red deck with RunSelect. Both of these are unexpected.


## Additional Info:
- [X] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [X] I didn't modify api's or I've updated lsp definitions.
- [X] I didn't make new lovely files or all new lovely files have appropriate priority.
