### PR TITLE
Card:start_materialize Custom Set Color Fix

### DIFF
--- a/lovely/center.toml
+++ b/lovely/center.toml
@@ -743,5 +743,5 @@ pattern = "(self.ability.set == 'Voucher' and {G.C.SECONDARY_SET.Voucher, G.C.CL
 position = 'after'
 match_indent = true
 payload = '''
-(G.C.SECONDARY_SET[self.ability.set] and {G.C.SECONDARY_SET[self.ability.set]}) or
+(next(G.C.SECONDARY_SET[self.ability.set]) and {G.C.SECONDARY_SET[self.ability.set]}) or
 '''


### PR DESCRIPTION
Allows custom sets to properly materialize as the designated secondary color opposed from the default green

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [ ] I didn't modify api's or I've updated lsp definitions.
- [ ] I didn't make new lovely files or all new lovely files have appropriate priority.
