### PR TITLE
implement no_replace for poll_object

### DIFF
--- a/src/utils/weights.lua
+++ b/src/utils/weights.lua
@@ -550,6 +550,7 @@ function SMODS.cull_pool(pool, args)
             if args.types and (not args.types[v.set] and not (args.types['Consumeables'] and SMODS.ConsumableTypes[v.set])) then add = nil end
             if v.no_pool_flag and G.GAME.pool_flags[v.no_pool_flag] then add = nil end
             if v.yes_pool_flag and not G.GAME.pool_flags[v.yes_pool_flag] then add = nil end
+            if args.no_replace and v.set == 'Enhanced' and v.replace_base_card then add = nil end
             
             add = in_pool and (add or ((not _rarity or _rarity == v.rarity) and pool_opts.override_base_checks))
             


### PR DESCRIPTION
SMODS.poll_object, when used by SMODS.poll_enhancement, does not respond to the original's `no_replace` argument. this fixes that

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
