### PR TITLE
Fix crash when changing hand size before old_slots is initialized (e.g. Juggle Tag)

### DIFF
--- a/lovely/card_limit.toml
+++ b/lovely/card_limit.toml
@@ -93,7 +93,7 @@ function CardArea:change_size(delta)
 payload = '''
     -- SMODS BYPASS ORIGINAL FUNCTION
     if true then
-        if delta > 0 and self == G.hand and self.config.card_limits.old_slots > self.config.card_limits.total_slots then
+        if delta > 0 and self == G.hand and self.config.card_limits.old_slots and self.config.card_limits.old_slots > self.config.card_limits.total_slots then
             SMODS.draw_cards(delta)
         end
         self.config.card_limits.mod = (self.config.card_limits.mod or 0) + delta
@@ -408,7 +408,7 @@ pattern = '''
 G.STATE = G.STATES.SELECTING_HAND
 '''
 payload = '''
-if G.hand.config.card_limits.old_slots < G.hand.config.card_limits.total_slots then
+if not G.hand.config.card_limits.old_slots or G.hand.config.card_limits.old_slots < G.hand.config.card_limits.total_slots then
     G.hand.config.card_limits.old_slots = G.hand.config.card_limits.total_slots
 end
 '''

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -3946,7 +3946,7 @@ function CardArea:handle_card_limit()
                         return true
                     end
                 }))
-            elseif G.STATE == G.STATES.SELECTING_HAND and #G.deck.cards > 0 and self.config.card_limits.old_slots < self.config.card_limits.total_slots then
+            elseif G.STATE == G.STATES.SELECTING_HAND and #G.deck.cards > 0 and self.config.card_limits.old_slots and self.config.card_limits.old_slots < self.config.card_limits.total_slots then
                 G.FUNCS.draw_from_deck_to_hand()
             end
             if self == G.hand and G.STATE == G.STATES.SELECTING_HAND or G.STATE == G.STATES.DRAW_TO_HAND then


### PR DESCRIPTION
### Problem
When hand size is modified at the start of a round (e.g. via vanilla's **Juggle Tag** during `round_start_bonus`), `CardArea:change_size()` is called before cards are drawn and before `card_limits.old_slots` has ever been initialized.
Because `old_slots` defaults to `nil`, evaluating `self.config.card_limits.old_slots > self.config.card_limits.total_slots` throws a runtime error:
`cardarea.lua:120: attempt to compare number with nil`
Similarly, if `old_slots` was uninitialized when entering `SELECTING_HAND` or inside `CardArea:handle_card_limit()`, comparing it against `total_slots` could trigger the same crash.
### Solution
1. **`lovely/card_limit.toml` (`CardArea:change_size`)**: Added a nil check for `self.config.card_limits.old_slots` before comparing against `total_slots`.
2. **`lovely/card_limit.toml` (`game.lua` before `SELECTING_HAND`)**: Safely initialize `old_slots` to `total_slots` if `old_slots` is still `nil`.
3. **`src/utils.lua` (`CardArea:handle_card_limit`)**: Guarded `old_slots` against `nil` before checking if cards need to be drawn.
