### PR TITLE
allow legendaries when spawning legendaries

### DIFF
--- a/src/utils/weights.lua
+++ b/src/utils/weights.lua
@@ -329,6 +329,7 @@ function SMODS.create_poll_pool(labels, args)
         local join_func = (args.attributes and not args.union) and SMODS.intersect_lists or join_lists
         for i=1, #(args.rarities or {true}) do
             if label == "Booster" then SMODS.poll_object_allow_duplicates = true end
+            if args.rarities and args.rarities[i] == 'Legendary' then args.allow_legendaries = true end
             local _p = label == 'Blind' and SMODS.create_blind_pool(args.blind_type or 'boss') or SMODS.Attributes[label] and SMODS.get_attribute_pool(label) or get_current_pool(label, args.rarities and args.rarities[i], nil, args.append)
             SMODS.poll_object_allow_duplicates = nil
             if SMODS.Attributes[label] then


### PR DESCRIPTION
calling `create_card` with the `legendary` argument did not properly pass `allow_legendaries` into SMODS.poll_object, meaning cards such as The Soul would filter out every legendary in the legendary pool, resulting in the pool being empty and spawning Joker instead. this PR adjusts `create_poll_pool` to automatically set `allow_legendaries` to true if you are polling for the Legendary rarity, which fixes The Soul and should also result in more intuitive behavior for anyone making anything similar to The Soul

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
