### PR TITLE
populate attributes for blinds

### DIFF
--- a/src/game_objects/blind.lua
+++ b/src/game_objects/blind.lua
@@ -32,6 +32,14 @@ SMODS.Blind = SMODS.GameObject:extend {
         }
 
         G.P_BLINDS[self.key] = self
+        if self.attributes then
+            for _, attribute in ipairs(self.attributes) do
+                if SMODS.Attributes[attribute] then
+                    self.attributes[attribute] = true
+                    SMODS.Attributes[attribute].keys = SMODS.merge_lists({SMODS.Attributes[attribute].keys or {}, {self.key}})
+                end
+            end
+        end
         if self.modifies_draw then SMODS.Blinds.modifies_draw[self.key] = true end
     end
 }


### PR DESCRIPTION
SMODS.Blind's inject function was missing the code to properly populate its attributes table, meaning you cannot use `has_attribute` on modded blinds currently

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
