### PR TITLE
`default` for rarities

### DIFF
--- a/lovely/pool.toml
+++ b/lovely/pool.toml
@@ -91,7 +91,12 @@ pattern = "if _type == 'Tarot' or _type == 'Tarot_Planet' then _pool[#_pool + 1]
 match_indent = true
 position = 'at'
 payload = '''
-if _rarity and SMODS.Rarities[_rarity] and SMODS.Rarities[_rarity].disable_if_empty then _pool[#_pool + 1] = "empty_rarity"
+local vanilla_rarities = { "Common", "Uncommon", "Rare", "Legendary" }
+local rarity_prototype = _rarity and (SMODS.Rarities[_rarity] or SMODS.Rarities[vanilla_rarities[_rarity]])
+if rarity_prototype and rarity_prototype.disable_if_empty then _pool[#_pool + 1] = "empty_rarity"
+elseif rarity_prototype and (type(rarity_prototype.default) == "string" or 
+(type(rarity_prototype.default) == "table" and rarity_prototype.default[_type])) then
+    _pool[#_pool+1] = type(rarity_prototype.default) == "table" and rarity_prototype.default[_type] or rarity_prototype.default
 elseif SMODS.ObjectTypes[_type] and SMODS.ObjectTypes[_type].default and G.P_CENTERS[SMODS.ObjectTypes[_type].default] then
     _pool[#_pool+1] = SMODS.ObjectTypes[_type].default
 elseif _type == 'Tarot' or _type == 'Tarot_Planet' then _pool[#_pool + 1] = "c_strength"'''

--- a/lsp_def/classes/rarity.lua
+++ b/lsp_def/classes/rarity.lua
@@ -8,6 +8,7 @@
 ---@field pools? table Table with a list of ObjectTypes keys this rarity should be added to.
 ---@field text_colour? table Colour of the label for the badge.
 ---@field badge_colour? table HEX color the rarity badge uses.
+---@field default? string|table<string,string> Default object if all cards of the rarity are owned (defaults to the type's default object)
 ---@field default_weight? number Default weight of the rarity. When referenced in ObjectTypes with just the key, this value is used as the default. 
 ---@field disable_if_empty? boolean Disables polling of the rarity if set to `true` if there are no available objects.
 ---@field __call? fun(self: SMODS.Rarity|table, o: SMODS.Rarity|table): nil|table|SMODS.Rarity


### PR DESCRIPTION
Allows `SMODS.Rarities` to have a default similar to sets when all cards from the rarity are owned. This can also be a table with different defaults for each set (if a set doesn't have one it still uses the regular default).

Also fixes and issue where `disable_if_empty` wasn't respected for vanilla rarities (with take_ownership, for example). They also work with this feature

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
