### PR TITLE
`context.booster_select_card` and `on_select` changes

### DIFF
--- a/lovely/booster.toml
+++ b/lovely/booster.toml
@@ -403,12 +403,42 @@ if select_to then
     if card.config.center.on_select and type(card.config.center.on_select) == 'function' then
         card.config.center:on_select(card)
     end
+    SMODS.calculate_context{booster_select_card = true, card = card, booster = booster_obj, cardarea = G[select_to]}
     play_sound('card1', 0.8, 0.6)
     play_sound('generic1')
     dont_dissolve = true
     delay_fac = 0.2
 elseif card.ability.consumeable then
       if nc then
+'''
+
+[[patches]]
+[patches.pattern]
+target = 'functions/button_callbacks.lua'
+match_indent = true
+position = 'after'
+pattern = '''
+G.deck:emplace(card)
+'''
+payload = '''
+if card.config.center.on_select and type(card.config.center.on_select) == 'function' then
+    card.config.center:on_select(card)
+end
+SMODS.calculate_context{booster_select_card = true, card = card, booster = booster_obj, cardarea = G.deck}
+'''
+[[patches]]
+[patches.pattern]
+target = 'functions/button_callbacks.lua'
+match_indent = true
+position = 'after'
+pattern = '''
+G.jokers:emplace(card)
+'''
+payload = '''
+if card.config.center.on_select and type(card.config.center.on_select) == 'function' then
+    card.config.center:on_select(card)
+end
+SMODS.calculate_context{booster_select_card = true, card = card, booster = booster_obj, cardarea = G.jokers}
 '''
 # G.FUNCS.end_consumeable()
 [[patches]]


### PR DESCRIPTION
Adds a context when a card is selected to be obtained (not used) from a booster pack. I decided to not include use since there's jank with vanilla using the same function and there already being contexts for use of consumables and boosters.

Also allows `on_select` to work with Jokers and Enhancements even if they don't have `select_card` specified.

I'm still bad at naming contexts, I take suggestions

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
