### PR TITLE
Fix/galdur UI duplicate tooltips

### DIFF
--- a/src/utils/run_select.lua
+++ b/src/utils/run_select.lua
@@ -777,12 +777,21 @@ function SMODS.RunSelect.Functions.grab_tooltips(set, key)
     local loc_target = G.localization.descriptions[set][key]
     for _, lines in ipairs(loc_target.text_parsed) do
         for _, part in ipairs(lines) do
-            if part.control.T then 
-                info_queue[#info_queue+1] = G.P_CENTERS[part.control.T] or G.P_TAGS[part.control.T] or {
-                    set = part.control.T_set or 'Other',
-                    key = part.control.T,
-                    vars = part.control.T_vars and parse_tooltip_vars(part.control.T_vars) or {}
-                }
+            if part.control.T then
+                local already_added = false
+                for _, v in ipairs(info_queue) do
+                    if v == G.P_CENTERS[part.control.T] or v == G.P_TAGS[part.control.T] then
+                        already_added = true
+                        break
+                    end
+                end
+                if not already_added then
+                    info_queue[#info_queue+1] = G.P_CENTERS[part.control.T] or G.P_TAGS[part.control.T] or {
+                        set = part.control.T_set or 'Other',
+                        key = part.control.T,
+                        vars = part.control.T_vars and parse_tooltip_vars(part.control.T_vars) or {}
+                    }
+                end
             end
         end
     end


### PR DESCRIPTION
This prevents duplicate tooltips from being added in Galdur UI infoboxes

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
