### PR TITLE
Fix `SMODS.card_to_image`

### DIFF
--- a/src/utils.lua
+++ b/src/utils.lua
@@ -4573,8 +4573,11 @@ function SMODS.card_to_image(card, scale, filename)
 	filename = (filename or key == "j_joker" and "jimbo" or key) .. ".png"
     
     local atlas = card.children and card.children.center and card.children.center.atlas or {}
-    local display = card.config.center.display_size or {} --I don't think this is correct but I'm not 100% sure what's correct about it
+    local display = card.config.center.display_size or {}
     local px,py = display.w or atlas.px or 71, display.h or atlas.py or 95
+    display.w, display.h = display.w or 71, display.h or 95
+    local ratiox,ratioy = px/display.w, py/display.h
+    if (ratiox - ratioy) > 1/95 then print("yayyyy this might not work as intended.") end --No clue how to handle the case where image scaling isn't 1:1
 
 	local canvas = love.graphics.newCanvas(px * scale, py * scale, {type = '2d', readable = true})
     canvas:setFilter('nearest', 'nearest')
@@ -4584,7 +4587,7 @@ function SMODS.card_to_image(card, scale, filename)
     local old_rm = G.SETTINGS.reduced_motion
     card.T.r = 0
     local old_scale = card.T.scale 
-    card.T.scale = scale / G.TILE_H * G.window_prev.orig_scale * G.window_prev.orig_scale/G.TILESCALE * 1.5 -- Don't ask me why I had to multiply by 1.5 here, and by the per-dimension factors below, I do not know,,, (this may have been brute-tinkered)
+    card.T.scale = scale / G.TILE_H * G.window_prev.orig_scale * G.window_prev.orig_scale/G.TILESCALE * 1.5 * ratiox -- Don't ask me why I had to multiply by 1.5 here, and by the per-dimension factors below, I do not know,,, (this may have been brute-tinkered)
     local w, h = old_t.w * 0.997, old_t.h * 0.99348                                                         -- (well these factors are needed to remove extra pixels in height/width for scales == 2.0 -> 16.0 (at least))
     card:hard_set_T(w/2*(card.T.scale-1), h/2*(card.T.scale-1), w, h)
 	card.no_shadow = true

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -4572,7 +4572,11 @@ function SMODS.card_to_image(card, scale, filename)
     scale = scale or G.SETTINGS.GRAPHICS.texture_scaling
 	filename = (filename or key == "j_joker" and "jimbo" or key) .. ".png"
     
-	local canvas = love.graphics.newCanvas(71 * scale, 95 * scale, {type = '2d', readable = true})
+    local atlas = card.children and card.children.center and card.children.center.atlas or {}
+    local display = card.config.center.display_size or {} --I don't think this is correct but I'm not 100% sure what's correct about it
+    local px,py = display.w or atlas.px or 71, display.h or atlas.py or 95
+
+	local canvas = love.graphics.newCanvas(px * scale, py * scale, {type = '2d', readable = true})
     canvas:setFilter('nearest', 'nearest')
 
     local old_t = SMODS.shallow_copy(card.T)


### PR DESCRIPTION
Started working on making it not choke on cards of sizes other than 71x95 exactly
Still some hiccups, it rendered FaC's green pirate hat (710x950) as a 71x95 image stuck in the corner of a 710x950 canvas and idk why. It does mostly work but these hiccups confuse me. Thus the draft status to see if anyone else can figure it out.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
