### PR TITLE
Automatic area buffers

### DIFF
--- a/lovely/card_limit.toml
+++ b/lovely/card_limit.toml
@@ -45,6 +45,7 @@ self.config = setmetatable({card_limits = {card_limit}}, {
 })
 
 SMODS.merge_defaults(self.config, config)
+self.config.buffer = 0
 '''
 
 # Load metatable

--- a/lovely/cardarea.toml
+++ b/lovely/cardarea.toml
@@ -51,3 +51,42 @@ if card.highlighted then
     self:remove_from_highlighted(card, true)
 end
 '''
+
+# Redirect old cardarea buffers to new ones
+[[patches]]
+[patches.pattern]
+target = 'game.lua'
+match_indent = true
+position = 'after'
+pattern = '''
+self.GAME = saveTable and saveTable.GAME or self:init_game_object()
+'''
+payload = '''
+-- Redirect cardarea buffers to config buffers
+self.GAME.consumeable_buffer = nil
+self.GAME.joker_buffer = nil
+self.GAME = setmetatable(self.GAME, {
+    __index = function(t, key)
+        if key == "joker_buffer" then
+            return G.jokers and G.jokers.config.buffer or 0
+        elseif key == "consumeable_buffer" then
+            return G.consumeables and G.consumeables.config.buffer or 0
+        end
+        return rawget(t, key)
+    end,
+    __newindex = function(t, key, value)
+        if key == "joker_buffer" then
+            if G.jokers then
+                rawset(G.jokers.config, "buffer", value)
+            end
+            return
+        elseif key == "consumeable_buffer" then
+            if G.consumeables then
+                rawset(G.consumeables.config, "buffer", value)
+            end
+            return
+        end
+        rawset(t, key, value)
+    end
+})
+'''

--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -987,3 +987,9 @@ function SMODS.process_loc_element(element) end
 --- Returns if the current ante would have a showdown boss blind.
 ---@return boolean
 function SMODS.is_showdown_ante() end
+
+--- Returns the amount of free slots in the CardArea, 0 if it doesn't exist
+---@param area? CardArea|PlayAreas|table 
+---@param ignore_buffer? boolean
+---@return number
+function SMODS.get_slots_available(area, ignore_buffer) end

--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -473,7 +473,7 @@ function SMODS.find_card(key, count_debuffed) end
 ---@field enhanced_poll? number Chance to pick 'Base' over 'Enhanced' with set 'Playing Card'.
 ---@field silent? true|{edition?:true, seal?:true} Applies edition and/or seal silently
 ---@field attributes? string[] Creates a card with these attributes. All other arguments will be passed to SMODS.poll_object
----@field create_event? boolean Adds the card in an event instead of immediately. Automatically increments the area's buffer unless `ignore_buffer` is `true`
+---@field create_event? boolean|table Adds the card in an event instead of immediately. Can be a table with the event's parameters. Automatically increments the area's buffer unless `ignore_buffer` is `true`
 ---@field ignore_buffer? boolean Doesn't increment the area's buffer when called with `create_event` set to `true`
 ---@field buffer_increment? integer Increments buffer by this specific value instead of calculating it automatically when called with `create_event` set to `true`
 

--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -473,6 +473,9 @@ function SMODS.find_card(key, count_debuffed) end
 ---@field enhanced_poll? number Chance to pick 'Base' over 'Enhanced' with set 'Playing Card'.
 ---@field silent? true|{edition?:true, seal?:true} Applies edition and/or seal silently
 ---@field attributes? string[] Creates a card with these attributes. All other arguments will be passed to SMODS.poll_object
+---@field create_event? boolean Adds the card in an event instead of immediately. Automatically increments the area's buffer unless `ignore_buffer` is `true`
+---@field ignore_buffer? boolean Doesn't increment the area's buffer when called with `create_event` set to `true`
+---@field buffer_increment? integer Increments buffer by this specific value instead of calculating it automatically when called with `create_event` set to `true`
 
 ---@param t CreateCard|table
 ---@return Card|table

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -4674,6 +4674,6 @@ function SMODS.split_string(_string, parts)
     return text_output
 end
 
-function SMODS.get_slots_available(area)
-    return area and (area.config.card_limit - (#area.cards + (area.config.buffer or 0))) or 0
+function SMODS.get_slots_available(area, ignore_buffer)
+    return area and (area.config.card_limit - (#area.cards + (not ignore_buffer and area.config.buffer or 0))) or 0
 end

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -4516,13 +4516,34 @@ function SMODS.add_to_deck(card, args)
     if not args.area and SMODS.ConsumableTypes[card.ability.set] then
         args.area = G.consumeables
     end
-    card:add_to_deck()
-    if is_playing_card then
-        G.deck.config.card_limit = G.deck.config.card_limit + 1
-        table.insert(G.playing_cards, card)
-    end
+
     local area = args.area or G.jokers
-    area:emplace(card)
+
+    local add_card = function()
+        card:add_to_deck()
+        if is_playing_card then
+            G.deck.config.card_limit = G.deck.config.card_limit + 1
+            table.insert(G.playing_cards, card)
+        end
+        area:emplace(card)
+    end
+
+    if args.create_event then
+        if not args.ignore_buffer then
+            area.config.buffer = (area.config.buffer or 0) +
+                (args.buffer_increment or (1 + (card.ability.extra_slots_used or 0)))
+        end
+        G.E_MANAGER:add_event(Event({
+            func = function()
+                add_card()
+                area.config.buffer = 0
+                return true
+            end
+        }))
+    else
+        add_card()
+    end
+
     return card
 end
 
@@ -4650,4 +4671,8 @@ function SMODS.split_string(_string, parts)
     end
 
     return text_output
+end
+
+function SMODS.get_slots_available(area)
+    return area and (area.config.card_limit - (#area.cards + (area.config.buffer or 0))) or 0
 end

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -4533,13 +4533,14 @@ function SMODS.add_to_deck(card, args)
             area.config.buffer = (area.config.buffer or 0) +
                 (args.buffer_increment or (1 + (card.ability.extra_slots_used or 0)))
         end
-        G.E_MANAGER:add_event(Event({
-            func = function()
-                add_card()
-                area.config.buffer = 0
-                return true
-            end
-        }))
+        local event_args = type(args.create_event) == "table" and args.create_event or {}
+        local event_func = event_args.func or function() return true end
+        event_args.func = function()
+            add_card()
+            area.config.buffer = 0
+            return event_func()
+        end
+        G.E_MANAGER:add_event(Event(event_args))
     else
         add_card()
     end

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -4531,7 +4531,7 @@ function SMODS.add_to_deck(card, args)
     if args.create_event then
         if not args.ignore_buffer then
             area.config.buffer = (area.config.buffer or 0) +
-                (args.buffer_increment or (1 + (card.ability.extra_slots_used or 0)))
+                (args.buffer_increment or 1)
         end
         local event_args = type(args.create_event) == "table" and args.create_event or {}
         local event_func = event_args.func or function() return true end

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -4539,6 +4539,7 @@ function SMODS.add_to_deck(card, args)
         local event_args = type(args.create_event) == "table" and args.create_event or {}
         local event_func = event_args.func or function() return true end
         event_args.func = function()
+            if event_args.pre_func then event_args.pre_func(card) end
             add_card()
             area.config.buffer = 0
             return event_func()

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -4500,7 +4500,10 @@ function SMODS.copy_card(card, args)
 
     if args.new_card or args.no_add then return copy end
 
-    return SMODS.add_to_deck(copy, {area = args.area or card.area, playing_card = playing_card})
+    args.area = args.area or card.area
+    args.playing_card = playing_card
+
+    return SMODS.add_to_deck(copy, args)
 end
 
 function SMODS.add_to_deck(card, args)


### PR DESCRIPTION
Makes every cardarea have a buffer under `area.config.buffer` and redirects the vanilla joker and consumable buffer to these values.

Adds new arguments for SMODS.add_to_deck (and by consequence SMODS.add_card) to handle buffers automatically:
   - `create_event` adds the card in an event (you can change the event parameters) and changes the buffer automatically ~~(it takes into account `extra_slots_used` but not `card_limit` since vanilla doesn't account for Negatives normally, although the first behavior might also not be wanted)~~ edit: decided to remove this
   - `ignore_buffer` doesn't increment the buffer when creating an event
   - `buffer_increment` to increment a buffer manually by a certain value (for example to account for Negatives)

Also adds `SMODS.get_slots_available(area, ignore_buffer)` as a helper function to check for area slots. Decided to return 0 when the area doesn't exist for loc_vars collection stuff.

Mostly @WilsontheWolf 's idea

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
