### PR TITLE
Fix crash from negative hand levels

### DIFF
--- a/lovely/fixes.toml
+++ b/lovely/fixes.toml
@@ -973,3 +973,22 @@ G.PROFILES[G.SETTINGS.profile].all_unlocked = true
 payload = '''
 EMPTY(G.P_LOCKED)
 '''
+
+# Fix negative hand levels causing a crash
+[[patches]]
+[patches.pattern]
+target = 'functions/common_events.lua'
+match_indent = true
+position = 'after'
+pattern = '''
+if type(vals.level) == 'number' then 
+    G.hand_text_area.hand_level.config.colour = G.C.HAND_LEVELS[math.min(vals.level, 7)]
+else
+    G.hand_text_area.hand_level.config.colour = G.C.HAND_LEVELS[1]
+end
+'''
+payload = '''
+if not G.hand_text_area.hand_level.config.colour then
+    G.hand_text_area.hand_level.config.colour = G.C.HAND_LEVELS[0]
+end
+'''


### PR DESCRIPTION
The cause of the bug is this snippet from `update_hand_text` that doesn't account for negative levels, which makes the colour nil causing a crash later on in `UIElement:draw_self`
```lua
if type(vals.level) == 'number' then 
    G.hand_text_area.hand_level.config.colour = G.C.HAND_LEVELS[math.min(vals.level, 7)]
else
    G.hand_text_area.hand_level.config.colour = G.C.HAND_LEVELS[1]
end
```
The fix I implemented is to add a nil check after this if statement and fallback to G.C.RED (the color for level 0)
```lua
if not G.hand_text_area.hand_level.config.colour then
    G.hand_text_area.hand_level.config.colour = G.C.HAND_LEVELS[0]
end
```
A lot of mods use the pattern `G.hand_text_area.hand_level.config.colour = G.C.HAND_LEVELS[math.min(vals.level, 7)]` so I avoided changing that line to not break compatibility.

I tested that it works but not the compatibility with other mods, although I have looked through most of the references to this code on github search and haven't seen any mods or patches that it breaks.

~~The only mod it might break is suikalatro because they [match against the entire function](https://github.com/pi-cubed-cat/suikalatro/blob/main/lovely/play_hand_fixes.toml#L101) to remove a few lines.~~ (I just tested and the patch I linked already fails to apply on the latest steamodded version)


## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [x] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
