### PR TITLE
Fix nil values for vanilla cards in info_queue

### DIFF
--- a/lovely/center.toml
+++ b/lovely/center.toml
@@ -627,14 +627,7 @@ position = 'after'
 pattern = "elseif _c.set == 'Joker' then"
 payload = '''
     if not card then
-        local ability = copy_table(_c.config)
-        ability.set = 'Joker'
-        ability.name = _c.name
-        -- temporary stopgap. fake cards should be implemented better
-        ability.x_mult = _c['config'].Xmult or _c['config'].x_mult
-        if ability.name == 'To Do List' then
-            ability.to_do_poker_hand = "High Card" -- fallback
-        end
+        local ability = SMODS.merge_defaults(copy_table(_c.config), SMODS.get_default_ability_vars(_c, card))
         local ret = {Card.generate_UIBox_ability_table({ ability = ability, config = { center = _c }, bypass_lock = true}, true)}
         specific_vars = ret[1]
         if ret[2] then desc_nodes[#desc_nodes+1] = ret[2] end

--- a/lovely/center.toml
+++ b/lovely/center.toml
@@ -627,7 +627,7 @@ position = 'after'
 pattern = "elseif _c.set == 'Joker' then"
 payload = '''
     if not card then
-        local ability = SMODS.merge_defaults(copy_table(_c.config), SMODS.get_default_ability_vars(_c, card))
+        local ability = SMODS.get_default_ability_vars(_c, card)
         local ret = {Card.generate_UIBox_ability_table({ ability = ability, config = { center = _c }, bypass_lock = true}, true)}
         specific_vars = ret[1]
         if ret[2] then desc_nodes[#desc_nodes+1] = ret[2] end

--- a/lovely/fixes.toml
+++ b/lovely/fixes.toml
@@ -218,6 +218,8 @@ position = 'at'
 line_prepend = '$indent'
 payload = '''
 local new_ability = $2
+new_ability = SMODS.merge_defaults(new_ability, SMODS.get_default_ability_vars(self, center))
+
 self.ability = self.ability or {}
 new_ability.extra_value = nil
 new_ability.debuff_sources = {}

--- a/lovely/fixes.toml
+++ b/lovely/fixes.toml
@@ -218,7 +218,7 @@ position = 'at'
 line_prepend = '$indent'
 payload = '''
 local new_ability = $2
-new_ability = SMODS.merge_defaults(new_ability, SMODS.get_default_ability_vars(self, center))
+new_ability = SMODS.merge_defaults(new_ability, SMODS.get_default_ability_vars(self, center, true))
 
 self.ability = self.ability or {}
 new_ability.extra_value = nil

--- a/lovely/perma_bonus.toml
+++ b/lovely/perma_bonus.toml
@@ -108,52 +108,6 @@ bonus_chips = bonus_chips ~= 0 and bonus_chips or nil,
 bonus_repetitions = self.ability.perma_repetitions ~= 0 and self.ability.perma_repetitions or nil,'''
 match_indent = true
 
-# set_ability: set defaults for temporary bonuses
-# Also add conformance with SMODS documentation.
-[[patches]]
-[patches.pattern]
-target = "card.lua"
-pattern = "x_mult = center.config.Xmult or 1,"
-position = "at"
-payload = '''
-x_mult = center.config.Xmult or center.config.x_mult or 1,
-h_chips = center.config.h_chips or 0,
-x_chips = center.config.x_chips or 1,
-h_x_chips = center.config.h_x_chips or 1,
-repetitions = center.config.repetitions or 0,
-'''
-match_indent = true
-
-# set_ability: set defaults for permanent bonuses
-[[patches]]
-[patches.pattern]
-target = "card.lua"
-pattern = "perma_bonus = self.ability and self.ability.perma_bonus or 0,"
-position = "after"
-payload = '''
-perma_x_chips = self.ability and self.ability.perma_x_chips or 0,
-perma_mult = self.ability and self.ability.perma_mult or 0,
-perma_x_mult = self.ability and self.ability.perma_x_mult or 0,
-perma_h_chips = self.ability and self.ability.perma_h_chips or 0,
-perma_h_x_chips = self.ability and self.ability.perma_h_x_chips or 0,
-perma_h_mult = self.ability and self.ability.perma_h_mult or 0,
-perma_h_x_mult = self.ability and self.ability.perma_h_x_mult or 0,
-perma_p_dollars = self.ability and self.ability.perma_p_dollars or 0,
-perma_h_dollars = self.ability and self.ability.perma_h_dollars or 0,
-perma_repetitions = self.ability and self.ability.perma_repetitions or 0,
-card_limit = self.ability and self.ability.card_limit or 0,
-extra_slots_used = self.ability and self.ability.extra_slots_used or 0,
-perma_score = self.ability and self.ability.perma_score or 0,
-perma_h_score = self.ability and self.ability.perma_h_score or 0,
-perma_x_score = self.ability and self.ability.perma_x_score or 0,
-perma_h_x_score = self.ability and self.ability.perma_h_x_score or 0,
-perma_blind_size = self.ability and self.ability.perma_blind_size or 0,
-perma_h_blind_size = self.ability and self.ability.perma_h_blind_size or 0,
-perma_x_blind_size = self.ability and self.ability.perma_x_blind_size or 0,
-perma_h_x_blind_size = self.ability and self.ability.perma_h_x_blind_size or 0,
-'''
-match_indent = true
-
 # Card:get_chip_bonus
 [[patches]]
 [patches.pattern]

--- a/lsp_def/utils.lua
+++ b/lsp_def/utils.lua
@@ -984,3 +984,10 @@ function SMODS.process_loc_element(element) end
 --- Returns if the current ante would have a showdown boss blind.
 ---@return boolean
 function SMODS.is_showdown_ante() end
+
+--- Returns the default ability table for this center
+---@param center SMODS.Center|table
+---@param card? Card|table
+---@param no_copy? boolean Skips copying the config values of the center
+---@return table
+SMODS.get_default_ability_vars = function(center, card, no_copy) end

--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -2742,7 +2742,7 @@ function add_tag(_tag)
     add_tag_ref(_tag)
 end
 
-SMODS.get_default_ability_vars = function(center, card)
+SMODS.get_default_ability_vars = function(center, card, no_copy)
 	card = card or {}
 	card.ability = card.ability or {}
 
@@ -2755,8 +2755,8 @@ SMODS.get_default_ability_vars = function(center, card)
         to_do_poker_hand = pseudorandom_element(_poker_hands, 'false_to_do_smods')
     end
 
-	return {
-		name = center.name,
+	local new_ability = {
+		name = center.name or center.key,
 		effect = center.effect,
 		set = center.set,
 		mult = center.config.mult or 0,
@@ -2807,8 +2807,24 @@ SMODS.get_default_ability_vars = function(center, card)
         yorick_discards = center.name == 'Yorick' and (center.config.extra or {}).discards or nil,
 		burnt_hand = center.name == 'Loyalty Card' and 0 or nil,
 		loyalty_remaining = center.name == 'Loyalty Card' and (center.config.extra or {}).every or nil,
-		hands_played_at_create = G.GAME and G.GAME.hands_played or 0
+        hands_played_at_create = G.GAME and G.GAME.hands_played or 0,
+		
+		bonus = (card.ability.bonus or 0) + (center.config.bonus or 0)
 	}
+
+	if not no_copy then
+		for k, v in pairs(center.config) do
+			if k ~= 'bonus' then
+				if type(v) == 'table' then
+					new_ability[k] = copy_table(v)
+				else
+					new_ability[k] = v
+				end
+			end
+		end
+	end
+
+	return new_ability
 end
 
 function Card:quantum_set_ability(center)
@@ -2839,7 +2855,7 @@ function Card:quantum_set_ability(center)
     end
 
     self.ARGS.smods_quantum_ability = self.ARGS.smods_quantum_ability or {}
-    local new_ability = SMODS.merge_defaults(SMODS.get_default_ability_vars(self, center), self.ARGS.smods_quantum_ability)
+    local new_ability = SMODS.merge_defaults(SMODS.get_default_ability_vars(self, center, true), self.ARGS.smods_quantum_ability)
     
     self.ability = self.ability or {}
     new_ability.extra_value = nil

--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -2733,13 +2733,82 @@ end
 
 local add_tag_ref = add_tag
 function add_tag(_tag)
-	_tag = _tag or {}
-	_tag.key = _tag.key or 'unknown'
-	assert(G.P_TAGS[_tag.key], ("Could not find tag \"%s\"."):format(_tag.key))
-	if not (_tag.is and _tag:is(Tag)) then
-		_tag = Tag(_tag.key, nil, _tag.blind_type)
-	end
-	add_tag_ref(_tag)
+    _tag = _tag or {}
+    _tag.key = _tag.key or 'unknown'
+    assert(G.P_TAGS[_tag.key], ("Could not find tag \"%s\"."):format(_tag.key))
+    if not (_tag.is and _tag:is(Tag)) then
+        _tag = Tag(_tag.key, nil, _tag.blind_type)
+    end
+    add_tag_ref(_tag)
+end
+
+SMODS.get_default_ability_vars = function(center, card)
+	card = card or {}
+	card.ability = card.ability or {}
+
+	local to_do_poker_hand
+    if center.name == 'To Do List' then
+        local _poker_hands = {}
+        for key, _ in pairs(G.GAME.hands) do
+            if SMODS.is_poker_hand_visible(key) then _poker_hands[#_poker_hands+1] = key end
+        end
+        to_do_poker_hand = pseudorandom_element(_poker_hands, 'false_to_do_smods')
+    end
+
+	return {
+		name = center.name,
+		effect = center.effect,
+		set = center.set,
+		mult = center.config.mult or 0,
+		h_mult = center.config.h_mult or 0,
+		h_x_mult = center.config.h_x_mult or 0,
+		h_dollars = center.config.h_dollars or 0,
+		p_dollars = center.config.p_dollars or 0,
+		t_mult = center.config.t_mult or 0,
+		t_chips = center.config.t_chips or 0,
+		x_mult = center.config.Xmult or center.config.x_mult or 1,
+		h_chips = center.config.h_chips or 0,
+		x_chips = center.config.x_chips or 1,
+		h_x_chips = center.config.h_x_chips or 1,
+		repetitions = center.config.repetitions or 0,
+		h_size = center.config.h_size or 0,
+		d_size = center.config.d_size or 0,
+		extra = copy_table(center.config.extra) or nil,
+		extra_value = 0,
+		type = center.config.type or '',
+		order = center.order or nil,
+		forced_selection = card.ability.forced_selection or nil,
+		perma_bonus = card.ability.perma_bonus or 0,
+		perma_x_chips = card.ability.perma_x_chips or 0,
+		perma_mult = card.ability.perma_mult or 0,
+		perma_x_mult = card.ability.perma_x_mult or 0,
+		perma_h_chips = card.ability.perma_h_chips or 0,
+		perma_h_x_chips = card.ability.perma_h_x_chips or 0,
+		perma_h_mult = card.ability.perma_h_mult or 0,
+		perma_h_x_mult = card.ability.perma_h_x_mult or 0,
+		perma_p_dollars = card.ability.perma_p_dollars or 0,
+		perma_h_dollars = card.ability.perma_h_dollars or 0,
+		perma_repetitions = card.ability.perma_repetitions or 0,
+		card_limit = card.ability.card_limit or 0,
+		extra_slots_used = card.ability.extra_slots_used or 0,
+		perma_score = card.ability.perma_score or 0,
+		perma_h_score = card.ability.perma_h_score or 0,
+		perma_x_score = card.ability.perma_x_score or 0,
+		perma_h_x_score = card.ability.perma_h_x_score or 0,
+		perma_blind_size = card.ability.perma_blind_size or 0,
+		perma_h_blind_size = card.ability.perma_h_blind_size or 0,
+		perma_x_blind_size = card.ability.perma_x_blind_size or 0,
+        perma_h_x_blind_size = card.ability.perma_h_x_blind_size or 0,
+		
+        consumeable = center.consumeable and center.config or nil,
+        invis_rounds = center.name == "Invisible Joker" and 0 or nil,
+        to_do_poker_hand = to_do_poker_hand,
+        caino_xmult = center.name == 'Caino' and 1 or nil,
+        yorick_discards = center.name == 'Yorick' and (center.config.extra or {}).discards or nil,
+		burnt_hand = center.name == 'Loyalty Card' and 0 or nil,
+		loyalty_remaining = center.name == 'Loyalty Card' and (center.config.extra or {}).every or nil,
+		hands_played_at_create = G.GAME and G.GAME.hands_played or 0
+	}
 end
 
 function Card:quantum_set_ability(center)
@@ -2770,51 +2839,7 @@ function Card:quantum_set_ability(center)
     end
 
     self.ARGS.smods_quantum_ability = self.ARGS.smods_quantum_ability or {}
-    local new_ability = self.ARGS.smods_quantum_ability
-
-    new_ability.name = center.name
-    new_ability.effect = center.effect
-    new_ability.set = center.set
-    new_ability.mult = center.config.mult or 0
-    new_ability.h_mult = center.config.h_mult or 0
-    new_ability.h_x_mult = center.config.h_x_mult or 0
-    new_ability.h_dollars = center.config.h_dollars or 0
-    new_ability.p_dollars = center.config.p_dollars or 0
-    new_ability.t_mult = center.config.t_mult or 0
-    new_ability.t_chips = center.config.t_chips or 0
-    new_ability.x_mult = center.config.Xmult or center.config.x_mult or 1
-    new_ability.h_chips = center.config.h_chips or 0
-    new_ability.x_chips = center.config.x_chips or 1
-    new_ability.h_x_chips = center.config.h_x_chips or 1
-    new_ability.repetitions = center.config.repetitions or 0
-    new_ability.h_size = center.config.h_size or 0
-    new_ability.d_size = center.config.d_size or 0
-    new_ability.extra = copy_table(center.config.extra) or nil
-    new_ability.extra_value = 0
-    new_ability.type = center.config.type or ''
-    new_ability.order = center.order or nil
-    new_ability.forced_selection = self.ability and self.ability.forced_selection or nil
-    new_ability.perma_bonus = self.ability and self.ability.perma_bonus or 0
-    new_ability.perma_x_chips = self.ability and self.ability.perma_x_chips or 0
-    new_ability.perma_mult = self.ability and self.ability.perma_mult or 0
-    new_ability.perma_x_mult = self.ability and self.ability.perma_x_mult or 0
-    new_ability.perma_h_chips = self.ability and self.ability.perma_h_chips or 0
-    new_ability.perma_h_x_chips = self.ability and self.ability.perma_h_x_chips or 0
-    new_ability.perma_h_mult = self.ability and self.ability.perma_h_mult or 0
-    new_ability.perma_h_x_mult = self.ability and self.ability.perma_h_x_mult or 0
-    new_ability.perma_p_dollars = self.ability and self.ability.perma_p_dollars or 0
-    new_ability.perma_h_dollars = self.ability and self.ability.perma_h_dollars or 0
-    new_ability.perma_repetitions = self.ability and self.ability.perma_repetitions or 0
-    new_ability.card_limit = self.ability and self.ability.card_limit or 0
-    new_ability.extra_slots_used = self.ability and self.ability.extra_slots_used or 0
-    new_ability.perma_score = self.ability and self.ability.perma_score or 0
-    new_ability.perma_h_score = self.ability and self.ability.perma_h_score or 0
-    new_ability.perma_x_score = self.ability and self.ability.perma_x_score or 0
-    new_ability.perma_h_x_score = self.ability and self.ability.perma_h_x_score or 0
-    new_ability.perma_blind_size = self.ability and self.ability.perma_blind_size or 0
-    new_ability.perma_h_blind_size = self.ability and self.ability.perma_h_blind_size or 0
-    new_ability.perma_x_blind_size = self.ability and self.ability.perma_x_blind_size or 0
-    new_ability.perma_h_x_blind_size = self.ability and self.ability.perma_h_x_blind_size or 0
+    local new_ability = SMODS.merge_defaults(SMODS.get_default_ability_vars(self, center), self.ARGS.smods_quantum_ability)
     
     self.ability = self.ability or {}
     new_ability.extra_value = nil


### PR DESCRIPTION
Creates `SMODS.get_default_ability_vars` to basically standardize the 3 places where ability tables are constructed (`set_ability`, `quantum_set_ability` and now `generate_card_ui`). For `set_ability` I decided to not replace the vanilla table to not break any patches there but it does remove the other SMODS patches to that table.

I don't think this will break anything *but* I didn't test this with quantum enhancements.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
