### PR TITLE
Stencil-canvas-related adjustments

### DIFF
--- a/lsp_def/ui.lua
+++ b/lsp_def/ui.lua
@@ -132,8 +132,9 @@ function SMODS.pop_from_stencil_stack() end
 function SMODS.reset_stencil_stack() end
 
 --- Restore stencil buffer in current canvas
---- @param full boolean Fully reload stencil stack by cleaning up current stencil and redrawing all stencils from stack
-function SMODS.reload_stencil_stack(full) end
+--- @param full? boolean Fully reload stencil stack by cleaning up current stencil and redrawing all stencils from stack
+--- @param canvas? table Canvas to pass into `love.graphics.setCanvas`, default is current canvas
+function SMODS.reload_stencil_stack(full, canvas) end
 
 ---@param str string
 ---@return any

--- a/src/ui.lua
+++ b/src/ui.lua
@@ -46,8 +46,8 @@ function SMODS.reset_stencil_stack()
     love.graphics.setStencilTest()
     love.graphics.stencil(function() end)
 end
-function SMODS.reload_stencil_stack(full)
-    love.graphics.setCanvas({ love.graphics.getCanvas(), depthstencil = SMODS.stencil_canvas })
+function SMODS.reload_stencil_stack(full, canvas)
+    love.graphics.setCanvas({ canvas or love.graphics.getCanvas(), depthstencil = SMODS.stencil_canvas })
     if full then
         local stack_snapshot = SMODS.shallow_copy(SMODS.stencil_stack)
         SMODS.reset_stencil_stack()
@@ -66,7 +66,7 @@ end
 local old_get_canvas = love.graphics.getCanvas
 function love.graphics.getCanvas(...)
     local r = old_get_canvas(...)
-    return r.depthstencil and r[1] or r
+    return r and r.depthstencil and r[1] or r
 end
 
 local old_resize = love.resize


### PR DESCRIPTION
This PR adjust 2 things related to stencils and canvases.

1. Fixed a crash which happens when `love.graphics.getCanvas` returns nil.
2. Adds `canvas` argument to `SMODS.reload_stencil_stack` as shortcut for setting canvas together with depthstencil.
```lua
-- old way: 2 setCanvas calls
love.graphics.setCanvas(new_canvas)
SMODS.reload_stencil_stack()

-- new way: 1 setCanvas call
-- first argument is full stencil reload, second argument is canvas we want to set
SMODS.reload_stencil_stack(nil, new_canvas)
```

## Additional Info:
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
