### PR TITLE
`mod.badge_text_no_shadow`

### DIFF
--- a/src/preflight/loader.lua
+++ b/src/preflight/loader.lua
@@ -147,6 +147,7 @@ function loadMods(modsDirectory)
         badge_colour = { type = 'string', check = function(mod, s) local success, hex = pcall(sUtil.hex, s); mod.badge_colour = success and hex or sUtil.hex('666665FF') end },
         badge_text_colour = { type = 'string', check = function(mod, s) local success, hex = pcall(sUtil.hex, s); mod.badge_text_colour = success and hex or sUtil.hex('FFFFFFFF') end},
         badge_shader = { type = 'string', },
+        badge_text_no_shadow = { type = 'boolean', },
         prefix = { type = 'string', required = true, check = function(mod, s) if string.find(s, '%$') then error("Disallowed use of reserved prefix "..s) end end },
         version = { type = 'string', check = function(mod, x) return x and sUtil.V(x):is_valid() and x or '0.0.0' end },
         dump_loc = { type = 'boolean' },

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -530,7 +530,7 @@ function SMODS.create_mod_badge(mod, obj, width, text_height)
     local mod_name = mod.display_name
     local max_text_width = width or 1.732
     local scale_fac = 1
-    local badge_text = DynaText({string = mod_name or 'ERROR', colours = {mod.badge_text_colour or G.C.WHITE}, maxw = mod.no_marquee and max_text_width, float = true, shadow = true, offset_y = -0.05, silent = true, spacing = 1*scale_fac, scale = text_height or 0.297})
+    local badge_text = DynaText({string = mod_name or 'ERROR', colours = {mod.badge_text_colour or G.C.WHITE}, maxw = mod.no_marquee and max_text_width, float = true, shadow = not mod.badge_text_no_shadow, offset_y = -0.05, silent = true, spacing = 1*scale_fac, scale = text_height or 0.297})
     local badge_scroll = SMODS.UIScrollBox({
         content = badge_text,
         container = {


### PR DESCRIPTION
This PR adds new boolean property `badge_text_no_shadow`  to mod json metadata which disables badge text shadow.

Default:
<img width="170" height="40" alt="Balatro_kwcUNqjiAD" src="https://github.com/user-attachments/assets/8958ad34-fc4a-4529-a10b-333331014e42" />
`badge_text_no_shadow: true`
<img width="167" height="39" alt="Balatro_lSAZmwyOkd" src="https://github.com/user-attachments/assets/3382e1b1-26cb-4729-8d2d-c35d5f82825c" />


## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [ ] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [x] I didn't modify api's or I've updated lsp definitions.
- [x] I didn't make new lovely files or all new lovely files have appropriate priority.
