### PR TITLE
properly replace get_new_boss()

### DIFF
--- a/src/overrides.lua
+++ b/src/overrides.lua
@@ -3091,3 +3091,8 @@ function AnimatedSprite:get_pos_pixel()
     self.RETS.get_pos_pixel[4] = self.animation.h
     return self.RETS.get_pos_pixel
 end
+
+-- completely bypass get_new_boss()
+function get_new_boss()
+	return SMODS.get_new_blind("boss")
+end


### PR DESCRIPTION
Completely overrides the `get_new_boss()` function, replacing it with a call to `SMODS.get_new_blind("boss")`. The boss reroll function still called `get_new_boss()`, which wasn't fully up to date with the new blind system and wouldn't get the boss blind pool properly.

## Additional Info:
<!-- Don't worry too much if you don't know what these are or how to fill them. It's mostly reminders for maintainers ;) -->
- [X] I didn't modify api's or I've made a PR to the [wiki repo](https://github.com/Steamodded/wiki).
- [X] I didn't modify api's or I've updated lsp definitions.
- [X] I didn't make new lovely files or all new lovely files have appropriate priority.
